### PR TITLE
feat(s3-request-presigner): automatically add host header

### DIFF
--- a/packages/s3-request-presigner/src/presigner.spec.ts
+++ b/packages/s3-request-presigner/src/presigner.spec.ts
@@ -107,4 +107,12 @@ describe("s3 presigner", () => {
     expect(signedHeaders).toContain("x-amz-server-side-encryption");
     expect(signedHeaders).toContain("x-amz-server-side-encryption-customer-algorithm");
   });
+
+  it("should inject host header if not supplied", async () => {
+    const signer = new S3RequestPresigner(s3ResolvedConfig);
+    const signed = await signer.presign(minimalRequest);
+    expect(signed.headers).toMatchObject({
+      host: minimalRequest.hostname,
+    });
+  });
 });

--- a/packages/s3-request-presigner/src/presigner.ts
+++ b/packages/s3-request-presigner/src/presigner.ts
@@ -43,6 +43,9 @@ export class S3RequestPresigner implements RequestPresigner {
         unhoistableHeaders.add(header);
       });
     requestToSign.headers[SHA256_HEADER] = UNSIGNED_PAYLOAD;
+    if (!requestToSign.headers["host"]) {
+      requestToSign.headers.host = requestToSign.hostname;
+    }
     return this.signer.presign(requestToSign, {
       expiresIn: 900,
       unsignableHeaders,


### PR DESCRIPTION
### Description
Previously, if user use `S3RequestPresigner` class to sign an existing request. The request is **required** to have a `host` header to get SigV4 signature properly. This change automatically injects the `host` header if not present, making the code less error prone.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.