### PR TITLE
feat: use git-sync action to sync with private mirror

### DIFF
--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -1,0 +1,25 @@
+name: git-sync-with-mirror
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  git-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: git-sync
+        env:
+          git_sync_source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
+          git_sync_destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }}
+        if: env.git_sync_source_repo && env.git_sync_destination_repo
+        uses: wei/git-sync@v3
+        with:
+          source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
+          source_branch: "master"
+          destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }} 
+          destination_branch: "master"
+          source_ssh_private_key: ${{ secrets.GIT_SYNC_SOURCE_SSH_PRIVATE_KEY }}
+          destination_ssh_private_key:  ${{ secrets.GIT_SYNC_DESTINATION_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/aws/aws-sdk-js/pull/3610

*Description of changes:*
use git-sync action to sync with private mirror

*Testing:*
Testing done with the following packages:
* source: [`trivikr/git-sync-test`](https://github.com/trivikr/git-sync-test)
* destination: [`trivikr/private-git-sync-test`](https://github.com/trivikr/private-git-sync-test)

Config tested: https://github.com/trivikr/git-sync-test/blob/302d7d5cf429594757c9a32ead5e0816715f9b95/.github/workflows/git-sync.yml
Example GitHub Action run: https://github.com/trivikr/git-sync-test/runs/1778705960?check_suite_focus=true

Verified that secrets are not shown in the GitHub Action log

<details>
<summary>GitHub Action log</summary>

```
Cloning into '/root/source'...
SOURCE=git@github.com:***.git:main
DESTINATION=git@github.com:***.git:main
Warning: Permanently added 'github.com,140.82.113.3' (RSA) to the list of known hosts.
* main                302d7d5 [source/main] chore: update step name to git-sync
  remotes/source/HEAD -> source/main
  remotes/source/main 302d7d5 chore: update step name to git-sync
Warning: Permanently added the RSA host key for IP address '140.82.114.4' to the list of known hosts.
To github.com:***.git
   de881a8..302d7d5  main -> main
```

</details>

Note that:
* source GitHub URL is hidden `SOURCE=git@github.com:***.git:main`
* destination GitHub URL is hidden `DESTINATION=git@github.com:***.git:main`
* destination GitHub URL is hidden in git output `To github.com:***.git`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
