### PR TITLE
fix(deps): add @aws-sdk/middleware-sdk-rds in DocDB and Neptune

### DIFF
--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -38,6 +38,7 @@
     "@aws-sdk/middleware-host-header": "3.5.0",
     "@aws-sdk/middleware-logger": "3.5.0",
     "@aws-sdk/middleware-retry": "3.5.0",
+    "@aws-sdk/middleware-sdk-rds": "3.5.0",
     "@aws-sdk/middleware-serde": "3.4.1",
     "@aws-sdk/middleware-signing": "3.5.0",
     "@aws-sdk/middleware-stack": "3.4.1",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -38,6 +38,7 @@
     "@aws-sdk/middleware-host-header": "3.5.0",
     "@aws-sdk/middleware-logger": "3.5.0",
     "@aws-sdk/middleware-retry": "3.5.0",
+    "@aws-sdk/middleware-sdk-rds": "3.5.0",
     "@aws-sdk/middleware-serde": "3.4.1",
     "@aws-sdk/middleware-signing": "3.5.0",
     "@aws-sdk/middleware-stack": "3.4.1",


### PR DESCRIPTION
### Issue
Missed in https://github.com/aws/aws-sdk-js-v3/pull/1985, probably because of dependency on intermediate PR.

### Description
add @aws-sdk/middleware-sdk-rds dependency in DocDB and Neptune

### Testing
CI

### Additional context
Backlog issue for CI to catch such lack of dependency https://github.com/aws/aws-sdk-js-v3/issues/817

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.