### PR TITLE
feat(client-sso*): remove auth dependencies if client doesn't need

### DIFF
--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -22,7 +22,6 @@ import {
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
-import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
 import {
   UserAgentInputConfig,
   UserAgentResolvedConfig,
@@ -160,7 +159,6 @@ export type SSOOIDCClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
-  AwsAuthInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
   UserAgentInputConfig;
@@ -169,7 +167,6 @@ export type SSOOIDCClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
-  AwsAuthResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   UserAgentResolvedConfig;
@@ -209,12 +206,11 @@ export class SSOOIDCClient extends __Client<
     };
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
-    let _config_3 = resolveAwsAuthConfig(_config_2);
-    let _config_4 = resolveRetryConfig(_config_3);
-    let _config_5 = resolveHostHeaderConfig(_config_4);
-    let _config_6 = resolveUserAgentConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_3 = resolveRetryConfig(_config_2);
+    let _config_4 = resolveHostHeaderConfig(_config_3);
+    let _config_5 = resolveUserAgentConfig(_config_4);
+    super(_config_5);
+    this.config = _config_5;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -39,7 +39,6 @@
     "@aws-sdk/middleware-logger": "3.5.0",
     "@aws-sdk/middleware-retry": "3.5.0",
     "@aws-sdk/middleware-serde": "3.4.1",
-    "@aws-sdk/middleware-signing": "3.5.0",
     "@aws-sdk/middleware-stack": "3.4.1",
     "@aws-sdk/middleware-user-agent": "3.5.0",
     "@aws-sdk/node-config-provider": "3.4.1",

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -20,7 +20,6 @@ import {
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
-import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
 import {
   UserAgentInputConfig,
   UserAgentResolvedConfig,
@@ -160,7 +159,6 @@ export type SSOClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
-  AwsAuthInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
   UserAgentInputConfig;
@@ -169,7 +167,6 @@ export type SSOClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
-  AwsAuthResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   UserAgentResolvedConfig;
@@ -207,12 +204,11 @@ export class SSOClient extends __Client<
     };
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
-    let _config_3 = resolveAwsAuthConfig(_config_2);
-    let _config_4 = resolveRetryConfig(_config_3);
-    let _config_5 = resolveHostHeaderConfig(_config_4);
-    let _config_6 = resolveUserAgentConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_3 = resolveRetryConfig(_config_2);
+    let _config_4 = resolveHostHeaderConfig(_config_3);
+    let _config_5 = resolveUserAgentConfig(_config_4);
+    super(_config_5);
+    this.config = _config_5;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -39,7 +39,6 @@
     "@aws-sdk/middleware-logger": "3.5.0",
     "@aws-sdk/middleware-retry": "3.5.0",
     "@aws-sdk/middleware-serde": "3.4.1",
-    "@aws-sdk/middleware-signing": "3.5.0",
     "@aws-sdk/middleware-stack": "3.4.1",
     "@aws-sdk/middleware-user-agent": "3.5.0",
     "@aws-sdk/node-config-provider": "3.4.1",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -54,6 +54,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_CONFIG)
+                        .servicePredicate((m, s) -> !isAllOptionalAuthOperation(m, s))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
@@ -174,5 +175,16 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
             }
         }
         return false;
+    }
+
+    private static boolean isAllOptionalAuthOperation(Model model, ServiceShape service) {
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
+        for (OperationShape operation : operations) {
+            if (!operation.getTrait(OptionalAuthTrait.class).isPresent()) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
### Description
Now the client still imports signing dependencies if ALL of the operations has `optionalAuth` trait. The change remove all auth dependencies if non of the operations requires signing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.