### PR TITLE
fix(node-http-handler)!: set maxSockets=50 by default

### DIFF
--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -18,15 +18,19 @@ import {
 describe("NodeHttpHandler", () => {
   describe("constructor", () => {
     it("can set httpAgent and httpsAgent", () => {
+      let keepAlive = false;
       let maxSockets = Math.round(Math.random() * 50) + 1;
       let nodeHttpHandler = new NodeHttpHandler({
-        httpAgent: new http.Agent({ maxSockets }),
+        httpAgent: new http.Agent({ keepAlive, maxSockets }),
       });
+      expect((nodeHttpHandler as any).httpAgent.keepAlive).toEqual(keepAlive);
       expect((nodeHttpHandler as any).httpAgent.maxSockets).toEqual(maxSockets);
+      keepAlive = true;
       maxSockets = Math.round(Math.random() * 50) + 1;
       nodeHttpHandler = new NodeHttpHandler({
-        httpsAgent: new https.Agent({ maxSockets }),
+        httpsAgent: new https.Agent({ keepAlive, maxSockets }),
       });
+      expect((nodeHttpHandler as any).httpsAgent.keepAlive).toEqual(keepAlive);
       expect((nodeHttpHandler as any).httpsAgent.maxSockets).toEqual(maxSockets);
     });
   });

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -17,9 +17,14 @@ import {
 
 describe("NodeHttpHandler", () => {
   describe("constructor", () => {
-    it("sets keepAlive to true by default", () => {
+    it("sets keepAlive=true by default", () => {
       const nodeHttpHandler = new NodeHttpHandler();
       expect((nodeHttpHandler as any).httpAgent.keepAlive).toEqual(true);
+    });
+
+    it("sets maxSockets=50 by default", () => {
+      const nodeHttpHandler = new NodeHttpHandler();
+      expect((nodeHttpHandler as any).httpAgent.maxSockets).toEqual(50);
     });
 
     it("can set httpAgent and httpsAgent", () => {

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -17,6 +17,11 @@ import {
 
 describe("NodeHttpHandler", () => {
   describe("constructor", () => {
+    it("sets keepAlive to true by default", () => {
+      const nodeHttpHandler = new NodeHttpHandler();
+      expect((nodeHttpHandler as any).httpAgent.keepAlive).toEqual(true);
+    });
+
     it("can set httpAgent and httpsAgent", () => {
       let keepAlive = false;
       let maxSockets = Math.round(Math.random() * 50) + 1;

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -42,8 +42,9 @@ export class NodeHttpHandler implements HttpHandler {
     this.connectionTimeout = connectionTimeout;
     this.socketTimeout = socketTimeout;
     const keepAlive = true;
-    this.httpAgent = httpAgent || new hAgent({ keepAlive });
-    this.httpsAgent = httpsAgent || new hsAgent({ keepAlive });
+    const maxSockets = 50;
+    this.httpAgent = httpAgent || new hAgent({ keepAlive, maxSockets });
+    this.httpsAgent = httpsAgent || new hsAgent({ keepAlive, maxSockets });
   }
 
   destroy(): void {


### PR DESCRIPTION
### Issue #
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1959

### Description
set maxSockets=50 by default in node-http-handler

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.