### PR TITLE
feat(util-dynamodb): add option to convert class instance to map

### DIFF
--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -6,137 +6,141 @@ import { NativeAttributeValue } from "./models";
 
 describe("convertToAttr", () => {
   describe("null", () => {
-    it(`returns for null`, () => {
-      [false, true].forEach((convertClassInstanceToMap) => {
+    [true, false].forEach((convertClassInstanceToMap) => {
+      it(`returns for null`, () => {
         expect(convertToAttr(null, { convertClassInstanceToMap })).toEqual({ NULL: true });
       });
     });
   });
 
   describe("boolean", () => {
-    [true, false].forEach((isClassInstance) => {
-      [true, false].forEach((boolValue) => {
-        const bool = isClassInstance ? Boolean(boolValue) : boolValue;
-        it(`returns for boolean: ${bool}`, () => {
-          expect(convertToAttr(bool)).toEqual({ BOOL: bool });
+    [true, false].forEach((convertClassInstanceToMap) => {
+      [true, false].forEach((isClassInstance) => {
+        [true, false].forEach((boolValue) => {
+          const bool = isClassInstance ? Boolean(boolValue) : boolValue;
+          it(`returns for boolean: ${bool}`, () => {
+            expect(convertToAttr(bool, { convertClassInstanceToMap })).toEqual({ BOOL: bool });
+          });
         });
       });
     });
   });
 
   describe("number", () => {
-    [true, false].forEach((isClassInstance) => {
-      [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((numValue) => {
-        const num = isClassInstance ? Number(numValue) : numValue;
-        it(`returns for number (integer): ${num}`, () => {
-          expect(convertToAttr(num)).toEqual({ N: num.toString() });
+    [true, false].forEach((convertClassInstanceToMap) => {
+      [true, false].forEach((isClassInstance) => {
+        [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((numValue) => {
+          const num = isClassInstance ? Number(numValue) : numValue;
+          it(`returns for number (integer): ${num}`, () => {
+            expect(convertToAttr(num, { convertClassInstanceToMap })).toEqual({ N: num.toString() });
+          });
         });
-      });
 
-      [1.01, Math.PI, Math.E, Number.MIN_VALUE, Number.EPSILON].forEach((numValue) => {
-        const num = isClassInstance ? Number(numValue) : numValue;
-        it(`returns for number (floating point): ${num}`, () => {
-          expect(convertToAttr(num)).toEqual({ N: num.toString() });
+        [1.01, Math.PI, Math.E, Number.MIN_VALUE, Number.EPSILON].forEach((numValue) => {
+          const num = isClassInstance ? Number(numValue) : numValue;
+          it(`returns for number (floating point): ${num}`, () => {
+            expect(convertToAttr(num, { convertClassInstanceToMap })).toEqual({ N: num.toString() });
+          });
         });
-      });
 
-      [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((numValue) => {
-        const num = isClassInstance ? Number(numValue) : numValue;
-        it(`throws for number (special numeric value): ${num}`, () => {
-          expect(() => {
-            convertToAttr(num);
-          }).toThrowError(`Special numeric value ${num} is not allowed`);
+        [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((numValue) => {
+          const num = isClassInstance ? Number(numValue) : numValue;
+          it(`throws for number (special numeric value): ${num}`, () => {
+            expect(() => {
+              convertToAttr(num, { convertClassInstanceToMap });
+            }).toThrowError(`Special numeric value ${num} is not allowed`);
+          });
         });
-      });
 
-      [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE].forEach((numValue) => {
-        const num = isClassInstance ? Number(numValue) : numValue;
-        it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
-          const errorPrefix = `Number ${num} is greater than Number.MAX_SAFE_INTEGER.`;
+        [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE].forEach((numValue) => {
+          const num = isClassInstance ? Number(numValue) : numValue;
+          it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
+            const errorPrefix = `Number ${num} is greater than Number.MAX_SAFE_INTEGER.`;
 
-          expect(() => {
-            convertToAttr(num);
-          }).toThrowError(`${errorPrefix} Use BigInt.`);
+            expect(() => {
+              convertToAttr(num, { convertClassInstanceToMap });
+            }).toThrowError(`${errorPrefix} Use BigInt.`);
 
-          const BigIntConstructor = BigInt;
-          (BigInt as any) = undefined;
-          expect(() => {
-            convertToAttr(num);
-          }).toThrowError(`${errorPrefix} Pass string value instead.`);
-          BigInt = BigIntConstructor;
+            const BigIntConstructor = BigInt;
+            (BigInt as any) = undefined;
+            expect(() => {
+              convertToAttr(num, { convertClassInstanceToMap });
+            }).toThrowError(`${errorPrefix} Pass string value instead.`);
+            BigInt = BigIntConstructor;
+          });
         });
-      });
 
-      [Number.MIN_SAFE_INTEGER - 1].forEach((numValue) => {
-        const num = isClassInstance ? Number(numValue) : numValue;
-        it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
-          const errorPrefix = `Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`;
+        [Number.MIN_SAFE_INTEGER - 1].forEach((numValue) => {
+          const num = isClassInstance ? Number(numValue) : numValue;
+          it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
+            const errorPrefix = `Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`;
 
-          expect(() => {
-            convertToAttr(num);
-          }).toThrowError(`${errorPrefix} Use BigInt.`);
+            expect(() => {
+              convertToAttr(num, { convertClassInstanceToMap });
+            }).toThrowError(`${errorPrefix} Use BigInt.`);
 
-          const BigIntConstructor = BigInt;
-          (BigInt as any) = undefined;
-          expect(() => {
-            convertToAttr(num);
-          }).toThrowError(`${errorPrefix} Pass string value instead.`);
-          BigInt = BigIntConstructor;
+            const BigIntConstructor = BigInt;
+            (BigInt as any) = undefined;
+            expect(() => {
+              convertToAttr(num, { convertClassInstanceToMap });
+            }).toThrowError(`${errorPrefix} Pass string value instead.`);
+            BigInt = BigIntConstructor;
+          });
         });
       });
     });
   });
 
   describe("bigint", () => {
-    const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
-    [
-      // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
-      1n,
-      // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
-      maxSafe * 2n,
-      // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
-      maxSafe * -2n,
-      BigInt(Number.MAX_VALUE),
-      BigInt("0x1fffffffffffff"),
-      BigInt("0b11111111111111111111111111111111111111111111111111111"),
-    ].forEach((num) => {
-      it(`returns for bigint: ${num}`, () => {
-        expect(convertToAttr(num)).toEqual({ N: num.toString() });
+    [true, false].forEach((convertClassInstanceToMap) => {
+      const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+      [
+        // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+        1n,
+        // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+        maxSafe * 2n,
+        // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+        maxSafe * -2n,
+        BigInt(Number.MAX_VALUE),
+        BigInt("0x1fffffffffffff"),
+        BigInt("0b11111111111111111111111111111111111111111111111111111"),
+      ].forEach((num) => {
+        it(`returns for bigint: ${num}`, () => {
+          expect(convertToAttr(num, { convertClassInstanceToMap })).toEqual({ N: num.toString() });
+        });
       });
     });
   });
 
   describe("binary", () => {
-    const buffer = new ArrayBuffer(64);
-    const arr = [...Array(64).keys()];
-    const addPointOne = (num: number) => num + 0.1;
+    [true, false].forEach((convertClassInstanceToMap) => {
+      const buffer = new ArrayBuffer(64);
+      const arr = [...Array(64).keys()];
+      const addPointOne = (num: number) => num + 0.1;
 
-    [
-      buffer,
-      new Blob([new Uint8Array(buffer)]),
-      Buffer.from(buffer),
-      new DataView(buffer),
-      new Int8Array(arr),
-      new Uint8Array(arr),
-      new Uint8ClampedArray(arr),
-      new Int16Array(arr),
-      new Uint16Array(arr),
-      new Int32Array(arr),
-      new Uint32Array(arr),
-      new Float32Array(arr.map(addPointOne)),
-      new Float64Array(arr.map(addPointOne)),
-      new BigInt64Array(arr.map(BigInt)),
-      new BigUint64Array(arr.map(BigInt)),
-    ].forEach((data) => {
-      it(`returns for binary: ${data.constructor.name}`, () => {
-        [false, true].forEach((convertClassInstanceToMap) => {
+      [
+        buffer,
+        new Blob([new Uint8Array(buffer)]),
+        Buffer.from(buffer),
+        new DataView(buffer),
+        new Int8Array(arr),
+        new Uint8Array(arr),
+        new Uint8ClampedArray(arr),
+        new Int16Array(arr),
+        new Uint16Array(arr),
+        new Int32Array(arr),
+        new Uint32Array(arr),
+        new Float32Array(arr.map(addPointOne)),
+        new Float64Array(arr.map(addPointOne)),
+        new BigInt64Array(arr.map(BigInt)),
+        new BigUint64Array(arr.map(BigInt)),
+      ].forEach((data) => {
+        it(`returns for binary: ${data.constructor.name}`, () => {
           expect(convertToAttr(data, { convertClassInstanceToMap })).toEqual({ B: data });
         });
       });
-    });
 
-    it("returns null for Binary when options.convertEmptyValues=true", () => {
-      [false, true].forEach((convertClassInstanceToMap) => {
+      it("returns null for Binary when options.convertEmptyValues=true", () => {
         expect(convertToAttr(new Uint8Array(), { convertClassInstanceToMap, convertEmptyValues: true })).toEqual({
           NULL: true,
         });
@@ -379,17 +383,19 @@ describe("convertToAttr", () => {
   });
 
   describe("string", () => {
-    [true, false].forEach((isClassInstance) => {
-      ["", "string", "'single-quote'", '"double-quote"'].forEach((strValue) => {
-        const str = isClassInstance ? String(strValue) : strValue;
-        it(`returns for string: ${str}`, () => {
-          expect(convertToAttr(str)).toEqual({ S: str });
+    [true, false].forEach((convertClassInstanceToMap) => {
+      [true, false].forEach((isClassInstance) => {
+        ["", "string", "'single-quote'", '"double-quote"'].forEach((strValue) => {
+          const str = isClassInstance ? String(strValue) : strValue;
+          it(`returns for string: ${str}`, () => {
+            expect(convertToAttr(str, { convertClassInstanceToMap })).toEqual({ S: str });
+          });
         });
-      });
 
-      it("returns null for string when options.convertEmptyValues=true", () => {
-        const str = isClassInstance ? String("") : "";
-        expect(convertToAttr(str, { convertEmptyValues: true })).toEqual({ NULL: true });
+        it("returns null for string when options.convertEmptyValues=true", () => {
+          const str = isClassInstance ? String("") : "";
+          expect(convertToAttr(str, { convertClassInstanceToMap, convertEmptyValues: true })).toEqual({ NULL: true });
+        });
       });
     });
   });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -14,65 +14,75 @@ describe("convertToAttr", () => {
   });
 
   describe("boolean", () => {
-    [true, false].forEach((bool) => {
-      it(`returns for boolean: ${bool}`, () => {
-        expect(convertToAttr(bool)).toEqual({ BOOL: bool });
+    [true, false].forEach((isClassInstance) => {
+      [true, false].forEach((boolValue) => {
+        const bool = isClassInstance ? Boolean(boolValue) : boolValue;
+        it(`returns for boolean: ${bool}`, () => {
+          expect(convertToAttr(bool)).toEqual({ BOOL: bool });
+        });
       });
     });
   });
 
   describe("number", () => {
-    [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((num) => {
-      it(`returns for number (integer): ${num}`, () => {
-        expect(convertToAttr(num)).toEqual({ N: num.toString() });
+    [true, false].forEach((isClassInstance) => {
+      [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((numValue) => {
+        const num = isClassInstance ? Number(numValue) : numValue;
+        it(`returns for number (integer): ${num}`, () => {
+          expect(convertToAttr(num)).toEqual({ N: num.toString() });
+        });
       });
-    });
 
-    [1.01, Math.PI, Math.E, Number.MIN_VALUE, Number.EPSILON].forEach((num) => {
-      it(`returns for number (floating point): ${num}`, () => {
-        expect(convertToAttr(num)).toEqual({ N: num.toString() });
+      [1.01, Math.PI, Math.E, Number.MIN_VALUE, Number.EPSILON].forEach((numValue) => {
+        const num = isClassInstance ? Number(numValue) : numValue;
+        it(`returns for number (floating point): ${num}`, () => {
+          expect(convertToAttr(num)).toEqual({ N: num.toString() });
+        });
       });
-    });
 
-    [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((num) => {
-      it(`throws for number (special numeric value): ${num}`, () => {
-        expect(() => {
-          convertToAttr(num);
-        }).toThrowError(`Special numeric value ${num} is not allowed`);
+      [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((numValue) => {
+        const num = isClassInstance ? Number(numValue) : numValue;
+        it(`throws for number (special numeric value): ${num}`, () => {
+          expect(() => {
+            convertToAttr(num);
+          }).toThrowError(`Special numeric value ${num} is not allowed`);
+        });
       });
-    });
 
-    [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE].forEach((num) => {
-      it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
-        const errorPrefix = `Number ${num} is greater than Number.MAX_SAFE_INTEGER.`;
+      [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE].forEach((numValue) => {
+        const num = isClassInstance ? Number(numValue) : numValue;
+        it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
+          const errorPrefix = `Number ${num} is greater than Number.MAX_SAFE_INTEGER.`;
 
-        expect(() => {
-          convertToAttr(num);
-        }).toThrowError(`${errorPrefix} Use BigInt.`);
+          expect(() => {
+            convertToAttr(num);
+          }).toThrowError(`${errorPrefix} Use BigInt.`);
 
-        const BigIntConstructor = BigInt;
-        (BigInt as any) = undefined;
-        expect(() => {
-          convertToAttr(num);
-        }).toThrowError(`${errorPrefix} Pass string value instead.`);
-        BigInt = BigIntConstructor;
+          const BigIntConstructor = BigInt;
+          (BigInt as any) = undefined;
+          expect(() => {
+            convertToAttr(num);
+          }).toThrowError(`${errorPrefix} Pass string value instead.`);
+          BigInt = BigIntConstructor;
+        });
       });
-    });
 
-    [Number.MIN_SAFE_INTEGER - 1].forEach((num) => {
-      it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
-        const errorPrefix = `Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`;
+      [Number.MIN_SAFE_INTEGER - 1].forEach((numValue) => {
+        const num = isClassInstance ? Number(numValue) : numValue;
+        it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
+          const errorPrefix = `Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`;
 
-        expect(() => {
-          convertToAttr(num);
-        }).toThrowError(`${errorPrefix} Use BigInt.`);
+          expect(() => {
+            convertToAttr(num);
+          }).toThrowError(`${errorPrefix} Use BigInt.`);
 
-        const BigIntConstructor = BigInt;
-        (BigInt as any) = undefined;
-        expect(() => {
-          convertToAttr(num);
-        }).toThrowError(`${errorPrefix} Pass string value instead.`);
-        BigInt = BigIntConstructor;
+          const BigIntConstructor = BigInt;
+          (BigInt as any) = undefined;
+          expect(() => {
+            convertToAttr(num);
+          }).toThrowError(`${errorPrefix} Pass string value instead.`);
+          BigInt = BigIntConstructor;
+        });
       });
     });
   });
@@ -369,14 +379,18 @@ describe("convertToAttr", () => {
   });
 
   describe("string", () => {
-    ["", "string", "'single-quote'", '"double-quote"'].forEach((str) => {
-      it(`returns for string: ${str}`, () => {
-        expect(convertToAttr(str)).toEqual({ S: str });
+    [true, false].forEach((isClassInstance) => {
+      ["", "string", "'single-quote'", '"double-quote"'].forEach((strValue) => {
+        const str = isClassInstance ? String(strValue) : strValue;
+        it(`returns for string: ${str}`, () => {
+          expect(convertToAttr(str)).toEqual({ S: str });
+        });
       });
-    });
 
-    it("returns null for string when options.convertEmptyValues=true", () => {
-      expect(convertToAttr("", { convertEmptyValues: true })).toEqual({ NULL: true });
+      it("returns null for string when options.convertEmptyValues=true", () => {
+        const str = isClassInstance ? String("") : "";
+        expect(convertToAttr(str, { convertEmptyValues: true })).toEqual({ NULL: true });
+      });
     });
   });
 

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -279,7 +279,6 @@ describe("convertToAttr", () => {
     describe("unallowed set", () => {
       it("throws error", () => {
         expect(() => {
-          // @ts-expect-error Type 'Set<boolean>' is not assignable
           convertToAttr(new Set([true, false]));
         }).toThrowError(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed.`);
       });
@@ -394,7 +393,6 @@ describe("convertToAttr", () => {
     [new Date(), new FooClass("foo")].forEach((data) => {
       it(`throws for: ${String(data)}`, () => {
         expect(() => {
-          // @ts-expect-error Argument is not assignable to parameter of type 'NativeAttributeValue'
           convertToAttr(data);
         }).toThrowError(`Unsupported type passed: ${String(data)}`);
       });
@@ -417,7 +415,6 @@ describe("convertToAttr", () => {
       }
       expect(
         convertToAttr(
-          // @ts-expect-error Argument is not assignable to parameter of type 'NativeAttributeValue'
           new FooClass(
             null,
             true,
@@ -454,7 +451,6 @@ describe("convertToAttr", () => {
     });
 
     it("returns empty for Date object", () => {
-      // @ts-expect-error Argument is not assignable to parameter of type 'NativeAttributeValue'
       expect(convertToAttr(new Date(), { marshallObjects: true })).toEqual({ M: {} });
     });
   });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -7,8 +7,8 @@ import { NativeAttributeValue } from "./models";
 describe("convertToAttr", () => {
   describe("null", () => {
     it(`returns for null`, () => {
-      [false, true].forEach((marshallObjects) => {
-        expect(convertToAttr(null, { marshallObjects })).toEqual({ NULL: true });
+      [false, true].forEach((convertTypeofObject) => {
+        expect(convertToAttr(null, { convertTypeofObject })).toEqual({ NULL: true });
       });
     });
   });
@@ -119,15 +119,17 @@ describe("convertToAttr", () => {
       new BigUint64Array(arr.map(BigInt)),
     ].forEach((data) => {
       it(`returns for binary: ${data.constructor.name}`, () => {
-        [false, true].forEach((marshallObjects) => {
-          expect(convertToAttr(data, { marshallObjects })).toEqual({ B: data });
+        [false, true].forEach((convertTypeofObject) => {
+          expect(convertToAttr(data, { convertTypeofObject })).toEqual({ B: data });
         });
       });
     });
 
     it("returns null for Binary when options.convertEmptyValues=true", () => {
-      [false, true].forEach((marshallObjects) => {
-        expect(convertToAttr(new Uint8Array(), { marshallObjects, convertEmptyValues: true })).toEqual({ NULL: true });
+      [false, true].forEach((convertTypeofObject) => {
+        expect(convertToAttr(new Uint8Array(), { convertTypeofObject, convertEmptyValues: true })).toEqual({
+          NULL: true,
+        });
       });
     });
   });
@@ -397,13 +399,13 @@ describe("convertToAttr", () => {
         }).toThrowError(
           `Unsupported type passed: ${String(
             data
-          )}. Pass options.marshallObjects=true to marshall typeof object as map attribute.`
+          )}. Pass options.convertTypeofObject=true to marshall typeof object as map attribute.`
         );
       });
     });
   });
 
-  describe("typeof object with options.marshallObjects=true", () => {
+  describe("typeof object with options.convertTypeofObject=true", () => {
     it("returns map for class", () => {
       class FooClass {
         constructor(
@@ -435,7 +437,7 @@ describe("convertToAttr", () => {
             }
           ),
           {
-            marshallObjects: true,
+            convertTypeofObject: true,
           }
         )
       ).toEqual({
@@ -455,7 +457,7 @@ describe("convertToAttr", () => {
     });
 
     it("returns empty for Date object", () => {
-      expect(convertToAttr(new Date(), { marshallObjects: true })).toEqual({ M: {} });
+      expect(convertToAttr(new Date(), { convertTypeofObject: true })).toEqual({ M: {} });
     });
   });
 });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -394,7 +394,11 @@ describe("convertToAttr", () => {
       it(`throws for: ${String(data)}`, () => {
         expect(() => {
           convertToAttr(data);
-        }).toThrowError(`Unsupported type passed: ${String(data)}`);
+        }).toThrowError(
+          `Unsupported type passed: ${String(
+            data
+          )}. Pass options.marshallObjects=true to marshall typeof object as map attribute.`
+        );
       });
     });
   });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -7,7 +7,9 @@ import { NativeAttributeValue } from "./models";
 describe("convertToAttr", () => {
   describe("null", () => {
     it(`returns for null`, () => {
-      expect(convertToAttr(null)).toEqual({ NULL: true });
+      [false, true].forEach((marshallObjects) => {
+        expect(convertToAttr(null, { marshallObjects })).toEqual({ NULL: true });
+      });
     });
   });
 
@@ -117,12 +119,16 @@ describe("convertToAttr", () => {
       new BigUint64Array(arr.map(BigInt)),
     ].forEach((data) => {
       it(`returns for binary: ${data.constructor.name}`, () => {
-        expect(convertToAttr(data)).toEqual({ B: data });
+        [false, true].forEach((marshallObjects) => {
+          expect(convertToAttr(data, { marshallObjects })).toEqual({ B: data });
+        });
       });
     });
 
     it("returns null for Binary when options.convertEmptyValues=true", () => {
-      expect(convertToAttr(new Uint8Array(), { convertEmptyValues: true })).toEqual({ NULL: true });
+      [false, true].forEach((marshallObjects) => {
+        expect(convertToAttr(new Uint8Array(), { marshallObjects, convertEmptyValues: true })).toEqual({ NULL: true });
+      });
     });
   });
 

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -7,8 +7,8 @@ import { NativeAttributeValue } from "./models";
 describe("convertToAttr", () => {
   describe("null", () => {
     it(`returns for null`, () => {
-      [false, true].forEach((convertTypeofObject) => {
-        expect(convertToAttr(null, { convertTypeofObject })).toEqual({ NULL: true });
+      [false, true].forEach((convertClassInstanceToMap) => {
+        expect(convertToAttr(null, { convertClassInstanceToMap })).toEqual({ NULL: true });
       });
     });
   });
@@ -119,15 +119,15 @@ describe("convertToAttr", () => {
       new BigUint64Array(arr.map(BigInt)),
     ].forEach((data) => {
       it(`returns for binary: ${data.constructor.name}`, () => {
-        [false, true].forEach((convertTypeofObject) => {
-          expect(convertToAttr(data, { convertTypeofObject })).toEqual({ B: data });
+        [false, true].forEach((convertClassInstanceToMap) => {
+          expect(convertToAttr(data, { convertClassInstanceToMap })).toEqual({ B: data });
         });
       });
     });
 
     it("returns null for Binary when options.convertEmptyValues=true", () => {
-      [false, true].forEach((convertTypeofObject) => {
-        expect(convertToAttr(new Uint8Array(), { convertTypeofObject, convertEmptyValues: true })).toEqual({
+      [false, true].forEach((convertClassInstanceToMap) => {
+        expect(convertToAttr(new Uint8Array(), { convertClassInstanceToMap, convertEmptyValues: true })).toEqual({
           NULL: true,
         });
       });
@@ -399,13 +399,13 @@ describe("convertToAttr", () => {
         }).toThrowError(
           `Unsupported type passed: ${String(
             data
-          )}. Pass options.convertTypeofObject=true to marshall typeof object as map attribute.`
+          )}. Pass options.convertClassInstanceToMap=true to marshall typeof object as map attribute.`
         );
       });
     });
   });
 
-  describe("typeof object with options.convertTypeofObject=true", () => {
+  describe("typeof object with options.convertClassInstanceToMap=true", () => {
     it("returns map for class", () => {
       class FooClass {
         constructor(
@@ -437,7 +437,7 @@ describe("convertToAttr", () => {
             }
           ),
           {
-            convertTypeofObject: true,
+            convertClassInstanceToMap: true,
           }
         )
       ).toEqual({
@@ -457,7 +457,7 @@ describe("convertToAttr", () => {
     });
 
     it("returns empty for Date object", () => {
-      expect(convertToAttr(new Date(), { convertTypeofObject: true })).toEqual({ M: {} });
+      expect(convertToAttr(new Date(), { convertClassInstanceToMap: true })).toEqual({ M: {} });
     });
   });
 });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -17,9 +17,9 @@ describe("convertToAttr", () => {
     [true, false].forEach((convertClassInstanceToMap) => {
       [true, false].forEach((isClassInstance) => {
         [true, false].forEach((boolValue) => {
-          const bool = isClassInstance ? Boolean(boolValue) : boolValue;
+          const bool = isClassInstance ? new Boolean(boolValue) : boolValue;
           it(`returns for boolean: ${bool}`, () => {
-            expect(convertToAttr(bool, { convertClassInstanceToMap })).toEqual({ BOOL: bool });
+            expect(convertToAttr(bool, { convertClassInstanceToMap })).toEqual({ BOOL: bool.valueOf() });
           });
         });
       });
@@ -30,32 +30,32 @@ describe("convertToAttr", () => {
     [true, false].forEach((convertClassInstanceToMap) => {
       [true, false].forEach((isClassInstance) => {
         [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((numValue) => {
-          const num = isClassInstance ? Number(numValue) : numValue;
+          const num = isClassInstance ? new Number(numValue) : numValue;
           it(`returns for number (integer): ${num}`, () => {
             expect(convertToAttr(num, { convertClassInstanceToMap })).toEqual({ N: num.toString() });
           });
         });
 
         [1.01, Math.PI, Math.E, Number.MIN_VALUE, Number.EPSILON].forEach((numValue) => {
-          const num = isClassInstance ? Number(numValue) : numValue;
+          const num = isClassInstance ? new Number(numValue) : numValue;
           it(`returns for number (floating point): ${num}`, () => {
             expect(convertToAttr(num, { convertClassInstanceToMap })).toEqual({ N: num.toString() });
           });
         });
 
         [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((numValue) => {
-          const num = isClassInstance ? Number(numValue) : numValue;
+          const num = isClassInstance ? new Number(numValue) : numValue;
           it(`throws for number (special numeric value): ${num}`, () => {
             expect(() => {
               convertToAttr(num, { convertClassInstanceToMap });
-            }).toThrowError(`Special numeric value ${num} is not allowed`);
+            }).toThrowError(`Special numeric value ${num.toString()} is not allowed`);
           });
         });
 
         [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE].forEach((numValue) => {
-          const num = isClassInstance ? Number(numValue) : numValue;
+          const num = isClassInstance ? new Number(numValue) : numValue;
           it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
-            const errorPrefix = `Number ${num} is greater than Number.MAX_SAFE_INTEGER.`;
+            const errorPrefix = `Number ${num.toString()} is greater than Number.MAX_SAFE_INTEGER.`;
 
             expect(() => {
               convertToAttr(num, { convertClassInstanceToMap });
@@ -71,9 +71,9 @@ describe("convertToAttr", () => {
         });
 
         [Number.MIN_SAFE_INTEGER - 1].forEach((numValue) => {
-          const num = isClassInstance ? Number(numValue) : numValue;
+          const num = isClassInstance ? new Number(numValue) : numValue;
           it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
-            const errorPrefix = `Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`;
+            const errorPrefix = `Number ${num.toString()} is lesser than Number.MIN_SAFE_INTEGER.`;
 
             expect(() => {
               convertToAttr(num, { convertClassInstanceToMap });
@@ -386,14 +386,14 @@ describe("convertToAttr", () => {
     [true, false].forEach((convertClassInstanceToMap) => {
       [true, false].forEach((isClassInstance) => {
         ["", "string", "'single-quote'", '"double-quote"'].forEach((strValue) => {
-          const str = isClassInstance ? String(strValue) : strValue;
+          const str = isClassInstance ? new String(strValue) : strValue;
           it(`returns for string: ${str}`, () => {
-            expect(convertToAttr(str, { convertClassInstanceToMap })).toEqual({ S: str });
+            expect(convertToAttr(str, { convertClassInstanceToMap })).toEqual({ S: str.toString() });
           });
         });
 
         it("returns null for string when options.convertEmptyValues=true", () => {
-          const str = isClassInstance ? String("") : "";
+          const str = isClassInstance ? new String("") : "";
           expect(convertToAttr(str, { convertClassInstanceToMap, convertEmptyValues: true })).toEqual({ NULL: true });
         });
       });

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -130,12 +130,16 @@ const validateBigIntAndThrow = (errorPrefix: string) => {
 };
 
 const convertToNumberAttr = (num: number | Number): { N: string } => {
-  if ([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].includes(num as number)) {
-    throw new Error(`Special numeric value ${num} is not allowed`);
+  if (
+    [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]
+      .map((val) => val.toString())
+      .includes(num.toString())
+  ) {
+    throw new Error(`Special numeric value ${num.toString()} is not allowed`);
   } else if (num > Number.MAX_SAFE_INTEGER) {
-    validateBigIntAndThrow(`Number ${num} is greater than Number.MAX_SAFE_INTEGER.`);
+    validateBigIntAndThrow(`Number ${num.toString()} is greater than Number.MAX_SAFE_INTEGER.`);
   } else if (num < Number.MIN_SAFE_INTEGER) {
-    validateBigIntAndThrow(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`);
+    validateBigIntAndThrow(`Number ${num.toString()} is lesser than Number.MIN_SAFE_INTEGER.`);
   }
   return { N: num.toString() };
 };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -21,7 +21,6 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
   } else if (data?.constructor?.name === "Object") {
     return convertToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
   } else if (isBinary(data)) {
-    // @ts-expect-error Property 'length' does not exist on type 'ArrayBuffer'.
     if (data.length === 0 && options?.convertEmptyValues) {
       return convertToNullAttr();
     }

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -27,7 +27,7 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
     // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
     // @ts-expect-error Type '{ B: NativeAttributeBinary; }' is not assignable to type 'AttributeValue'
     return convertToBinaryAttr(data);
-  } else if (options?.convertTypeofObject && typeof data === "object") {
+  } else if (options?.convertClassInstanceToMap && typeof data === "object") {
     return convertToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
   } else {
     return convertToScalarAttr(data as NativeScalarAttributeValue, options);
@@ -121,7 +121,7 @@ const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshal
     return convertToStringAttr(data);
   }
   throw new Error(
-    `Unsupported type passed: ${data}. Pass options.convertTypeofObject=true to marshall typeof object as map attribute.`
+    `Unsupported type passed: ${data}. Pass options.convertClassInstanceToMap=true to marshall typeof object as map attribute.`
   );
 };
 

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -120,7 +120,9 @@ const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshal
     }
     return convertToStringAttr(data);
   }
-  throw new Error(`Unsupported type passed: ${data}`);
+  throw new Error(
+    `Unsupported type passed: ${data}. Pass options.marshallObjects=true to marshall typeof object as map attribute.`
+  );
 };
 
 // For future-proofing: this functions are called from multiple places

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -10,7 +10,11 @@ import { NativeAttributeBinary, NativeAttributeValue, NativeScalarAttributeValue
  * @param {marshallOptions} options - An optional configuration object for `convertToAttr`
  */
 export const convertToAttr = (data: NativeAttributeValue, options?: marshallOptions): AttributeValue => {
-  if (Array.isArray(data)) {
+  if (data === undefined) {
+    throw new Error(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
+  } else if (data === null && typeof data === "object") {
+    return convertToNullAttr();
+  } else if (Array.isArray(data)) {
     return convertToListAttr(data, options);
   } else if (data?.constructor?.name === "Set") {
     return convertToSetAttr(data as Set<any>, options);
@@ -103,11 +107,7 @@ const convertToMapAttr = (
 });
 
 const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshallOptions): AttributeValue => {
-  if (data === undefined) {
-    throw new Error(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
-  } else if (data === null && typeof data === "object") {
-    return convertToNullAttr();
-  } else if (typeof data === "boolean") {
+  if (typeof data === "boolean") {
     return { BOOL: data };
   } else if (typeof data === "number") {
     return convertToNumberAttr(data);

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -16,6 +16,14 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
     return convertToSetAttr(data as Set<any>, options);
   } else if (data?.constructor?.name === "Object") {
     return convertToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
+  } else if (isBinary(data)) {
+    // @ts-expect-error Property 'length' does not exist on type 'ArrayBuffer'.
+    if (data.length === 0 && options?.convertEmptyValues) {
+      return convertToNullAttr();
+    }
+    // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
+    // @ts-expect-error Type '{ B: NativeAttributeBinary; }' is not assignable to type 'AttributeValue'
+    return convertToBinaryAttr(data);
   } else {
     return convertToScalarAttr(data as NativeScalarAttributeValue, options);
   }
@@ -105,14 +113,6 @@ const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshal
     return convertToNumberAttr(data);
   } else if (typeof data === "bigint") {
     return convertToBigIntAttr(data);
-  } else if (isBinary(data)) {
-    // @ts-expect-error Property 'length' does not exist on type 'ArrayBuffer'.
-    if (data.length === 0 && options?.convertEmptyValues) {
-      return convertToNullAttr();
-    }
-    // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
-    // @ts-expect-error Type '{ B: NativeAttributeBinary; }' is not assignable to type 'AttributeValue'
-    return convertToBinaryAttr(data);
   } else if (typeof data === "string") {
     if (data.length === 0 && options?.convertEmptyValues) {
       return convertToNullAttr();

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -27,13 +27,13 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
     // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
     // @ts-expect-error Type '{ B: NativeAttributeBinary; }' is not assignable to type 'AttributeValue'
     return convertToBinaryAttr(data);
-  } else if (typeof data === "boolean") {
-    return { BOOL: data };
-  } else if (typeof data === "number") {
+  } else if (typeof data === "boolean" || data?.constructor?.name === "Boolean") {
+    return { BOOL: data.valueOf() };
+  } else if (typeof data === "number" || data?.constructor?.name === "Number") {
     return convertToNumberAttr(data);
   } else if (typeof data === "bigint") {
     return convertToBigIntAttr(data);
-  } else if (typeof data === "string") {
+  } else if (typeof data === "string" || data?.constructor?.name === "String") {
     if (data.length === 0 && options?.convertEmptyValues) {
       return convertToNullAttr();
     }
@@ -122,15 +122,15 @@ const convertToMapAttr = (
 // For future-proofing: this functions are called from multiple places
 const convertToNullAttr = (): { NULL: true } => ({ NULL: true });
 const convertToBinaryAttr = (data: NativeAttributeBinary): { B: NativeAttributeBinary } => ({ B: data });
-const convertToStringAttr = (data: string): { S: string } => ({ S: data });
+const convertToStringAttr = (data: string | String): { S: string } => ({ S: data.toString() });
 const convertToBigIntAttr = (data: bigint): { N: string } => ({ N: data.toString() });
 
 const validateBigIntAndThrow = (errorPrefix: string) => {
   throw new Error(`${errorPrefix} ${typeof BigInt === "function" ? "Use BigInt." : "Pass string value instead."} `);
 };
 
-const convertToNumberAttr = (num: number): { N: string } => {
-  if ([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].includes(num)) {
+const convertToNumberAttr = (num: number | Number): { N: string } => {
+  if ([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].includes(num as number)) {
     throw new Error(`Special numeric value ${num} is not allowed`);
   } else if (num > Number.MAX_SAFE_INTEGER) {
     validateBigIntAndThrow(`Number ${num} is greater than Number.MAX_SAFE_INTEGER.`);

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -27,7 +27,7 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
     // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
     // @ts-expect-error Type '{ B: NativeAttributeBinary; }' is not assignable to type 'AttributeValue'
     return convertToBinaryAttr(data);
-  } else if (options?.marshallObjects && typeof data === "object") {
+  } else if (options?.convertTypeofObject && typeof data === "object") {
     return convertToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
   } else {
     return convertToScalarAttr(data as NativeScalarAttributeValue, options);
@@ -121,7 +121,7 @@ const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshal
     return convertToStringAttr(data);
   }
   throw new Error(
-    `Unsupported type passed: ${data}. Pass options.marshallObjects=true to marshall typeof object as map attribute.`
+    `Unsupported type passed: ${data}. Pass options.convertTypeofObject=true to marshall typeof object as map attribute.`
   );
 };
 

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -28,6 +28,8 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
     // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
     // @ts-expect-error Type '{ B: NativeAttributeBinary; }' is not assignable to type 'AttributeValue'
     return convertToBinaryAttr(data);
+  } else if (options?.marshallObjects && typeof data === "object") {
+    return convertToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
   } else {
     return convertToScalarAttr(data as NativeScalarAttributeValue, options);
   }

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -4,18 +4,16 @@ import { marshall } from "./marshall";
 jest.mock("./convertToAttr");
 
 describe("marshall", () => {
-  const input = { a: "A", b: "B" };
-
-  beforeEach(() => {
-    (convertToAttr as jest.Mock).mockReturnValue({ M: input });
-  });
+  const mockOutput = { S: "mockOutput" };
+  (convertToAttr as jest.Mock).mockReturnValue({ M: mockOutput });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("calls convertToAttr", () => {
-    expect(marshall(input)).toEqual(input);
+  it("with object as an input", () => {
+    const input = { a: "A", b: "B" };
+    expect(marshall(input)).toEqual(mockOutput);
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
@@ -24,11 +22,44 @@ describe("marshall", () => {
     describe(`options.${option}`, () => {
       [false, true].forEach((value) => {
         it(`passes ${value} to convertToAttr`, () => {
-          expect(marshall(input, { [option]: value })).toEqual(input);
+          const input = { a: "A", b: "B" };
+          expect(marshall(input, { [option]: value })).toEqual(mockOutput);
           expect(convertToAttr).toHaveBeenCalledTimes(1);
           expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
         });
       });
     });
+  });
+
+  it("with type as an input", () => {
+    type TestInputType = { a: string; b: string };
+    const input: TestInputType = { a: "A", b: "B" };
+
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
+
+  it("with Interface as an input", () => {
+    interface TestInputInterface {
+      a: string;
+      b: string;
+    }
+    const input: TestInputInterface = { a: "A", b: "B" };
+
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
+
+  it("with class instance as an input", () => {
+    class TestInputClass {
+      constructor(private readonly a: string, private readonly b: string) {}
+    }
+    const input = new TestInputClass("A", "B");
+
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
 });

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -16,9 +16,9 @@ export interface marshallOptions {
    */
   removeUndefinedValues?: boolean;
   /**
-   * Whether to marshall typeof object while marshalling.
+   * Whether to convert typeof object to map attribute.
    */
-  marshallObjects?: boolean;
+  convertTypeofObject?: boolean;
 }
 
 /**

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -27,7 +27,7 @@ export interface marshallOptions {
  * @param {any} data - The data to convert to a DynamoDB record
  * @param {marshallOptions} options - An optional configuration object for `marshall`
  */
-export const marshall = (
-  data: { [key: string]: NativeAttributeValue },
+export const marshall = <T extends { [K in keyof T]: NativeAttributeValue }>(
+  data: T,
   options?: marshallOptions
 ): { [key: string]: AttributeValue } => convertToAttr(data, options).M as { [key: string]: AttributeValue };

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -15,6 +15,10 @@ export interface marshallOptions {
    * Whether to remove undefined values while marshalling.
    */
   removeUndefinedValues?: boolean;
+  /**
+   * Whether to marshall typeof object while marshalling.
+   */
+  marshallObjects?: boolean;
 }
 
 /**

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -18,7 +18,7 @@ export interface marshallOptions {
   /**
    * Whether to convert typeof object to map attribute.
    */
-  convertTypeofObject?: boolean;
+  convertClassInstanceToMap?: boolean;
 }
 
 /**

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -15,7 +15,7 @@ export type NativeAttributeValue =
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
   | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>
-  | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.convertTypeofObject
+  | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.convertClassInstanceToMap
 
 export type NativeScalarAttributeValue =
   | null

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -15,7 +15,7 @@ export type NativeAttributeValue =
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
   | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>
-  | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.marshallObjects
+  | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.convertTypeofObject
 
 export type NativeScalarAttributeValue =
   | null

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -14,7 +14,8 @@ export type NativeAttributeValue =
   | NativeScalarAttributeValue
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
-  | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>;
+  | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>
+  | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.marshallObjects
 
 export type NativeScalarAttributeValue =
   | null


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1647
Closes: https://github.com/aws/aws-sdk-js-v3/issues/1535
Closes: https://github.com/aws/aws-sdk-js-v3/issues/1865
Closes: https://github.com/aws/aws-sdk-js-v3/issues/1534
Closes: https://github.com/aws/aws-sdk-js-v3/issues/1861
Closes: https://github.com/aws/aws-sdk-js-v3/issues/1102
Closes: https://github.com/aws/aws-sdk-js-v3/issues/1534

### Description
adds option to convert class instance to map in `@aws-sdk/util-dynamodb`
```js
convertToAttr(data, { convertClassInstanceToMap: true })
```

### Testing
Unit tests for marshall and convertToAttr functions

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.