### PR TITLE
fix(middleware-sdk-ec2): add undeclared dependency @aws-sdk/protocol-http

### DIFF
--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/types": "3.4.1",
     "@aws-sdk/util-format-url": "3.4.1",
     "@aws-sdk/util-uri-escape": "3.4.1",
+    "@aws-sdk/protocol-http": "3.5.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue #
<none>

### Description
There is an undeclared dependency on `@aws-sdk/protocol-http` in https://github.com/blake-transcend/aws-sdk-js-v3/blob/patch-2/packages/middleware-sdk-ec2/src/index.ts#L1. This adds the dependency to the package.json file

### Testing
tested locally

### Additional context
<none>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.