### PR TITLE
fix(util-dynamodb): state options.wrapNumbers on BigInt error in unmarshall

### DIFF
--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -86,6 +86,14 @@ describe("convertToNative", () => {
         );
       });
     });
+
+    [`${Number.MAX_SAFE_INTEGER + 2}.1`, `${Number.MIN_SAFE_INTEGER - 2}.1`].forEach((numString) => {
+      it(`throws if number cannot be converted into BigInt: ${numString}`, () => {
+        expect(() => {
+          convertToNative({ N: numString });
+        }).toThrowError(`${numString} can't be converted to BigInt. Set options.wrapNumbers to get string value.`);
+      });
+    });
   });
 
   describe("binary", () => {

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -50,7 +50,11 @@ const convertNumber = (numString: string, options?: unmarshallOptions): number |
   const infinityValues = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
   if ((num > Number.MAX_SAFE_INTEGER || num < Number.MIN_SAFE_INTEGER) && !infinityValues.includes(num)) {
     if (typeof BigInt === "function") {
-      return BigInt(numString);
+      try {
+        return BigInt(numString);
+      } catch (error) {
+        throw new Error(`${numString} can't be converted to BigInt. Set options.wrapNumbers to get string value.`);
+      }
     } else {
       throw new Error(`${numString} is outside SAFE_INTEGER bounds. Set options.wrapNumbers to get string value.`);
     }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2014

### Description
Error states `options.wrapNumbers` when BigInt throws in unmarshall

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.