### PR TITLE
fix(credential-provider-ini): refactor provider options interfaces

### DIFF
--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -111,8 +111,10 @@ const isAssumeRoleProfile = (arg: any): arg is AssumeRoleProfile =>
  * Creates a credential provider that will read from ini files and supports
  * role assumption and multi-factor authentication.
  */
-export const fromIni = (init: FromIniInit = {}): CredentialProvider => () =>
-  parseKnownFiles(init).then((profiles) => resolveProfileData(getMasterProfileName(init), profiles, init));
+export const fromIni = (init: FromIniInit = {}): CredentialProvider => async () => {
+  const profiles = await parseKnownFiles(init);
+  return resolveProfileData(getMasterProfileName(init), profiles, init);
+};
 
 /**
  * Load profiles from credentials and config INI files and normalize them into a
@@ -123,13 +125,11 @@ export const fromIni = (init: FromIniInit = {}): CredentialProvider => () =>
 export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
   const { loadedConfig = loadSharedConfigFiles(init) } = init;
 
-  return loadedConfig.then((parsedFiles) => {
-    const { configFile, credentialsFile } = parsedFiles;
-    return {
-      ...configFile,
-      ...credentialsFile,
-    };
-  });
+  const parsedFiles = await loadedConfig;
+  return {
+    ...parsedFiles.configFile,
+    ...parsedFiles.credentialsFile,
+  };
 };
 
 /**

--- a/packages/credential-provider-process/src/index.ts
+++ b/packages/credential-provider-process/src/index.ts
@@ -15,10 +15,12 @@ export interface FromProcessInit extends SourceProfileInit {}
  * Creates a credential provider that will read from a credential_process specified
  * in ini files.
  */
-export const fromProcess = (init: FromProcessInit = {}): CredentialProvider => () =>
-  parseKnownFiles(init).then((profiles) => resolveProcessCredentials(getMasterProfileName(init), profiles));
+export const fromProcess = (init: FromProcessInit = {}): CredentialProvider => async () => {
+  const profiles = await parseKnownFiles(init);
+  return resolveProcessCredentials(getMasterProfileName(init), profiles);
+};
 
-async function resolveProcessCredentials(profileName: string, profiles: ParsedIniData): Promise<Credentials> {
+const resolveProcessCredentials = async (profileName: string, profiles: ParsedIniData): Promise<Credentials> => {
   const profile = profiles[profileName];
 
   if (profiles[profileName]) {
@@ -80,7 +82,7 @@ async function resolveProcessCredentials(profileName: string, profiles: ParsedIn
     // a parameter, anenvironment variable, or another profile's `source_profile` key).
     throw new ProviderError(`Profile ${profileName} could not be found in shared credentials file.`);
   }
-}
+};
 
 const execPromise = (command: string) =>
   new Promise(function (resolve, reject) {

--- a/packages/credential-provider-process/src/index.ts
+++ b/packages/credential-provider-process/src/index.ts
@@ -1,6 +1,6 @@
-import { getMasterProfileName, parseKnownFiles } from "@aws-sdk/credential-provider-ini";
+import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/credential-provider-ini";
 import { ProviderError } from "@aws-sdk/property-provider";
-import { ParsedIniData, SharedConfigFiles, SharedConfigInit } from "@aws-sdk/shared-ini-file-loader";
+import { ParsedIniData } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { exec } from "child_process";
 
@@ -9,36 +9,16 @@ import { exec } from "child_process";
  */
 export const ENV_PROFILE = "AWS_PROFILE";
 
-export interface FromProcessInit extends SharedConfigInit {
-  /**
-   * The configuration profile to use.
-   */
-  profile?: string;
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
-}
+export interface FromProcessInit extends SourceProfileInit {}
 
 /**
  * Creates a credential provider that will read from a credential_process specified
  * in ini files.
  */
-export function fromProcess(init: FromProcessInit = {}): CredentialProvider {
-  return () =>
-    parseKnownFiles(init).then((profiles) => resolveProcessCredentials(getMasterProfileName(init), profiles, init));
-}
+export const fromProcess = (init: FromProcessInit = {}): CredentialProvider => () =>
+  parseKnownFiles(init).then((profiles) => resolveProcessCredentials(getMasterProfileName(init), profiles));
 
-async function resolveProcessCredentials(
-  profileName: string,
-  profiles: ParsedIniData,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  options: FromProcessInit
-): Promise<Credentials> {
+async function resolveProcessCredentials(profileName: string, profiles: ParsedIniData): Promise<Credentials> {
   const profile = profiles[profileName];
 
   if (profiles[profileName]) {
@@ -102,8 +82,8 @@ async function resolveProcessCredentials(
   }
 }
 
-function execPromise(command: string) {
-  return new Promise(function (resolve, reject) {
+const execPromise = (command: string) =>
+  new Promise(function (resolve, reject) {
     exec(command, (error, stdout) => {
       if (error) {
         reject(error);
@@ -113,4 +93,3 @@ function execPromise(command: string) {
       resolve(stdout.trim());
     });
   });
-}


### PR DESCRIPTION
### Description
This change adds a  `SourceProfileInit` option interface for credential providers that consumes shared INI file but doesn't need to assume roles. As a result, the `ProcessCredential` only need to use `SourceProfileInit` rather than create its own interface. This change also makes traditional functions to arrow function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
