### PR TITLE
feat(credential-provider-env): provide option for custom env prefix

### DIFF
--- a/packages/credential-provider-env/README.md
+++ b/packages/credential-provider-env/README.md
@@ -20,3 +20,19 @@ the following environment variables:
 If either the `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` environment
 variable is not set or contains a falsy value, the promise returned by the
 `fromEnv` function will be rejected.
+
+### Environment variable prefixes
+
+An optional options object containing a `prefix` property can be provided, which will
+alter the environment variables from which credentials will be read. For example,
+
+```
+fromEnv({ prefix: "AMAZON" })
+```
+
+would read the environment variables:
+
+- `AMAZON_ACCESS_KEY_ID`
+- `AMAZON_SECRET_ACCESS_KEY`
+- `AMAZON_SESSION_TOKEN`
+- `AMAZON_CREDENTIAL_EXPIRATION`

--- a/packages/credential-provider-env/src/index.spec.ts
+++ b/packages/credential-provider-env/src/index.spec.ts
@@ -37,6 +37,31 @@ describe("fromEnv", () => {
     });
   });
 
+  it("should read credentials from prefixed environment variables", async () => {
+    const prefix = "TEST_PREFIX";
+    const PREFIXED_ENV_KEY = prefix + "_ACCESS_KEY_ID";
+    const PREFIXED_ENV_SECRET = prefix + "_SECRET_ACCESS_KEY";
+    const PREFIXED_ENV_SESSION = prefix + "_SESSION_TOKEN";
+    const PREFIXED_ENV_EXPIRATION = prefix + "_CREDENTIAL_EXPIRATION";
+    const dateString = "1970-01-01T07:00:00Z";
+    process.env[PREFIXED_ENV_KEY] = "foo";
+    process.env[PREFIXED_ENV_SECRET] = "bar";
+    process.env[PREFIXED_ENV_SESSION] = "baz";
+    process.env[PREFIXED_ENV_EXPIRATION] = dateString;
+
+    expect(await fromEnv({ prefix })()).toEqual({
+      accessKeyId: "foo",
+      secretAccessKey: "bar",
+      sessionToken: "baz",
+      expiration: new Date(dateString),
+    });
+
+    delete process.env[PREFIXED_ENV_KEY];
+    delete process.env[PREFIXED_ENV_SECRET];
+    delete process.env[PREFIXED_ENV_SESSION];
+    delete process.env[PREFIXED_ENV_EXPIRATION];
+  });
+
   it("can create credentials without a session token or expiration", async () => {
     process.env[ENV_KEY] = "foo";
     process.env[ENV_SECRET] = "bar";

--- a/packages/credential-provider-env/src/index.ts
+++ b/packages/credential-provider-env/src/index.ts
@@ -6,21 +6,51 @@ export const ENV_SECRET = "AWS_SECRET_ACCESS_KEY";
 export const ENV_SESSION = "AWS_SESSION_TOKEN";
 export const ENV_EXPIRATION = "AWS_CREDENTIAL_EXPIRATION";
 
+interface EnvVars {
+  ENV_KEY: string;
+  ENV_SECRET: string;
+  ENV_SESSION: string;
+  ENV_EXPIRATION: string;
+}
+
+const suffixes: EnvVars = {
+  ENV_KEY: "_ACCESS_KEY_ID",
+  ENV_SECRET: "_SECRET_ACCESS_KEY",
+  ENV_SESSION: "_SESSION_TOKEN",
+  ENV_EXPIRATION: "_CREDENTIAL_EXPIRATION",
+};
+
+function getEnvVarsFromPrefix(prefix: string): EnvVars {
+  return Object.entries(suffixes).reduce((processedEnvVars, [key, suffix]) => {
+    processedEnvVars[key as keyof EnvVars] = prefix + suffix;
+    return processedEnvVars;
+  }, {} as EnvVars);
+}
+
+export interface FromEnvInit {
+  prefix: string;
+}
+
 /**
  * Source AWS credentials from known environment variables. If either the
  * `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` environment variable is not
  * set in this process, the provider will return a rejected promise.
  */
-export function fromEnv(): CredentialProvider {
+export function fromEnv(
+  { prefix }: FromEnvInit = {
+    prefix: "AWS",
+  }
+): CredentialProvider {
   return () => {
-    const accessKeyId: string | undefined = process.env[ENV_KEY];
-    const secretAccessKey: string | undefined = process.env[ENV_SECRET];
-    const expiry: string | undefined = process.env[ENV_EXPIRATION];
+    const processedEnvVars = getEnvVarsFromPrefix(prefix);
+    const accessKeyId: string | undefined = process.env[processedEnvVars.ENV_KEY];
+    const secretAccessKey: string | undefined = process.env[processedEnvVars.ENV_SECRET];
+    const expiry: string | undefined = process.env[processedEnvVars.ENV_EXPIRATION];
     if (accessKeyId && secretAccessKey) {
       return Promise.resolve({
         accessKeyId,
         secretAccessKey,
-        sessionToken: process.env[ENV_SESSION],
+        sessionToken: process.env[processedEnvVars.ENV_SESSION],
         expiration: expiry ? new Date(expiry) : undefined,
       });
     }


### PR DESCRIPTION
Allows for the provision of a custom prefix that will replace `AWS` at the start of each read environment variable.

### Motivation
My use case is creating to separate S3 clients - one for generating pre-signed links, and one for in-service S3 operations. We would like to use separate credentials for each client, to ensure the pre-signed credentials do not expire prior to the link expiry, and to minimise the permissions given to the pre-signed link.
Currently to achieve this, I have to copy/paste the `credential-provider-env` package into my service, and use different env var names. By allowing options to `fromEnv`, I can use it more easily with a different prefix.

This is similar to the usage to the `EnvironmentCredentials` class in the v2 sdk (https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EnvironmentCredentials.html)

I have not been able to run `generate-clients` locally - the following error:

```
Execution failed for task ':smithy-aws-typescript-codegen:compileJava'.
> Could not resolve all files for configuration ':smithy-aws-typescript-codegen:compileClasspath'.
   > Could not find software.amazon.smithy:smithy-typescript-codegen:0.3.0.
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.