### PR TITLE
fix(util-user-agent-browser): use default import from bowser

### DIFF
--- a/packages/util-user-agent-browser/src/index.ts
+++ b/packages/util-user-agent-browser/src/index.ts
@@ -1,5 +1,5 @@
 import { Provider, UserAgent } from "@aws-sdk/types";
-import * as bowser from "bowser";
+import bowser from "bowser";
 
 import { DefaultUserAgentOptions } from "./configurations";
 

--- a/packages/util-user-agent-browser/src/index.ts
+++ b/packages/util-user-agent-browser/src/index.ts
@@ -1,5 +1,5 @@
 import { Provider, UserAgent } from "@aws-sdk/types";
-import { parse } from "bowser";
+import * as bowser from "bowser";
 
 import { DefaultUserAgentOptions } from "./configurations";
 
@@ -11,7 +11,7 @@ export const defaultUserAgent = ({
   serviceId,
   clientVersion,
 }: DefaultUserAgentOptions): Provider<UserAgent> => async () => {
-  const parsedUA = window?.navigator?.userAgent ? parse(window.navigator.userAgent) : undefined;
+  const parsedUA = window?.navigator?.userAgent ? bowser.parse(window.navigator.userAgent) : undefined;
   const sections: UserAgent = [
     // sdk-metadata
     ["aws-sdk-js", clientVersion],


### PR DESCRIPTION
### Issue #
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1992

### Description
Uses default import from bowser as suggested in README https://github.com/lancedikson/bowser#use-cases

### Testing
Verified that snowpack build is successful and todo-app works after performing:
* `yarn local-publish` to publish packages from workspace using verdaccio.
* `./node_modules/.bin/verdaccio -c verdaccio/config.yaml` to start verdaccio server.
* Use published version `"3.4.2-ci.0"` in todo-app with snowpack.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.