### PR TITLE
fix(util-dynamodb): unmarshall small numbers or those in scientific notation

### DIFF
--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -72,18 +72,15 @@ describe("convertToNative", () => {
         });
       });
 
-    [
-      `${Number.MAX_SAFE_INTEGER}.1`,
-      `${Number.MIN_SAFE_INTEGER}.1`,
-      `${Number.MIN_VALUE}1`,
-      `-${Number.MIN_VALUE}1`,
-    ].forEach((numString) => {
-      it(`throws if number is outside IEEE 754 Floating-Point Arithmetic: ${numString}`, () => {
-        expect(() => {
-          convertToNative({ N: numString });
-        }).toThrowError(
-          `Value ${numString} is outside IEEE 754 Floating-Point Arithmetic. Set options.wrapNumbers to get string value.`
-        );
+    [`0.0000001`, `0.0000000001`, `0.00000000000000000001`].forEach((numString) => {
+      it(`returns for small numbers: ${numString}`, () => {
+        expect(convertToNative({ N: numString })).toEqual(Number(numString));
+      });
+    });
+
+    [`1e-7`, `1e-20`, `1e15`].forEach((numString) => {
+      it(`returns numbers stored in scientific notation: ${numString}`, () => {
+        expect(convertToNative({ N: numString })).toEqual(Number(numString));
       });
     });
 

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -58,10 +58,6 @@ const convertNumber = (numString: string, options?: unmarshallOptions): number |
     } else {
       throw new Error(`${numString} is outside SAFE_INTEGER bounds. Set options.wrapNumbers to get string value.`);
     }
-  } else if (num.toString() !== numString) {
-    throw new Error(
-      `Value ${numString} is outside IEEE 754 Floating-Point Arithmetic. Set options.wrapNumbers to get string value.`
-    );
   }
   return num;
 };


### PR DESCRIPTION
### Issue #
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1983

### Description
supports unmarshalling small numbers or those using scientific notation

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.