### PR TITLE
chore: use headings in bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -7,25 +7,29 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**SDK version number**
+### Your environment
+#### SDK version number
+`@aws-sdk/package-name@version`
 
-**Is the issue in the browser/Node.js/ReactNative?**
+#### Is the issue in the browser/Node.js/ReactNative?
 Browser/Node.js/ReactNative
 
-**Details of the browser/Node.js/ReactNative version**
+#### Details of the browser/Node.js/ReactNative version
 Paste output of `npx envinfo --browsers` or `node -v` or `react-native -v`
 
-**To Reproduce (observed behavior)**
-Steps to reproduce the behavior (please share code or minimal repo)
+### Steps to reproduce
+Please share code or minimal repo, and steps to reproduce the behavior.
+#### Observed behavior
+A clear and concise description of what happens.
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+#### Expected behavior
+A clear and concise description of what you were expecting to happen.
 
-**Screenshots**
+#### Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Additional context**
+### Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Describe the bug
 A clear and concise description of what the bug is.
 
-### Your environment
+## Your environment
 #### SDK version number
 `@aws-sdk/package-name@version`
 
@@ -20,7 +20,7 @@ Browser/Node.js/ReactNative
 #### Details of the browser/Node.js/ReactNative version
 Paste output of `npx envinfo --browsers` or `node -v` or `react-native -v`
 
-### Steps to reproduce
+## Steps to reproduce
 Please share code or minimal repo, and steps to reproduce the behavior.
 #### Observed behavior
 A clear and concise description of what happens.
@@ -31,5 +31,5 @@ A clear and concise description of what you were expecting to happen.
 #### Screenshots
 If applicable, add screenshots to help explain your problem.
 
-### Additional context
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+#### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+#### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -10,10 +10,10 @@ assignees: ''
 ### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-#### Describe the solution you'd like
+### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-#### Describe alternatives you've considered
+### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
 ### Additional context

--- a/.github/ISSUE_TEMPLATE/--documentation.md
+++ b/.github/ISSUE_TEMPLATE/--documentation.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-### Describe the issue with documentation
+## Describe the issue with documentation
 A clear and concise description of what the issue is.
 
-### Steps to reproduce
+## Steps to reproduce
 Please share code or minimal repo if required, and steps to reproduce the behavior.
 #### Observed behavior
 A clear and concise description of what happens.
@@ -21,5 +21,5 @@ A clear and concise description of what you were expecting to happen.
 #### Screenshots
 If applicable, add screenshots to help explain your problem.
 
-### Additional context
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/--documentation.md
+++ b/.github/ISSUE_TEMPLATE/--documentation.md
@@ -7,17 +7,19 @@ assignees: ''
 
 ---
 
-**Describe the issue with documentation**
+### Describe the issue with documentation
 A clear and concise description of what the issue is.
 
-**To Reproduce (observed behavior)**
-Steps to reproduce the behavior (please share code or minimal repo)
+### Steps to reproduce
+Please share code or minimal repo if required, and steps to reproduce the behavior.
+#### Observed behavior
+A clear and concise description of what happens.
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+#### Expected behavior
+A clear and concise description of what you were expecting to happen.
 
-**Screenshots**
+#### Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Additional context**
+### Additional context
 Add any other context about the problem here.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Uses headings in bug report templates instead of bold, so that templates can be organize contents in a hierarchy.

<details>
<summary>Bug report template with bold</summary>

![issue-bold](https://user-images.githubusercontent.com/16024985/106043926-eac26700-6093-11eb-95c6-6e6f9fea0313.png)

</details>

<details>
<summary>Bug report template with headings</summary>

![Screen Shot 2021-01-27 at 11 39 00 AM](https://user-images.githubusercontent.com/16024985/106044263-54db0c00-6094-11eb-94b0-4250f86e8a1d.png)

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
