### PR TITLE
docs(clients): mark apiVersion as @internal

### DIFF
--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -4,6 +4,7 @@ import { Client as IClient, Command, MetadataBearer, RequestHandler } from "@aws
 export interface SmithyConfiguration<HandlerOptions> {
   requestHandler: RequestHandler<any, any, HandlerOptions>;
   /**
+   * The API version set internally by the SDK.
    * @internal
    */
   readonly apiVersion: string;

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -3,6 +3,9 @@ import { Client as IClient, Command, MetadataBearer, RequestHandler } from "@aws
 
 export interface SmithyConfiguration<HandlerOptions> {
   requestHandler: RequestHandler<any, any, HandlerOptions>;
+  /**
+   * @internal
+   */
   readonly apiVersion: string;
 }
 

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -4,7 +4,8 @@ import { Client as IClient, Command, MetadataBearer, RequestHandler } from "@aws
 export interface SmithyConfiguration<HandlerOptions> {
   requestHandler: RequestHandler<any, any, HandlerOptions>;
   /**
-   * The API version set internally by the SDK.
+   * The API version set internally by the SDK, and is
+   * not planned to be used by customer code.
    * @internal
    */
   readonly apiVersion: string;


### PR DESCRIPTION
### Issue #
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1869
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1986

### Description
marks `apiVersion` configuration as internal, and explicitly calls out that it is not to be used by customer code.

### Testing

Tested by verifying that VSCode shows the message in Intellisense.
<details>
<summary>Screenshot</summary>

![Screen Shot 2021-02-10 at 4 56 24 PM](https://user-images.githubusercontent.com/16024985/107592298-7b836180-6bc1-11eb-8b55-19f76ccf162b.png)

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.