### PR TITLE
chore(codegen): move CrossRegionCopying to separate plugin

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -39,15 +39,7 @@ import software.amazon.smithy.utils.SetUtils;
  * Adds all built-in runtime client plugins to clients.
  */
 public class AddBuiltinPlugins implements TypeScriptIntegration {
-
     private static final Set<String> ROUTE_53_ID_MEMBERS = SetUtils.of("DelegationSetId", "HostedZoneId", "Id");
-
-    private static final Set<String> RDS_PRESIGNED_URL_OPERATIONS = SetUtils.of(
-        "CopyDBSnapshot",
-        "CreateDBInstanceReadReplica",
-        "CreateDBCluster",
-        "CopyDBClusterSnapshot"
-    );
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
@@ -103,12 +95,6 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                                          "ChangeResourceRecordSets", HAS_MIDDLEWARE)
                         .operationPredicate((m, s, o) -> o.getId().getName().equals("ChangeResourceRecordSets")
                                             && testServiceId(s, "Route 53"))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> RDS_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
-                                            && testServiceId(s, "RDS"))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.ROUTE53_MIDDLEWARE.dependency, "IdNormalizer",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
+
+import java.util.List;
+import java.util.Set;
+
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SetUtils;
+
+public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
+    private static final Set<String> RDS_PRESIGNED_URL_OPERATIONS = SetUtils.of(
+        "CopyDBSnapshot",
+        "CreateDBInstanceReadReplica",
+        "CreateDBCluster",
+        "CopyDBClusterSnapshot"
+    );
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
+                        HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> RDS_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
+                        && testServiceId(s, "RDS"))
+                .build()
+        );
+    }
+
+    private static boolean testServiceId(Shape serviceShape, String expectedId) {
+        return serviceShape.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("").equals(expectedId);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -15,3 +15,4 @@ software.amazon.smithy.aws.typescript.codegen.AddTranscribeStreamingDependency
 software.amazon.smithy.aws.typescript.codegen.AddUserAgentDependency
 software.amazon.smithy.aws.typescript.codegen.AddOmitRetryHeadersDependency
 software.amazon.smithy.aws.typescript.codegen.StripNewEnumNames
+software.amazon.smithy.aws.typescript.codegen.AddCrossRegionCopyingPlugin


### PR DESCRIPTION
### Issue #
Internal JS-2351, in preparation to add cross region copying to DocDB and Neptune.

### Description
Moves addition of cross region copying to `AddCrossRegionCopyingPlugin.java`

### Testing
Running codegen did not update the clients

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.