### PR TITLE
docs(readme): use generic yarn install URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Make sure you have [`yarn`](https://yarnpkg.com/en/) installed by:
 yarn --version
 ```
 
-If not, please refer to [yarn installation](https://yarnpkg.com/en/docs/install#mac-stable) to install `yarn`.
+If not, please refer to [yarn installation](https://yarnpkg.com/en/docs/install) to install `yarn`.
 
 To install the dependencies and link the library, run the following command:
 


### PR DESCRIPTION
### Issue #
N/A

### Description
Just a simple URL adjustment to remove the macos route.

### Testing
N/A - only readme changed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.