### PR TITLE
fix(client-s3): use LifecycleConfiguration as the root element for BucketLifecycleConfiguration, as per v2 API

### DIFF
--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -10192,7 +10192,7 @@ const serializeAws_restXmlBucketLifecycleConfiguration = (
   input: BucketLifecycleConfiguration,
   context: __SerdeContext
 ): any => {
-  const bodyNode = new __XmlNode("BucketLifecycleConfiguration");
+  const bodyNode = new __XmlNode("LifecycleConfiguration");
   if (input.Rules !== undefined && input.Rules !== null) {
     const nodes = serializeAws_restXmlLifecycleRules(input.Rules, context);
     nodes.map((node: any) => {


### PR DESCRIPTION
fix(client-s3): use LifecycleConfiguration as the root element for BucketLifecycleConfiguration, as per v2 API.

### Issue #
Refs: n/a

### Description
What does this implement/fix? Explain your changes.

When using the v3 API code as below against an internal EMC S3 instance, we get presented with the generic error "MalformedXML: This happens when the user sends a malformed xml..."

```js
import { PutBucketLifecycleConfigurationCommand, S3 } from "@aws-sdk/client-s3";

const s3 = new S3({
  credentials: { ... },
  endpoint: "...",
  forcePathStyle: true,
  region: "us-east-1"
});

const run = async() => {
  try {
    await s3.send(new PutBucketLifecycleConfigurationCommand({
      Bucket: "andy-tst1",
      LifecycleConfiguration: {
        Rules: [
          {
            Expiration: {
              Days: 7,
            },
            Filter: {
              Prefix: "",
            },
            Status: "Enabled",
          }
        ]
      }
    }));
  } catch (err) {
    console.log(err);
  }
};
run();
```

However, when running similar code against the v2 API, it works successfully.

```js
import S3 from 'aws-sdk/clients/s3';

const s3 = new S3({
  accessKeyId: "...",
  secretAccessKey: "...",
  endpoint: "...",
  s3ForcePathStyle: true,
});

s3.putBucketLifecycleConfiguration({
  Bucket: "andy-tst1",
  LifecycleConfiguration: {
	Rules: [
	  {
		Expiration: {
		  Days: 7,
		},
		Filter: {
		  Prefix: "",
		},
		Status: "Enabled",
	  }
	]
  }
}, (err, data) => {
  console.log(err, data);
});
```

The reason appears to be that the XML sent is now as follows in v3
```console
<BucketLifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Rule>...
```

But was the below in v2:
```console
<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Rule>...
```

Therefore, this change is to change the root XML element to the version present in the V2 api.

### Testing

Modified locally and tested against a local EMC S3 instance

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.