### PR TITLE
chore(clients): support cross-region-copying in DocDB and Neptune

### DIFF
--- a/clients/client-docdb/commands/CopyDBClusterSnapshotCommand.ts
+++ b/clients/client-docdb/commands/CopyDBClusterSnapshotCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_queryCopyDBClusterSnapshotCommand,
   serializeAws_queryCopyDBClusterSnapshotCommand,
 } from "../protocols/Aws_query";
+import { getCrossRegionPresignedUrlPlugin } from "@aws-sdk/middleware-sdk-rds";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -57,6 +58,7 @@ export class CopyDBClusterSnapshotCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CopyDBClusterSnapshotCommandInput, CopyDBClusterSnapshotCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getCrossRegionPresignedUrlPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-docdb/commands/CreateDBClusterCommand.ts
+++ b/clients/client-docdb/commands/CreateDBClusterCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_queryCreateDBClusterCommand,
   serializeAws_queryCreateDBClusterCommand,
 } from "../protocols/Aws_query";
+import { getCrossRegionPresignedUrlPlugin } from "@aws-sdk/middleware-sdk-rds";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -46,6 +47,7 @@ export class CreateDBClusterCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateDBClusterCommandInput, CreateDBClusterCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getCrossRegionPresignedUrlPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-neptune/commands/CopyDBClusterSnapshotCommand.ts
+++ b/clients/client-neptune/commands/CopyDBClusterSnapshotCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_queryCopyDBClusterSnapshotCommand,
   serializeAws_queryCopyDBClusterSnapshotCommand,
 } from "../protocols/Aws_query";
+import { getCrossRegionPresignedUrlPlugin } from "@aws-sdk/middleware-sdk-rds";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -49,6 +50,7 @@ export class CopyDBClusterSnapshotCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CopyDBClusterSnapshotCommandInput, CopyDBClusterSnapshotCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getCrossRegionPresignedUrlPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-neptune/commands/CreateDBClusterCommand.ts
+++ b/clients/client-neptune/commands/CreateDBClusterCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_queryCreateDBClusterCommand,
   serializeAws_queryCreateDBClusterCommand,
 } from "../protocols/Aws_query";
+import { getCrossRegionPresignedUrlPlugin } from "@aws-sdk/middleware-sdk-rds";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -52,6 +53,7 @@ export class CreateDBClusterCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateDBClusterCommandInput, CreateDBClusterCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getCrossRegionPresignedUrlPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-rds/commands/StartDBInstanceAutomatedBackupsReplicationCommand.ts
+++ b/clients/client-rds/commands/StartDBInstanceAutomatedBackupsReplicationCommand.ts
@@ -7,6 +7,7 @@ import {
   deserializeAws_queryStartDBInstanceAutomatedBackupsReplicationCommand,
   serializeAws_queryStartDBInstanceAutomatedBackupsReplicationCommand,
 } from "../protocols/Aws_query";
+import { getCrossRegionPresignedUrlPlugin } from "@aws-sdk/middleware-sdk-rds";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -56,6 +57,7 @@ export class StartDBInstanceAutomatedBackupsReplicationCommand extends $Command<
     StartDBInstanceAutomatedBackupsReplicationCommandOutput
   > {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getCrossRegionPresignedUrlPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
@@ -34,7 +34,8 @@ public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
     );
     private static final Set<String> RDS_PRESIGNED_URL_OPERATIONS = SetUtils.of(
         "CopyDBSnapshot",
-        "CreateDBInstanceReadReplica"
+        "CreateDBInstanceReadReplica",
+        "StartDBInstanceAutomatedBackupsReplication"
     );
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
@@ -28,11 +28,13 @@ import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SetUtils;
 
 public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
+    private static final Set<String> SHARED_PRESIGNED_URL_OPERATIONS = SetUtils.of(
+        "CopyDBClusterSnapshot",
+        "CreateDBCluster"
+    );
     private static final Set<String> RDS_PRESIGNED_URL_OPERATIONS = SetUtils.of(
         "CopyDBSnapshot",
-        "CreateDBInstanceReadReplica",
-        "CreateDBCluster",
-        "CopyDBClusterSnapshot"
+        "CreateDBInstanceReadReplica"
     );
 
     @Override
@@ -42,6 +44,12 @@ public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
                 .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
                         HAS_MIDDLEWARE)
                 .operationPredicate((m, s, o) -> RDS_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
+                        && testServiceId(s, "RDS"))
+                .build(),
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
+                        HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> SHARED_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
                         && testServiceId(s, "RDS"))
                 .build()
         );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
@@ -51,7 +51,7 @@ public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
                 .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
                         HAS_MIDDLEWARE)
                 .operationPredicate((m, s, o) -> SHARED_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
-                        && testServiceId(s, "RDS"))
+                        && (testServiceId(s, "RDS") || testServiceId(s, "DocDB")))
                 .build()
         );
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
@@ -51,7 +51,7 @@ public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
                 .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
                         HAS_MIDDLEWARE)
                 .operationPredicate((m, s, o) -> SHARED_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
-                        && (testServiceId(s, "RDS") || testServiceId(s, "DocDB")))
+                        && (testServiceId(s, "RDS") || testServiceId(s, "DocDB")  || testServiceId(s, "Neptune")))
                 .build()
         );
     }


### PR DESCRIPTION
### Issue #
Internal JS-2351

### Description
supports cross-region-copying in DocDB and Neptune

### Testing
Verified that generated code adds middleware for operations in DocDB and Neptune

### Additional context
The PR would be made ready, and base branch would be changed to master after https://github.com/aws/aws-sdk-js-v3/pull/1984 is merged.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.