### PR TITLE
fix(credential-provider-cognito-identity): remove duplicate declarationDir

### DIFF
--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "declarationDir": "./dist/cjs",
     "noUnusedLocals": true,
     "baseUrl": "."
   },

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
-    "declaration": false,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
-    "declarationDir": null,
     "noUnusedLocals": true,
     "baseUrl": ".",
     "target": "es5",


### PR DESCRIPTION
*Issue #, if available:*
Missed in https://github.com/aws/aws-sdk-js-v3/pull/1938

*Description of changes:*
Remove duplicate declarationDir in credential-provider-cognito-identity

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
