### PR TITLE
fix(client-kinesis-video-signaling): remove retry headers

### DIFF
--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -20,7 +20,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -204,6 +210,7 @@ export class KinesisVideoSignalingClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -25,7 +25,7 @@ import {
   RetryResolvedConfig,
   getOmitRetryHeadersPlugin,
   getRetryPlugin,
-  resolveRetryConfig
+  resolveRetryConfig,
 } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -32,7 +32,8 @@ public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
     private static final Set<String> SERVICE_IDS = SetUtils.of(
         "ConnectParticipant",
         "IoT Data Plane",
-        "IoT"
+        "IoT",
+        "Kinesis Video Signaling"
     );
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1962

*Description of changes:*
Use getOmitRetryHeadersPlugin in KinesisVideoSignalingClient 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
