### PR TITLE
fix(clients): remove unsupported CORS retry headers in new services

### DIFF
--- a/clients/client-appintegrations/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/AppIntegrationsClient.ts
@@ -45,7 +45,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -248,6 +254,7 @@ export class AppIntegrationsClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-auditmanager/AuditManagerClient.ts
+++ b/clients/client-auditmanager/AuditManagerClient.ts
@@ -150,7 +150,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -464,6 +470,7 @@ export class AuditManagerClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-connect-contact-lens/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/ConnectContactLensClient.ts
@@ -19,7 +19,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -207,6 +213,7 @@ export class ConnectContactLensClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-customer-profiles/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/CustomerProfilesClient.ts
@@ -70,7 +70,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -317,6 +323,7 @@ export class CustomerProfilesClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-devops-guru/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/DevOpsGuruClient.ts
@@ -69,7 +69,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -284,6 +290,7 @@ export class DevOpsGuruClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
@@ -64,7 +64,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
+import {
+  RetryInputConfig,
+  RetryResolvedConfig,
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig,
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -284,6 +290,7 @@ export class ServiceCatalogAppRegistryClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -30,9 +30,9 @@ import software.amazon.smithy.utils.SetUtils;
 
 public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
     private static final Set<String> SERVICE_IDS = SetUtils.of(
-        "ConnectParticipant",
-        "IoT Data Plane",
-        "IoT",
+        "ConnectParticipant", // P43593766
+        "IoT Data Plane", // P40355845
+        "IoT", // P39759657
         "Kinesis Video Signaling"
     );
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -33,7 +33,14 @@ public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
         "ConnectParticipant", // P43593766
         "IoT Data Plane", // P40355845
         "IoT", // P39759657
-        "Kinesis Video Signaling"
+        "Kinesis Video Signaling",
+        "AppFlow",
+        "AppIntegrations",
+        "AuditManager",
+        "Connect Contact Lens",
+        "Customer Profiles",
+        "DevOps Guru",
+        "Service Catalog AppRegistry"
     );
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -34,13 +34,13 @@ public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
         "IoT Data Plane", // P40355845
         "IoT", // P39759657
         "Kinesis Video Signaling",
-        "AppFlow",
-        "AppIntegrations",
-        "AuditManager",
-        "Connect Contact Lens",
-        "Customer Profiles",
-        "DevOps Guru",
-        "Service Catalog AppRegistry"
+        "AppFlow", // P44424582
+        "AppIntegrations", // P44426207
+        "AuditManager", // P44428767
+        "Connect Contact Lens", // P44429036
+        "Customer Profiles", // P44430824
+        "DevOps Guru", // P44429743
+        "Service Catalog AppRegistry" // P44430229
     );
 
     @Override


### PR DESCRIPTION
### Issue #
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2038

### Description
Remove unsupported CORS retry headers in new services

### Testing
* Removal of CORS retry headers is already tested with existing services.
* Lack of support for CORS retry headers was found using latest update in report at https://github.com/AllanZhengYP/cors-test/blob/master/output.md

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.