### PR TITLE
wip: use downlevel-dts to generate TS 3.4 compatible types

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -73,6 +75,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -65,6 +65,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -66,6 +66,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -16,8 +16,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -15,7 +15,9 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -74,6 +76,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -74,6 +76,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -66,6 +66,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -73,6 +75,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -73,6 +75,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -15,8 +15,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -14,7 +14,9 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -64,6 +64,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -15,8 +15,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -14,7 +14,9 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -64,6 +64,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -61,8 +61,8 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
-    "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",
     "typescript": "~4.1.2"
   },

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -63,11 +65,22 @@
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
+    "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",
     "typescript": "~4.1.2"
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -68,6 +68,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -15,8 +15,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -14,7 +14,9 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -76,6 +78,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -15,7 +15,9 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -88,6 +90,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -16,8 +16,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -80,6 +80,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -15,7 +15,9 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "cp test/speech.wav dist/cjs/test"
+    "postbuild": "cp test/speech.wav dist/cjs/test",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -77,6 +79,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -16,8 +16,8 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "postbuild": "cp test/speech.wav dist/cjs/test",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -71,6 +73,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -70,6 +72,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -62,6 +62,7 @@
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@types/node": "^12.7.5",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -13,7 +13,9 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -69,6 +71,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/lib/storage/package.json
+++ b/lib/storage/package.json
@@ -11,6 +11,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "engines": {
@@ -40,6 +42,16 @@
     "karma-typescript": "^5.2.0",
     "ts-jest": "^26.4.1",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/trivikr/aws-sdk-js-v3/tree/master/lib/storage",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.4.0",
     "cucumber": "^6.0.5",
+    "downlevel-dts": "0.7.0",
     "eslint": "7.14.0",
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -11,6 +11,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/abort-controller",
   "repository": {

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/body-checksum-browser",
   "repository": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -35,6 +37,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/body-checksum-node",
   "repository": {

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -25,6 +27,16 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/chunked-blob-reader-native",
   "repository": {

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -24,6 +26,16 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/chunked-blob-reader",
   "repository": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/chunked-stream-reader-node",
   "repository": {

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
     "jest": "^26.1.0",
     "typedoc": "^0.19.2",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/client-documentation-generator",
   "repository": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/config-resolver",
   "repository": {

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
     "typescript": "~4.1.2"
   },
   "private": true,
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
+  },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/core-packages-documentation-generator",
   "repository": {
     "type": "git",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-cognito-identity",
   "repository": {

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -35,6 +37,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-env",
   "repository": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -36,6 +38,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-imds",
   "repository": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -36,6 +38,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-ini",
   "repository": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -13,6 +13,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -41,6 +43,16 @@
     "typescript": "~4.1.2"
   },
   "types": "./dist/cjs/index.d.ts",
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
+  },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-node",
   "repository": {
     "type": "git",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -37,6 +39,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-process",
   "repository": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/eventstream-handler-node",
   "repository": {

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",
@@ -36,6 +38,16 @@
   },
   "react-native": {
     "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/eventstream-marshaller",
   "repository": {

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/eventstream-serde-browser",
   "repository": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/eventstream-serde-config-resolver",
   "repository": {

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/eventstream-serde-node",
   "repository": {

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/eventstream-serde-universal",
   "repository": {

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --coverage && karma start karma.conf.js"
   },
   "author": {
@@ -29,6 +31,16 @@
     "@aws-sdk/abort-controller": "3.3.0",
     "@types/jest": "^26.0.4",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/fetch-http-handler",
   "repository": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "karma start karma.conf.js"
   },
   "main": "./dist/cjs/index.js",
@@ -32,6 +34,16 @@
   },
   "react-native": {
     "@aws-sdk/chunked-blob-reader": "@aws-sdk/chunked-blob-reader-native"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/hash-blob-browser",
   "repository": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/hash-node",
   "repository": {

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/hash-stream-node",
   "repository": {

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -25,6 +27,16 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/invalid-dependency",
   "repository": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/is-array-buffer",
   "repository": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/karma-credential-loader",
   "repository": {

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -37,6 +39,16 @@
   },
   "react-native": {
     "@aws-sdk/util-base64-node": "@aws-sdk/util-base64-browser"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/md5-js",
   "repository": {

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-apply-body-checksum",
   "repository": {

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -32,6 +34,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-bucket-endpoint",
   "repository": {

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-content-length",
   "repository": {

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-eventstream",
   "repository": {

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-expect-continue",
   "repository": {

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-header-default",
   "repository": {

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-host-header",
   "repository": {

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-location-constraint",
   "repository": {

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-logger",
   "repository": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -34,6 +36,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-retry",
   "repository": {

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-api-gateway",
   "repository": {

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-ec2",
   "repository": {

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-glacier",
   "repository": {

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-machinelearning",
   "repository": {

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -32,6 +34,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-rds",
   "repository": {

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-route53",
   "repository": {

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -32,6 +34,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-s3-control",
   "repository": {

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-s3",
   "repository": {

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-sqs",
   "repository": {

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "prepublishOnly": "yarn build",
     "pretest": "yarn build",
     "test": "jest --passWithNoTests"
@@ -37,6 +39,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-sdk-transcribe-streaming",
   "repository": {

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-serde",
   "repository": {

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-signing",
   "repository": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-ssec",
   "repository": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-stack",
   "repository": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/middleware-user-agent",
   "repository": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {
@@ -33,6 +35,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/node-config-provider",
   "repository": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --coverage"
   },
   "author": {
@@ -40,6 +42,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/node-http-handler",
   "repository": {

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -36,6 +38,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/polly-request-presigner",
   "repository": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/property-provider",
   "repository": {

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/protocol-http",
   "repository": {

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/querystring-builder",
   "repository": {

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/querystring-parser",
   "repository": {

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -35,6 +37,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/s3-presigned-post",
   "repository": {

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -36,6 +38,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/s3-request-presigner",
   "repository": {

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -25,6 +27,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/service-error-classification",
   "repository": {

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/sha256-tree-hash",
   "repository": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -16,6 +16,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -28,6 +30,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/shared-ini-file-loader",
   "repository": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -9,6 +9,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "prepublishOnly": "yarn build",
     "pretest": "yarn build",
     "test": "jest --coverage"
@@ -35,6 +37,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/signature-v4",
   "repository": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/smithy-client",
   "repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,6 +14,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "exit 0"
   },
   "author": {
@@ -23,6 +25,16 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/types",
   "repository": {

--- a/packages/url-parser-native/package.json
+++ b/packages/url-parser-native/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -34,6 +36,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/url-parser-node",
   "repository": {

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -26,6 +28,16 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/url-parser",
   "repository": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -29,6 +31,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-arn-parser",
   "repository": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -27,6 +29,16 @@
     "typescript": "~4.1.2"
   },
   "types": "./dist/cjs/index.d.ts",
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
+  },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-base64-browser",
   "repository": {
     "type": "git",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -30,6 +32,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-base64-node",
   "repository": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -25,6 +27,16 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-body-length-browser",
   "repository": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "devDependencies": {
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-body-length-node",
   "repository": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -29,6 +31,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-buffer-from",
   "repository": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -32,6 +34,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-create-request",
   "repository": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +30,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-dynamodb",
   "repository": {

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -29,6 +31,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-format-url",
   "repository": {

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -8,6 +8,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -28,6 +30,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-hex-encoding",
   "repository": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -28,6 +30,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-locate-window",
   "repository": {

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -27,6 +29,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-uri-escape",
   "repository": {

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +32,16 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-user-agent-browser",
   "repository": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -7,6 +7,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
@@ -31,6 +33,16 @@
   },
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-user-agent-node",
   "repository": {

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -26,6 +28,16 @@
     "typescript": "~4.1.2"
   },
   "types": "./dist/cjs/index.d.ts",
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
+  },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-utf8-browser",
   "repository": {
     "type": "git",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -10,6 +10,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -33,6 +35,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-utf8-node",
   "repository": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -18,6 +18,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -30,6 +32,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-waiter",
   "repository": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -16,6 +16,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -28,6 +30,16 @@
   "types": "./dist/cjs/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/xml-builder",
   "repository": {

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -65,6 +65,7 @@
     "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -73,6 +75,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -72,6 +74,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -65,6 +65,7 @@
     "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -73,6 +75,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -65,6 +65,7 @@
     "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -73,6 +75,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -13,7 +13,9 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
@@ -75,6 +77,16 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<3.9": {
+      "dist/cjs/*": [
+        "dist/cjs/ts3.4/*"
+      ],
+      "dist/es/*": [
+        "dist/es/ts3.4/*"
+      ]
+    }
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -14,8 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
-    "downlevel-dts:es": "downlevel-dts dist/es dist/es/ts3.4"
+    "postbuild:cjs": "downlevel-dts dist/cjs dist/cjs/ts3.4",
+    "postbuild:es": "downlevel-dts dist/es dist/es/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -67,6 +67,7 @@
     "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
+    "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -41,7 +41,7 @@ const getOverwritablePredicate = (packageName) => (pathName) => {
 const mergeManifest = (fromContent = {}, toContent = {}) => {
   const merged = {};
   for (const name of Object.keys(fromContent)) {
-    if (typeof fromContent[name] === "object") {
+    if (fromContent[name].constructor.name === "Object") {
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
       if (name === "scripts" || name === "devDependencies") {
         // Allow target package.json(toContent) has its own special script or

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,6 +4229,15 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+downlevel-dts@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.7.0.tgz#155c24310dad8a4820ad077e64b15a8c461aa932"
+  integrity sha512-tcjGqElN0/oad/LJBlaxmZ3zOYEQOBbGuirKzif8s1jeRiWBdNX9H6OBFlRjOQkosXgV+qSjs4osuGCivyZ4Jw==
+  dependencies:
+    semver "^7.3.2"
+    shelljs "^0.8.3"
+    typescript "^4.1.0-dev.20201026"
+
 dtrace-provider@~0.8:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
@@ -10051,7 +10060,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.4:
+shelljs@^0.8.3, shelljs@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -11199,7 +11208,7 @@ typedoc@^0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-typescript@~4.1.2:
+typescript@^4.1.0-dev.20201026, typescript@~4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1919

*Description of changes:*
WIP PR, will be replaced with a new one after https://github.com/aws/aws-sdk-js-v3/pull/1938 is merged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
