### PR TITLE
fix: allow packages/types in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ codegen/sdk-codegen/smithy-build.json
 coverage
 dist
 types
+!packages/types
 
 /verdaccio/*
 !/verdaccio/config.yaml


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/1938

*Description of changes:*
gitignore ignores packages/types in addition to types folders used for type definitions

```console
husky > pre-commit (node v14.15.4)
✔ Preparing...
✔ Running tasks...
✖ The following paths are ignored by one of your .gitignore files:
packages/types
Use -f if you really want to add them.
✔ Cleaning up...
husky > commit-msg (node v14.15.4)
```

This PR skips packages/types from gitignore.

Verified that:
* This change continues to gitignore `packages/types/types`
* This change doesn't ignore other changes in `packages/types`, like in `package.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
