### PR TITLE
feat(lib-storage): improve performance by reducing expensive buffer concat operations

### DIFF
--- a/lib/storage/src/data-chunk/readable-helper.ts
+++ b/lib/storage/src/data-chunk/readable-helper.ts
@@ -4,60 +4,53 @@ import { Readable } from "stream";
 import { DEFAULT } from "../upload/defaults";
 import { DataPart } from "./yield-chunk";
 
+type Buffers = {
+  chunks: Buffer[];
+  length: number;
+};
+
 export async function* chunkFromReadable(reader: Readable, chunkSize: number): AsyncGenerator<DataPart, void, unknown> {
   let partNumber = DEFAULT.MIN_PART_NUMBER;
-  let oldBuffer = Buffer.from("");
-  while (partNumber < DEFAULT.MAX_PART_NUMBER) {
-    let currentBuffer = oldBuffer;
-    if (reader.readable) {
-      reader.resume();
-      currentBuffer = await _chunkFromStream(reader, chunkSize, oldBuffer);
-      reader.pause();
-    }
+  const buf: Buffers = { chunks: [], length: 0 };
+  for await (const chunk of reader) {
+    const nextChunk = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    buf.chunks.push(nextChunk);
+    buf.length += nextChunk.length;
 
+    while (buf.length >= chunkSize) {
+      yield {
+        Body: _chunkFromStream(buf, chunkSize),
+        PartNumber: partNumber,
+      };
+      partNumber += 1;
+      if (partNumber >= DEFAULT.MAX_PART_NUMBER) {
+        throw `Exceeded ${DEFAULT.MAX_PART_NUMBER} parts, multipart upload failed`;
+      }
+    }
+  }
+
+  if (buf.length || partNumber === DEFAULT.MIN_PART_NUMBER)
     yield {
-      Body: currentBuffer.slice(0, chunkSize),
+      Body: _chunkFromStream(buf, chunkSize),
       PartNumber: partNumber,
     };
-    oldBuffer = currentBuffer.slice(chunkSize) as Buffer;
-    partNumber += 1;
-
-    if (!reader.readable && oldBuffer.length == 0) {
-      return;
-    }
-  }
-  if (partNumber >= DEFAULT.MAX_PART_NUMBER) {
-    throw `Exceeded ${DEFAULT.MAX_PART_NUMBER} parts, multipart upload failed`;
-  }
 }
 
-function _chunkFromStream(stream: Readable, chunkSize: number, oldBuffer: Buffer): Promise<Buffer> {
-  if (!stream.readable) {
-    return Promise.resolve(oldBuffer);
+function _chunkFromStream(buf: Buffers, chunkSize: number): Buffer {
+  let bodyLen = 0;
+  const chunk: Buffer[] = [];
+  while (buf.chunks.length && bodyLen < chunkSize) {
+    const nextLen = buf.chunks[0].length;
+    if (nextLen <= chunkSize - bodyLen) {
+      bodyLen += nextLen;
+      chunk.push(buf.chunks.shift()!);
+    } else {
+      const slice = buf.chunks[0].slice(0, chunkSize - bodyLen);
+      chunk.push(slice);
+      bodyLen += slice.length;
+      buf.chunks.splice(0, 1, buf.chunks[0].slice(slice.length));
+    }
   }
-
-  let currentChunk = oldBuffer;
-  return new Promise((resolve, reject) => {
-    const cleanupListeners = () => {
-      stream.removeAllListeners("data");
-      stream.removeAllListeners("error");
-      stream.removeAllListeners("end");
-    };
-
-    stream.on("data", (chunk) => {
-      currentChunk = Buffer.concat([currentChunk, Buffer.from(chunk)]);
-      if (currentChunk.length >= chunkSize || !stream.readable) {
-        cleanupListeners();
-        resolve(currentChunk);
-      }
-    });
-    stream.on("error", (err) => {
-      cleanupListeners();
-      reject(err);
-    });
-    stream.on("end", () => {
-      cleanupListeners();
-      resolve(currentChunk);
-    });
-  });
+  buf.length -= bodyLen;
+  return Buffer.concat(chunk);
 }

--- a/lib/storage/test/data-chunk/readable-helper.spec.ts
+++ b/lib/storage/test/data-chunk/readable-helper.spec.ts
@@ -7,6 +7,25 @@ describe(chunkFromReadable.name, () => {
   const fileStream = fs.createReadStream(__dirname + "/sample.file");
   const INPUT_STRING = "Farmer jack realized that big yellow quilts were expensive";
 
+  describe("Proper string handling", () => {
+    const JP_INPUT = "私はガラスを食べられます。それは私を傷つけません。";
+    expect(JP_INPUT.length).not.toEqual(Buffer.from(JP_INPUT).length);
+
+    const CHUNK_SIZE = 30;
+
+    it("Should decode encoded strings properly", async () => {
+      const chunks: Buffer[] = [];
+      const readableStream = Readable.from(JP_INPUT);
+      for await (const chunk of chunkFromReadable(readableStream, CHUNK_SIZE)) {
+        chunks.push(chunk.Body);
+      }
+
+      expect(chunks[0].length).toEqual(30);
+      expect(chunks[1].length).toEqual(30);
+      expect(chunks[2].length).toEqual(15);
+    });
+  });
+
   describe("Proper chunk creation", () => {
     let chunks: IteratorResult<DataPart>[] = [];
     const CHUNK_SIZE = 30;


### PR DESCRIPTION
*Issue #1841*

*Description of changes:*

The `for await` syntax reads chunks from a readable stream and is in my opinion more concise and less error prone as NodeJS will take care of event handlers, exception handling, etc.

In addition, `Buffer.concat` will only be called once per chunk which greatly improves performance (uploading a 1GB file would take 23 seconds previously, down to 10 seconds with this patch). The use of `Buffer.slice` is intentional as it does not copy or create a new buffer. Instead, it's basically a view into the buffer it slices over.

I ran a few profiling runs over the code and I think there is more room for improvement. V2 of the SDK still seems to be ~20 percent faster. For example, v3 calls `update` from `internal/crypto/hash.js` twice as many times as v2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
