### PR TITLE
fix(lib-storage): fix typo in Upload.intialize (initialize)

### DIFF
--- a/lib/storage/src/upload/Upload.ts
+++ b/lib/storage/src/upload/Upload.ts
@@ -62,7 +62,7 @@ export class Upload extends EventEmitter {
    */
   async done(): Promise<ServiceOutputTypes> {
     try {
-      await this.uploader.intialize();
+      await this.uploader.initialize();
       await this.uploader.upload();
       const result = await this.uploader.complete();
       return result;

--- a/lib/storage/src/upload/service-clients/Uploader.ts
+++ b/lib/storage/src/upload/service-clients/Uploader.ts
@@ -47,7 +47,7 @@ export abstract class Uploader extends EventEmitter {
   abstract _completeMultipartUpload(command: CompleteMultipartUploadRequest): Promise<ServiceOutputTypes>;
   abstract _abortUpload(command: AbortMultipartUploadRequest): Promise<ServiceOutputTypes>;
 
-  /** @deprecated */
+  /** @deprecated Use `initialize` instead. */
   async intialize() {
     return this.initialize();
   }

--- a/lib/storage/src/upload/service-clients/Uploader.ts
+++ b/lib/storage/src/upload/service-clients/Uploader.ts
@@ -47,7 +47,12 @@ export abstract class Uploader extends EventEmitter {
   abstract _completeMultipartUpload(command: CompleteMultipartUploadRequest): Promise<ServiceOutputTypes>;
   abstract _abortUpload(command: AbortMultipartUploadRequest): Promise<ServiceOutputTypes>;
 
+  /** @deprecated */
   async intialize() {
+    return this.initialize();
+  }
+
+  async initialize() {
     const intializeCommand = {
       Bucket: this.destination.Bucket,
       Key: this.destination.Key,


### PR DESCRIPTION
Keep the old name for now?

The name was introduced in b07e71986817d7781e12d9b687532c58d5ea6ba0
when the file was added

### Issue #


### Description
Fix typo in a method name

### Testing
TODO

### Additional context

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.