### PR TITLE
chore: Enable publishing of the aws generator

### DIFF
--- a/codegen/LICENSE
+++ b/codegen/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/codegen/NOTICE
+++ b/codegen/NOTICE
@@ -1,0 +1,2 @@
+Smithy AWS Typescript
+Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -12,10 +12,256 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+plugins {
+    `java-library`
+    `maven-publish`
+    signing
+    checkstyle
+    jacoco
+    id("com.github.spotbugs") version "4.6.0"
+    id("io.codearte.nexus-staging") version "0.21.0"
+}
 
 allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+    }
+    group = "software.amazon.smithy"
+    version = "0.3.0"
+}
+
+// The root project doesn't produce a JAR.
+tasks["jar"].enabled = false
+
+// Load the Sonatype user/password for use in publishing tasks.
+val sonatypeUser: String? by project
+val sonatypePassword: String? by project
+
+/*
+ * Sonatype Staging Finalization
+ * ====================================================
+ *
+ * When publishing to Maven Central, we need to close the staging
+ * repository and release the artifacts after they have been
+ * validated. This configuration is for the root project because
+ * it operates at the "group" level.
+ */
+if (sonatypeUser != null && sonatypePassword != null) {
+    apply(plugin = "io.codearte.nexus-staging")
+
+    nexusStaging {
+        packageGroup = "software.amazon"
+        stagingProfileId = "e789115b6c941"
+
+        username = sonatypeUser
+        password = sonatypePassword
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+subprojects {
+    val subproject = this
+
+    /*
+     * Java
+     * ====================================================
+     */
+    if (subproject.name == "smithy-aws-typescript-codegen") {
+        apply(plugin = "java-library")
+
+        java {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
+
+        tasks.withType<JavaCompile> {
+            options.encoding = "UTF-8"
+        }
+
+        // Use Junit5's test runner.
+        tasks.withType<Test> {
+            useJUnitPlatform()
+        }
+
+        // Apply junit 5 and hamcrest test dependencies to all java projects.
+        dependencies {
+            testCompile("org.junit.jupiter:junit-jupiter-api:5.4.0")
+            testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")
+            testCompile("org.junit.jupiter:junit-jupiter-params:5.4.0")
+            testCompile("org.hamcrest:hamcrest:2.1")
+        }
+
+        // Reusable license copySpec
+        val licenseSpec = copySpec {
+            from("${project.rootDir}/LICENSE")
+            from("${project.rootDir}/NOTICE")
+        }
+
+        // Set up tasks that build source and javadoc jars.
+        tasks.register<Jar>("sourcesJar") {
+            metaInf.with(licenseSpec)
+            from(sourceSets.main.get().allJava)
+            archiveClassifier.set("sources")
+        }
+
+        tasks.register<Jar>("javadocJar") {
+            metaInf.with(licenseSpec)
+            from(tasks.javadoc)
+            archiveClassifier.set("javadoc")
+        }
+
+        // Configure jars to include license related info
+        tasks.jar {
+            metaInf.with(licenseSpec)
+            inputs.property("moduleName", subproject.extra["moduleName"])
+            manifest {
+                attributes["Automatic-Module-Name"] = subproject.extra["moduleName"]
+            }
+        }
+
+        // Always run javadoc after build.
+        tasks["build"].finalizedBy(tasks["javadoc"])
+
+        /*
+         * Maven
+         * ====================================================
+         */
+        apply(plugin = "maven-publish")
+        apply(plugin = "signing")
+
+        repositories {
+            mavenLocal()
+            mavenCentral()
+        }
+
+        publishing {
+            repositories {
+                mavenCentral {
+                    url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                    credentials {
+                        username = sonatypeUser
+                        password = sonatypePassword
+                    }
+                }
+            }
+
+            publications {
+                create<MavenPublication>("mavenJava") {
+                    from(components["java"])
+
+                    // Ship the source and javadoc jars.
+                    artifact(tasks["sourcesJar"])
+                    artifact(tasks["javadocJar"])
+
+                    // Include extra information in the POMs.
+                    afterEvaluate {
+                        pom {
+                            name.set(subproject.extra["displayName"].toString())
+                            description.set(subproject.description)
+                            url.set("https://github.com/aws/aws-sdk-js-v3.git")
+                            licenses {
+                                license {
+                                    name.set("Apache License 2.0")
+                                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                                    distribution.set("repo")
+                                }
+                            }
+                            developers {
+                                developer {
+                                    id.set("smithy")
+                                    name.set("Smithy")
+                                    organization.set("Amazon Web Services")
+                                    organizationUrl.set("https://aws.amazon.com")
+                                    roles.add("developer")
+                                }
+                            }
+                            scm {
+                                url.set("https://github.com/aws/aws-sdk-js-v3.git")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Don't sign the artifacts if we didn't get a key and password to use.
+        val signingKey: String? by project
+        val signingPassword: String? by project
+        if (signingKey != null && signingPassword != null) {
+            signing {
+                useInMemoryPgpKeys(signingKey, signingPassword)
+                sign(publishing.publications["mavenJava"])
+            }
+        }
+
+        /*
+         * CheckStyle
+         * ====================================================
+         */
+        apply(plugin = "checkstyle")
+
+        tasks["checkstyleTest"].enabled = false
+
+        /*
+         * Tests
+         * ====================================================
+         *
+         * Configure the running of tests.
+         */
+        // Log on passed, skipped, and failed test events if the `-Plog-tests` property is set.
+        if (project.hasProperty("log-tests")) {
+            tasks.test {
+                testLogging.events("passed", "skipped", "failed")
+            }
+        }
+
+        /*
+         * Code coverage
+         * ====================================================
+         */
+        apply(plugin = "jacoco")
+
+        // Always run the jacoco test report after testing.
+        tasks["test"].finalizedBy(tasks["jacocoTestReport"])
+
+        // Configure jacoco to generate an HTML report.
+        tasks.jacocoTestReport {
+            reports {
+                xml.isEnabled = false
+                csv.isEnabled = false
+                html.destination = file("$buildDir/reports/jacoco")
+            }
+        }
+
+        /*
+         * Spotbugs
+         * ====================================================
+         */
+        apply(plugin = "com.github.spotbugs")
+
+        // We don't need to lint tests.
+        tasks["spotbugsTest"].enabled = false
+
+
+        // Log on passed, skipped, and failed test events if the `-Plog-tests` property is set.
+        if (project.hasProperty("log-tests")) {
+            tasks.test {
+                testLogging.events("passed", "skipped", "failed")
+            }
+        }
+
+        // Configure the bug filter for spotbugs.
+        spotbugs {
+            setEffort("max")
+            val excludeFile = File("${project.rootDir}/config/spotbugs/filter.xml")
+            if (excludeFile.exists()) {
+                excludeFilter.set(excludeFile)
+            }
+        }
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -13,68 +13,13 @@
  * permissions and limitations under the License.
  */
 
-plugins {
-    `java-library`
-    checkstyle
-    jacoco
-    id("com.github.spotbugs") version "4.6.0"
-}
-
-group = "software.amazon.smithy"
-version = "0.3.0"
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
+description = "Generates TypeScript code for AWS protocols from Smithy models"
+extra["displayName"] = "Smithy :: AWS :: Typescript :: Codegen"
+extra["moduleName"] = "software.amazon.smithy.aws.typescript.codegen"
 
 dependencies {
     api("software.amazon.smithy:smithy-aws-traits:[1.5.0, 2.0[")
     api("software.amazon.smithy:smithy-waiters:[1.5.0, 2.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.5.0, 2.0[")
     api("software.amazon.smithy:smithy-typescript-codegen:0.3.0")
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompile("org.junit.jupiter:junit-jupiter-params:5.4.0")
-    testCompile("org.hamcrest:hamcrest:2.1")
-}
-
-// == CheckStyle ==
-tasks["checkstyleTest"].enabled = false
-
-// == Code coverage ==
-// Always run the jacoco test report after testing.
-tasks["test"].finalizedBy(tasks["jacocoTestReport"])
-
-// Configure jacoco to generate an HTML report.
-tasks.withType<JacocoReport> {
-    reports {
-        xml.isEnabled = false
-        csv.isEnabled = false
-        html.destination = file("$buildDir/reports/jacoco")
-    }
-}
-
-// == Spotbugs ==
-// We don't need to lint tests.
-tasks["spotbugsTest"].enabled = false
-
-// Log on passed, skipped, and failed test events if the `-Plog-tests` property is set.
-if (project.hasProperty("log-tests")) {
-    tasks.test {
-        testLogging.events("passed", "skipped", "failed")
-    }
-}
-
-// Configure the bug filter for spotbugs.
-spotbugs {
-    setEffort("max")
-    val excludeFile = File("${project.rootDir}/config/spotbugs/filter.xml")
-    if (excludeFile.exists()) {
-        excludeFilter.set(excludeFile)
-    }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestJson1.java
@@ -21,7 +21,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 /**
  * Handles generating the aws.rest-json-1 protocol for services.
  *
- * @inheritDoc
+ * {@inheritDoc}
  *
  * @see RestJsonProtocolGenerator
  */


### PR DESCRIPTION
### Issue #
n/a

### Description
This updates the gradle build scripts to allow for publishing of the AWS protocol generators. Most of the java stuff had to be pulled up to the root since the maven plugin requires it to be there, but the actual contents haven't changed aside from javadoc getting run.

### Testing
Ran a clean build that succeeded.

### Additional context
This isn't actually forcing you to publish to maven, just making it possible. In the short term it enables publishing to maven local so that somebody could run the AWS generators outside of this repo if the locally published the generator first.

The license copy is there because we need one under the java project root to be included in the built jar

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.