### PR TITLE
fix(util-dynamodb): accept interface as in input for marshall

### DIFF
--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -5,16 +5,17 @@ import { INativeAttributeValue, NativeAttributeValue } from "./models";
 jest.mock("./convertToAttr");
 
 describe("marshall", () => {
+  const mockOutput = { S: "mockOutput" };
+  (convertToAttr as jest.Mock).mockReturnValue({ M: mockOutput });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it("with object as an input", () => {
     const input = { a: "A", b: "B" };
-    const output = { a: { S: "A" }, b: { S: "B" } };
-    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
 
-    expect(marshall(input)).toEqual(output);
+    expect(marshall(input)).toEqual(mockOutput);
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
@@ -22,15 +23,10 @@ describe("marshall", () => {
   ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
     describe(`options.${option}`, () => {
       const input = { a: "A", b: "B" };
-      const output = { a: { S: "A" }, b: { S: "B" } };
-
-      beforeEach(() => {
-        (convertToAttr as jest.Mock).mockReturnValue({ M: output });
-      });
 
       [false, true].forEach((value) => {
         it(`passes ${value} to convertToAttr`, () => {
-          expect(marshall(input, { [option]: value })).toEqual(output);
+          expect(marshall(input, { [option]: value })).toEqual(mockOutput);
           expect(convertToAttr).toHaveBeenCalledTimes(1);
           expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
         });
@@ -41,11 +37,8 @@ describe("marshall", () => {
   it("with type as an input", () => {
     type TestInputType = { a: string; b: string };
     const input: TestInputType = { a: "A", b: "B" };
-    const output = { a: { S: "A" }, b: { S: "B" } };
 
-    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
-
-    expect(marshall(input)).toEqual(output);
+    expect(marshall(input)).toEqual(mockOutput);
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
@@ -56,11 +49,8 @@ describe("marshall", () => {
       b: string;
     }
     const input: TestInputInterface = { a: "A", b: "B" };
-    const output = { a: { S: "A" }, b: { S: "B" } };
 
-    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
-
-    expect(marshall(input)).toEqual(output);
+    expect(marshall(input)).toEqual(mockOutput);
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
@@ -75,11 +65,8 @@ describe("marshall", () => {
       name: IPersonName;
     }
     const input: IPerson = { id: "id", name: { firstname: "John", lastname: "Doe" } };
-    const output = { a: { S: "A" }, b: { S: "B" } };
 
-    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
-
-    expect(marshall(input)).toEqual(output);
+    expect(marshall(input)).toEqual(mockOutput);
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -4,31 +4,76 @@ import { marshall } from "./marshall";
 jest.mock("./convertToAttr");
 
 describe("marshall", () => {
-  const input = { a: "A", b: "B" };
-
-  beforeEach(() => {
-    (convertToAttr as jest.Mock).mockReturnValue({ M: input });
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("calls convertToAttr", () => {
-    expect(marshall(input)).toEqual(input);
-    expect(convertToAttr).toHaveBeenCalledTimes(1);
-    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  describe("with object as an input", () => {
+    const input = { a: "A", b: "B" };
+    const output = { a: { S: "A" }, b: { S: "B" } };
+
+    beforeEach(() => {
+      (convertToAttr as jest.Mock).mockReturnValue({ M: output });
+    });
+
+    it("calls convertToAttr with object input", () => {
+      expect(marshall(input)).toEqual(output);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+    });
   });
 
   ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
     describe(`options.${option}`, () => {
+      const input = { a: "A", b: "B" };
+      const output = { a: { S: "A" }, b: { S: "B" } };
+
+      beforeEach(() => {
+        (convertToAttr as jest.Mock).mockReturnValue({ M: output });
+      });
+
       [false, true].forEach((value) => {
         it(`passes ${value} to convertToAttr`, () => {
-          expect(marshall(input, { [option]: value })).toEqual(input);
+          expect(marshall(input, { [option]: value })).toEqual(output);
           expect(convertToAttr).toHaveBeenCalledTimes(1);
           expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
         });
       });
+    });
+  });
+
+  describe("with type as an input", () => {
+    type TestInputType = { a: string; b: string };
+    const input: TestInputType = { a: "A", b: "B" };
+    const output = { a: { S: "A" }, b: { S: "B" } };
+
+    beforeEach(() => {
+      (convertToAttr as jest.Mock).mockReturnValue({ M: output });
+    });
+
+    it("calls convertToAttr with object input", () => {
+      expect(marshall(input)).toEqual(output);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+    });
+  });
+
+  describe("with Interface as an input", () => {
+    interface TestInputInterface {
+      a: string;
+      b: string;
+    }
+    const input: TestInputInterface = { a: "A", b: "B" };
+    const output = { a: { S: "A" }, b: { S: "B" } };
+
+    beforeEach(() => {
+      (convertToAttr as jest.Mock).mockReturnValue({ M: output });
+    });
+
+    it("calls convertToAttr with object input", () => {
+      expect(marshall(input)).toEqual(output);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
     });
   });
 });

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -1,5 +1,6 @@
 import { convertToAttr } from "./convertToAttr";
 import { marshall } from "./marshall";
+import { INativeAttributeValue, NativeAttributeValue } from "./models";
 
 jest.mock("./convertToAttr");
 
@@ -8,19 +9,14 @@ describe("marshall", () => {
     jest.clearAllMocks();
   });
 
-  describe("with object as an input", () => {
+  it("with object as an input", () => {
     const input = { a: "A", b: "B" };
     const output = { a: { S: "A" }, b: { S: "B" } };
+    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
 
-    beforeEach(() => {
-      (convertToAttr as jest.Mock).mockReturnValue({ M: output });
-    });
-
-    it("calls convertToAttr with object input", () => {
-      expect(marshall(input)).toEqual(output);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-    });
+    expect(marshall(input)).toEqual(output);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
 
   ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
@@ -42,38 +38,49 @@ describe("marshall", () => {
     });
   });
 
-  describe("with type as an input", () => {
+  it("with type as an input", () => {
     type TestInputType = { a: string; b: string };
     const input: TestInputType = { a: "A", b: "B" };
     const output = { a: { S: "A" }, b: { S: "B" } };
 
-    beforeEach(() => {
-      (convertToAttr as jest.Mock).mockReturnValue({ M: output });
-    });
+    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
 
-    it("calls convertToAttr with object input", () => {
-      expect(marshall(input)).toEqual(output);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-    });
+    expect(marshall(input)).toEqual(output);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
 
-  describe("with Interface as an input", () => {
-    interface TestInputInterface {
+  it("with Interface as an input", () => {
+    interface TestInputInterface extends INativeAttributeValue<NativeAttributeValue> {
       a: string;
       b: string;
     }
     const input: TestInputInterface = { a: "A", b: "B" };
     const output = { a: { S: "A" }, b: { S: "B" } };
 
-    beforeEach(() => {
-      (convertToAttr as jest.Mock).mockReturnValue({ M: output });
-    });
+    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
 
-    it("calls convertToAttr with object input", () => {
-      expect(marshall(input)).toEqual(output);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-    });
+    expect(marshall(input)).toEqual(output);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
+
+  it("with nested interfaces as an input", () => {
+    interface IPersonName extends INativeAttributeValue<NativeAttributeValue> {
+      firstname: string;
+      lastname: string;
+    }
+    interface IPerson extends INativeAttributeValue<NativeAttributeValue> {
+      id: string;
+      name: IPersonName;
+    }
+    const input: IPerson = { id: "id", name: { firstname: "John", lastname: "Doe" } };
+    const output = { a: { S: "A" }, b: { S: "B" } };
+
+    (convertToAttr as jest.Mock).mockReturnValue({ M: output });
+
+    expect(marshall(input)).toEqual(output);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
 });

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -23,7 +23,7 @@ export interface marshallOptions {
  * @param {any} data - The data to convert to a DynamoDB record
  * @param {marshallOptions} options - An optional configuration object for `marshall`
  */
-export const marshall = (
-  data: { [key: string]: NativeAttributeValue },
+export const marshall = <T extends { [K in keyof T]: NativeAttributeValue }>(
+  data: T,
   options?: marshallOptions
 ): { [key: string]: AttributeValue } => convertToAttr(data, options).M as { [key: string]: AttributeValue };

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -6,6 +6,10 @@
  * the `wrapNumbers` flag is set. This allows for numeric values that lose
  * precision when converted to JavaScript's `number` type.
  */
+export interface INativeAttributeValue<T> {
+  [key: string]: T;
+}
+
 export interface NumberValue {
   readonly value: string;
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1647
Refs: https://github.com/microsoft/TypeScript/issues/15300#issuecomment-530667695

*Description of changes:*
accepts interface as in input for marshall function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
