### PR TITLE
fix(lib-storage): S3 Upload can corrupt data from readable stream

### DIFF
--- a/lib/storage/src/data-chunk/readable-helper.ts
+++ b/lib/storage/src/data-chunk/readable-helper.ts
@@ -10,9 +10,7 @@ export async function* chunkFromReadable(reader: Readable, chunkSize: number): A
   while (partNumber < DEFAULT.MAX_PART_NUMBER) {
     let currentBuffer = oldBuffer;
     if (reader.readable) {
-      reader.resume();
       currentBuffer = await _chunkFromStream(reader, chunkSize, oldBuffer);
-      reader.pause();
     }
 
     yield {
@@ -42,6 +40,7 @@ function _chunkFromStream(stream: Readable, chunkSize: number, oldBuffer: Buffer
       stream.removeAllListeners("data");
       stream.removeAllListeners("error");
       stream.removeAllListeners("end");
+      stream.pause();
     };
 
     stream.on("data", (chunk) => {
@@ -59,5 +58,7 @@ function _chunkFromStream(stream: Readable, chunkSize: number, oldBuffer: Buffer
       cleanupListeners();
       resolve(currentChunk);
     });
+
+    stream.resume();
   });
 }


### PR DESCRIPTION
### Issue #
In some circumstance Upload miss some data from the readable stream and corrupt the uploaded data. This has been observed in a real situation when serializing data and uploading data on the fly by using a PassThrough between the serialization and the S3 Upload. The issue has been located in `lib/storage/src/data-chunk/readable-helper.ts`

### Description
In `readable-helper.ts` the pause/resume mechanism has a concurrency flaw between line
https://github.com/aws/aws-sdk-js-v3/blob/fa33f0b04b6c61e8305f07107f92da306d67242a/lib/storage/src/data-chunk/readable-helper.ts#L14
and
https://github.com/aws/aws-sdk-js-v3/blob/fa33f0b04b6c61e8305f07107f92da306d67242a/lib/storage/src/data-chunk/readable-helper.ts#L15

It can happen that stream can emit data that won't be process since no 'data' event listener is registered at that time.

Fix is to handle the pause/resume directly in _chunkFromStream in synchronous code, preventing the hole caused by await/aync code part.

PR #1955 also fix this problem.

### Testing
A new unit test has been added in `lib/storage/test/data-chunk/readable-helper.spec.ts` 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.