### PR TITLE
chore(protocol_tests): regenerate protocol test clients

### DIFF
--- a/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
+++ b/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
@@ -176,7 +176,7 @@ it("Ec2QueryEmptyInputAndEmptyOutput:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=EmptyInputAndEmptyOutput
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -449,7 +449,7 @@ it("Ec2NestedStructures:Request", async () => {
     &Nested.StringArg=foo
     &Nested.OtherArg=true
     &Nested.RecursiveArg.StringArg=baz`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -483,7 +483,7 @@ it("Ec2QueryNoInputAndOutput:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=NoInputAndOutput
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -553,7 +553,7 @@ it("Ec2ProtocolIdempotencyTokenAutoFill:Request", async () => {
     const bodyString = `Action=QueryIdempotencyTokenAutoFill
     &Version=2020-01-08
     &Token=00000000-0000-4000-8000-000000000000`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -591,7 +591,7 @@ it("Ec2ProtocolIdempotencyTokenAutoFillIsSet:Request", async () => {
     const bodyString = `Action=QueryIdempotencyTokenAutoFill
     &Version=2020-01-08
     &Token=00000000-0000-4000-8000-000000000123`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -642,7 +642,7 @@ it("Ec2Lists:Request", async () => {
     &ListArg.3=baz
     &ComplexListArg.1.Hi=hello
     &ComplexListArg.2.Hi=hola`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -678,7 +678,7 @@ it("Ec2EmptyQueryLists:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=QueryLists
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -716,7 +716,7 @@ it("Ec2ListArgWithXmlNameMember:Request", async () => {
     &Version=2020-01-08
     &ListArgWithXmlNameMember.1=A
     &ListArgWithXmlNameMember.2=B`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -754,7 +754,7 @@ it("Ec2ListMemberWithXmlName:Request", async () => {
     &Version=2020-01-08
     &Hi.1=A
     &Hi.2=B`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -798,7 +798,7 @@ it("Ec2TimestampsInput:Request", async () => {
     &NormalFormat=2015-01-25T08%3A00%3A00Z
     &EpochMember=1422172800
     &EpochTarget=1422172800`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -906,7 +906,7 @@ it("Ec2SimpleInputParamsStrings:Request", async () => {
     &Version=2020-01-08
     &Foo=val1
     &Bar=val2`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -947,7 +947,7 @@ it("Ec2SimpleInputParamsStringAndBooleanTrue:Request", async () => {
     &Version=2020-01-08
     &Foo=val1
     &Baz=true`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -985,7 +985,7 @@ it("Ec2SimpleInputParamsStringsAndBooleanFalse:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Baz=false`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1023,7 +1023,7 @@ it("Ec2SimpleInputParamsInteger:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Bam=10`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1061,7 +1061,7 @@ it("Ec2SimpleInputParamsFloat:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Boo=10.8`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1099,7 +1099,7 @@ it("Ec2SimpleInputParamsBlob:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Qux=dmFsdWU%3D`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1137,7 +1137,7 @@ it("Ec2Enums:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &FooEnum=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1175,7 +1175,7 @@ it("Ec2Query:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &A=Hi`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1213,7 +1213,7 @@ it("Ec2QueryIsPreferred:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &B=Hi`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1251,7 +1251,7 @@ it("Ec2XmlNameIsUppercased:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &C=Hi`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1932,7 +1932,7 @@ it("Ec2XmlTimestampsWithHttpDateFormat:Response", async () => {
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentFormUrlencodedBodies = (expectedBody: string, generatedBody: string): Object => {
   const fromEntries = (components: string[][]): { [key: string]: string } => {
     const parts: { [key: string]: string } = {};
 

--- a/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
+++ b/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
@@ -722,7 +722,7 @@ it("AwsJson11Enums:Request", async () => {
             \"zero\": \"0\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -833,7 +833,7 @@ it("AwsJson11SerializeStringUnionValue:Request", async () => {
             \"stringValue\": \"foo\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -876,7 +876,7 @@ it("AwsJson11SerializeBooleanUnionValue:Request", async () => {
             \"booleanValue\": true
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -919,7 +919,7 @@ it("AwsJson11SerializeNumberUnionValue:Request", async () => {
             \"numberValue\": 1
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -962,7 +962,7 @@ it("AwsJson11SerializeBlobUnionValue:Request", async () => {
             \"blobValue\": \"Zm9v\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1005,7 +1005,7 @@ it("AwsJson11SerializeTimestampUnionValue:Request", async () => {
             \"timestampValue\": 1398796238
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1048,7 +1048,7 @@ it("AwsJson11SerializeEnumUnionValue:Request", async () => {
             \"enumValue\": \"Foo\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1091,7 +1091,7 @@ it("AwsJson11SerializeListUnionValue:Request", async () => {
             \"listValue\": [\"foo\", \"bar\"]
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1141,7 +1141,7 @@ it("AwsJson11SerializeMapUnionValue:Request", async () => {
             }
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1188,7 +1188,7 @@ it("AwsJson11SerializeStructureUnionValue:Request", async () => {
             }
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1631,7 +1631,7 @@ it("serializes_string_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"String\":\"abc xyz\"}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1668,7 +1668,7 @@ it("serializes_string_shapes_with_jsonvalue_trait:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"JsonValue\":\"{\\"string\\":\\"value\\",\\"number\\":1234.5,\\"boolTrue\\":true,\\"boolFalse\\":false,\\"array\\":[1,2,3,4],\\"object\\":{\\"key\\":\\"value\\"},\\"null\\":null}\"}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1704,7 +1704,7 @@ it("serializes_integer_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Integer\":1234}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1740,7 +1740,7 @@ it("serializes_long_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Long\":999999999999}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1776,7 +1776,7 @@ it("serializes_float_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Float\":1234.5}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1812,7 +1812,7 @@ it("serializes_double_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Double\":1234.5}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1848,7 +1848,7 @@ it("serializes_blob_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Blob\":\"YmluYXJ5LXZhbHVl\"}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1884,7 +1884,7 @@ it("serializes_boolean_shapes_true:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Boolean\":true}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1920,7 +1920,7 @@ it("serializes_boolean_shapes_false:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Boolean\":false}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1956,7 +1956,7 @@ it("serializes_timestamp_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Timestamp\":946845296}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1992,7 +1992,7 @@ it("serializes_timestamp_shapes_with_iso8601_timestampformat:Request", async () 
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Iso8601Timestamp\":\"2000-01-02T20:34:56Z\"}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2028,7 +2028,7 @@ it("serializes_timestamp_shapes_with_httpdate_timestampformat:Request", async ()
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"HttpdateTimestamp\":\"Sun, 02 Jan 2000 20:34:56 GMT\"}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2064,7 +2064,7 @@ it("serializes_timestamp_shapes_with_unixtimestamp_timestampformat:Request", asy
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"UnixTimestamp\":946845296}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2100,7 +2100,7 @@ it("serializes_list_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"ListOfStrings\":[\"abc\",\"mno\",\"xyz\"]}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2136,7 +2136,7 @@ it("serializes_empty_list_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"ListOfStrings\":[]}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2184,7 +2184,7 @@ it("serializes_list_of_map_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"ListOfMapsOfStrings\":[{\"foo\":\"bar\"},{\"abc\":\"xyz\"},{\"red\":\"blue\"}]}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2232,7 +2232,7 @@ it("serializes_list_of_structure_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"ListOfStructs\":[{\"Value\":\"abc\"},{\"Value\":\"mno\"},{\"Value\":\"xyz\"}]}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2280,7 +2280,7 @@ it("serializes_list_of_recursive_structure_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"RecursiveList\":[{\"RecursiveList\":[{\"RecursiveList\":[{\"Integer\":123}]}]}]}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2320,7 +2320,7 @@ it("serializes_map_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"MapOfStrings\":{\"abc\":\"xyz\",\"mno\":\"hjk\"}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2356,7 +2356,7 @@ it("serializes_empty_map_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"MapOfStrings\":{}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2396,7 +2396,7 @@ it("serializes_map_of_list_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"MapOfListsOfStrings\":{\"abc\":[\"abc\",\"xyz\"],\"mno\":[\"xyz\",\"abc\"]}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2440,7 +2440,7 @@ it("serializes_map_of_structure_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"MapOfStructs\":{\"key1\":{\"Value\":\"value-1\"},\"key2\":{\"Value\":\"value-2\"}}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2488,7 +2488,7 @@ it("serializes_map_of_recursive_structure_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"RecursiveMap\":{\"key1\":{\"RecursiveMap\":{\"key2\":{\"RecursiveMap\":{\"key3\":{\"Boolean\":false}}}}}}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2526,7 +2526,7 @@ it("serializes_structure_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"SimpleStruct\":{\"Value\":\"abc\"}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2564,7 +2564,7 @@ it("serializes_structure_members_with_locationname_traits:Request", async () => 
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"StructWithLocationName\":{\"RenamedMember\":\"some-value\"}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2600,7 +2600,7 @@ it("serializes_empty_structure_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"SimpleStruct\":{}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2636,7 +2636,7 @@ it("serializes_structure_which_have_no_members:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"EmptyStruct\":{}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2696,7 +2696,7 @@ it("serializes_recursive_structure_shapes:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"String\":\"top-value\",\"Boolean\":false,\"RecursiveStruct\":{\"String\":\"nested-value\",\"Boolean\":true,\"RecursiveList\":[{\"String\":\"string-only\"},{\"RecursiveStruct\":{\"MapOfStrings\":{\"color\":\"red\",\"size\":\"large\"}}}]}}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3660,7 +3660,7 @@ it("AwsJson11StructuresDontSerializeNullValues:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3701,7 +3701,7 @@ it("AwsJson11MapsSerializeNullValues:Request", async () => {
             \"foo\": null
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3740,7 +3740,7 @@ it("AwsJson11ListsSerializeNull:Request", async () => {
             null
         ]
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3892,7 +3892,7 @@ it("can_call_operation_with_no_input_or_output:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3929,7 +3929,7 @@ it("can_call_operation_with_optional_input:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Value\":\"Hi\"}`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3969,7 +3969,7 @@ it("PutAndGetInlineDocumentsInput:Request", async () => {
     const bodyString = `{
         \"inlineDocument\": {\"foo\": \"bar\"}
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4020,7 +4020,7 @@ it("PutAndGetInlineDocumentsInput:Response", async () => {
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentJsonBodies = (expectedBody: string, generatedBody: string): Object => {
   const expectedParts = JSON.parse(expectedBody);
   const generatedParts = JSON.parse(generatedBody);
 

--- a/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
+++ b/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
@@ -184,7 +184,7 @@ it("QueryEmptyInputAndEmptyOutput:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=EmptyInputAndEmptyOutput
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -606,7 +606,7 @@ it("NestedStructures:Request", async () => {
     &Nested.StringArg=foo
     &Nested.OtherArg=true
     &Nested.RecursiveArg.StringArg=baz`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -640,7 +640,7 @@ it("QueryNoInputAndNoOutput:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=NoInputAndNoOutput
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -696,7 +696,7 @@ it("QueryNoInputAndOutput:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=NoInputAndOutput
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -756,7 +756,7 @@ it("QueryProtocolIdempotencyTokenAutoFill:Request", async () => {
     const bodyString = `Action=QueryIdempotencyTokenAutoFill
     &Version=2020-01-08
     &token=00000000-0000-4000-8000-000000000000`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -794,7 +794,7 @@ it("QueryProtocolIdempotencyTokenAutoFillIsSet:Request", async () => {
     const bodyString = `Action=QueryIdempotencyTokenAutoFill
     &Version=2020-01-08
     &token=00000000-0000-4000-8000-000000000123`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -845,7 +845,7 @@ it("QueryLists:Request", async () => {
     &ListArg.member.3=baz
     &ComplexListArg.member.1.hi=hello
     &ComplexListArg.member.2.hi=hola`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -881,7 +881,7 @@ it("EmptyQueryLists:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=QueryLists
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -919,7 +919,7 @@ it("FlattenedQueryLists:Request", async () => {
     &Version=2020-01-08
     &FlattenedListArg.1=A
     &FlattenedListArg.2=B`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -957,7 +957,7 @@ it("QueryListArgWithXmlNameMember:Request", async () => {
     &Version=2020-01-08
     &ListArgWithXmlNameMember.item.1=A
     &ListArgWithXmlNameMember.item.2=B`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -995,7 +995,7 @@ it("QueryFlattenedListArgWithXmlName:Request", async () => {
     &Version=2020-01-08
     &Hi.1=A
     &Hi.2=B`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1039,7 +1039,7 @@ it("QuerySimpleQueryMaps:Request", async () => {
     &MapArg.entry.1.value=Bar
     &MapArg.entry.2.key=foo
     &MapArg.entry.2.value=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1079,7 +1079,7 @@ it("QuerySimpleQueryMapsWithXmlName:Request", async () => {
     &Version=2020-01-08
     &Foo.entry.1.key=foo
     &Foo.entry.1.value=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1127,7 +1127,7 @@ it("QueryComplexQueryMaps:Request", async () => {
     &ComplexMapArg.entry.1.value.hi=Bar
     &ComplexMapArg.entry.2.key=foo
     &ComplexMapArg.entry.2.value.hi=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1163,7 +1163,7 @@ it("QueryEmptyQueryMaps:Request", async () => {
     expect(r.body).toBeDefined();
     const bodyString = `Action=QueryMaps
     &Version=2020-01-08`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1207,7 +1207,7 @@ it("QueryQueryMapWithMemberXmlName:Request", async () => {
     &MapWithXmlMemberName.entry.1.V=Bar
     &MapWithXmlMemberName.entry.2.K=foo
     &MapWithXmlMemberName.entry.2.V=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1251,7 +1251,7 @@ it("QueryFlattenedQueryMaps:Request", async () => {
     &FlattenedMap.1.value=Bar
     &FlattenedMap.2.key=foo
     &FlattenedMap.2.value=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1295,7 +1295,7 @@ it("QueryFlattenedQueryMapsWithXmlName:Request", async () => {
     &Hi.1.V=Bar
     &Hi.2.K=foo
     &Hi.2.V=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1341,7 +1341,7 @@ it("QueryQueryMapOfLists:Request", async () => {
     &MapOfLists.entry.2.key=foo
     &MapOfLists.entry.2.value.member.1=A
     &MapOfLists.entry.2.value.member.2=B`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1385,7 +1385,7 @@ it("QueryTimestampsInput:Request", async () => {
     &normalFormat=2015-01-25T08%3A00%3A00Z
     &epochMember=1422172800
     &epochTarget=1422172800`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1494,7 +1494,7 @@ it("QuerySimpleInputParamsStrings:Request", async () => {
     &Version=2020-01-08
     &Foo=val1
     &Bar=val2`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1535,7 +1535,7 @@ it("QuerySimpleInputParamsStringAndBooleanTrue:Request", async () => {
     &Version=2020-01-08
     &Foo=val1
     &Baz=true`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1573,7 +1573,7 @@ it("QuerySimpleInputParamsStringsAndBooleanFalse:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Baz=false`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1611,7 +1611,7 @@ it("QuerySimpleInputParamsInteger:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Bam=10`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1649,7 +1649,7 @@ it("QuerySimpleInputParamsFloat:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Boo=10.8`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1687,7 +1687,7 @@ it("QuerySimpleInputParamsBlob:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &Qux=dmFsdWU%3D`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1725,7 +1725,7 @@ it("QueryEnums:Request", async () => {
     const bodyString = `Action=SimpleInputParams
     &Version=2020-01-08
     &FooEnum=Foo`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2634,7 +2634,7 @@ it("QueryXmlTimestampsWithHttpDateFormat:Response", async () => {
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentFormUrlencodedBodies = (expectedBody: string, generatedBody: string): Object => {
   const fromEntries = (components: string[][]): { [key: string]: string } => {
     const parts: { [key: string]: string } = {};
 

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -956,7 +956,9 @@ it("RestJsonHttpPayloadTraitsWithBlob:Request", async () => {
     expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
+    const bodyString = `blobby blob blob`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -1104,7 +1106,9 @@ it("RestJsonHttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
     expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
+    const bodyString = `blobby blob blob`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -1187,7 +1191,7 @@ it("RestJsonHttpPayloadWithStructure:Request", async () => {
         \"greeting\": \"hello\",
         \"name\": \"Phreddy\"
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1625,7 +1629,7 @@ it("InlineDocumentInput:Request", async () => {
             \"foo\": \"bar\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1711,7 +1715,7 @@ it("InlineDocumentAsPayloadInput:Request", async () => {
     const bodyString = `{
         \"foo\": \"bar\"
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2217,7 +2221,7 @@ it("RestJsonJsonBlobs:Request", async () => {
     const bodyString = `{
         \"data\": \"dmFsdWU=\"
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2322,7 +2326,7 @@ it("RestJsonJsonEnums:Request", async () => {
             \"zero\": \"0\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2500,7 +2504,7 @@ it("RestJsonLists:Request", async () => {
             }
         ]
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2537,7 +2541,7 @@ it("RestJsonListsEmpty:Request", async () => {
     const bodyString = `{
         \"stringList\": []
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2577,7 +2581,7 @@ it("RestJsonListsSerializeNull:Request", async () => {
             \"hi\"
         ]
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2843,7 +2847,7 @@ it("RestJsonJsonMaps:Request", async () => {
             }
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2905,7 +2909,7 @@ it("RestJsonSerializesNullMapValues:Request", async () => {
             \"x\": null
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2967,7 +2971,7 @@ it("RestJsonSerializesZeroValuesInMaps:Request", async () => {
             \"x\": false
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3207,7 +3211,7 @@ it("RestJsonJsonTimestamps:Request", async () => {
     const bodyString = `{
         \"normal\": 1398796238
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3244,7 +3248,7 @@ it("RestJsonJsonTimestampsWithDateTimeFormat:Request", async () => {
     const bodyString = `{
         \"dateTime\": \"2014-04-29T18:30:38Z\"
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3281,7 +3285,7 @@ it("RestJsonJsonTimestampsWithEpochSecondsFormat:Request", async () => {
     const bodyString = `{
         \"epochSeconds\": 1398796238
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3318,7 +3322,7 @@ it("RestJsonJsonTimestampsWithHttpDateFormat:Request", async () => {
     const bodyString = `{
         \"httpDate\": \"Tue, 29 Apr 2014 18:30:38 GMT\"
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3519,7 +3523,7 @@ it("RestJsonSerializeStringUnionValue:Request", async () => {
             \"stringValue\": \"foo\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3560,7 +3564,7 @@ it("RestJsonSerializeBooleanUnionValue:Request", async () => {
             \"booleanValue\": true
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3601,7 +3605,7 @@ it("RestJsonSerializeNumberUnionValue:Request", async () => {
             \"numberValue\": 1
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3642,7 +3646,7 @@ it("RestJsonSerializeBlobUnionValue:Request", async () => {
             \"blobValue\": \"Zm9v\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3683,7 +3687,7 @@ it("RestJsonSerializeTimestampUnionValue:Request", async () => {
             \"timestampValue\": 1398796238
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3724,7 +3728,7 @@ it("RestJsonSerializeEnumUnionValue:Request", async () => {
             \"enumValue\": \"Foo\"
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3765,7 +3769,7 @@ it("RestJsonSerializeListUnionValue:Request", async () => {
             \"listValue\": [\"foo\", \"bar\"]
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3813,7 +3817,7 @@ it("RestJsonSerializeMapUnionValue:Request", async () => {
             }
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3858,7 +3862,7 @@ it("RestJsonSerializeStructureUnionValue:Request", async () => {
             }
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4626,7 +4630,7 @@ it("RestJsonRecursiveShapes:Request", async () => {
             }
         }
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4756,7 +4760,7 @@ it("RestJsonSimpleScalarProperties:Request", async () => {
         \"floatValue\": 5.5,
         \"DoubleDribble\": 6.5
     }`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4790,7 +4794,9 @@ it("RestJsonDoesntSerializeNullStructureValues:Request", async () => {
     expect(r.headers["content-type"]).toBe("application/json");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toBe("{}");
+    const bodyString = `{}`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -4925,7 +4931,9 @@ it("RestJsonStreamingTraitsWithBlob:Request", async () => {
     expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
+    const bodyString = `blobby blob blob`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -5084,7 +5092,9 @@ it("RestJsonStreamingTraitsRequireLengthWithBlob:Request", async () => {
     expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
+    const bodyString = `blobby blob blob`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -5242,7 +5252,9 @@ it("RestJsonStreamingTraitsWithMediaTypeWithBlob:Request", async () => {
     expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
+    const bodyString = `blobby blob blob`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -5408,9 +5420,26 @@ it("RestJsonTimestampFormatHeaders:Response", async () => {
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentJsonBodies = (expectedBody: string, generatedBody: string): Object => {
   const expectedParts = JSON.parse(expectedBody);
   const generatedParts = JSON.parse(generatedBody);
+
+  return compareParts(expectedParts, generatedParts);
+};
+
+/**
+ * Returns a map of key names that were un-equal to value objects showing the
+ * discrepancies between the components.
+ */
+const compareEquivalentUnknownTypeBodies = (
+  config: any,
+  expectedBody: string,
+  generatedBody: string | Uint8Array
+): Object => {
+  const expectedParts = { Value: expectedBody };
+  const generatedParts = {
+    Value: generatedBody instanceof Uint8Array ? config.utf8Encoder(generatedBody) : generatedBody,
+  };
 
   return compareParts(expectedParts, generatedParts);
 };

--- a/protocol_tests/aws-restxml/RestXmlProtocol.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocol.ts
@@ -198,6 +198,7 @@ import {
   XmlTimestampsCommandInput,
   XmlTimestampsCommandOutput,
 } from "./commands/XmlTimestampsCommand";
+import { XmlUnionsCommand, XmlUnionsCommandInput, XmlUnionsCommandOutput } from "./commands/XmlUnionsCommand";
 import { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
 
 /**
@@ -1567,6 +1568,29 @@ export class RestXmlProtocol extends RestXmlProtocolClient {
     cb?: (err: any, data?: XmlTimestampsCommandOutput) => void
   ): Promise<XmlTimestampsCommandOutput> | void {
     const command = new XmlTimestampsCommand(args);
+    if (typeof optionsOrCb === "function") {
+      this.send(command, optionsOrCb);
+    } else if (typeof cb === "function") {
+      if (typeof optionsOrCb !== "object") throw new Error(`Expect http options but get ${typeof optionsOrCb}`);
+      this.send(command, optionsOrCb || {}, cb);
+    } else {
+      return this.send(command, optionsOrCb);
+    }
+  }
+
+  public xmlUnions(args: XmlUnionsCommandInput, options?: __HttpHandlerOptions): Promise<XmlUnionsCommandOutput>;
+  public xmlUnions(args: XmlUnionsCommandInput, cb: (err: any, data?: XmlUnionsCommandOutput) => void): void;
+  public xmlUnions(
+    args: XmlUnionsCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: XmlUnionsCommandOutput) => void
+  ): void;
+  public xmlUnions(
+    args: XmlUnionsCommandInput,
+    optionsOrCb?: __HttpHandlerOptions | ((err: any, data?: XmlUnionsCommandOutput) => void),
+    cb?: (err: any, data?: XmlUnionsCommandOutput) => void
+  ): Promise<XmlUnionsCommandOutput> | void {
+    const command = new XmlUnionsCommand(args);
     if (typeof optionsOrCb === "function") {
       this.send(command, optionsOrCb);
     } else if (typeof cb === "function") {

--- a/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
@@ -110,6 +110,7 @@ import { XmlMapsCommandInput, XmlMapsCommandOutput } from "./commands/XmlMapsCom
 import { XmlMapsXmlNameCommandInput, XmlMapsXmlNameCommandOutput } from "./commands/XmlMapsXmlNameCommand";
 import { XmlNamespacesCommandInput, XmlNamespacesCommandOutput } from "./commands/XmlNamespacesCommand";
 import { XmlTimestampsCommandInput, XmlTimestampsCommandOutput } from "./commands/XmlTimestampsCommand";
+import { XmlUnionsCommandInput, XmlUnionsCommandOutput } from "./commands/XmlUnionsCommand";
 import { ClientDefaultValues as __ClientDefaultValues } from "./runtimeConfig";
 import {
   EndpointsInputConfig,
@@ -204,7 +205,8 @@ export type ServiceInputTypes =
   | XmlMapsCommandInput
   | XmlMapsXmlNameCommandInput
   | XmlNamespacesCommandInput
-  | XmlTimestampsCommandInput;
+  | XmlTimestampsCommandInput
+  | XmlUnionsCommandInput;
 
 export type ServiceOutputTypes =
   | AllQueryStringTypesCommandOutput
@@ -249,7 +251,8 @@ export type ServiceOutputTypes =
   | XmlMapsCommandOutput
   | XmlMapsXmlNameCommandOutput
   | XmlNamespacesCommandOutput
-  | XmlTimestampsCommandOutput;
+  | XmlTimestampsCommandOutput
+  | XmlUnionsCommandOutput;
 
 export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__HttpHandlerOptions>> {
   /**

--- a/protocol_tests/aws-restxml/commands/XmlUnionsCommand.ts
+++ b/protocol_tests/aws-restxml/commands/XmlUnionsCommand.ts
@@ -1,0 +1,74 @@
+import { RestXmlProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestXmlProtocolClient";
+import { XmlUnionsInputOutput } from "../models/models_0";
+import { deserializeAws_restXmlXmlUnionsCommand, serializeAws_restXmlXmlUnionsCommand } from "../protocols/Aws_restXml";
+import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
+import { Command as $Command } from "@aws-sdk/smithy-client";
+import {
+  FinalizeHandlerArguments,
+  Handler,
+  HandlerExecutionContext,
+  MiddlewareStack,
+  HttpHandlerOptions as __HttpHandlerOptions,
+  MetadataBearer as __MetadataBearer,
+  SerdeContext as __SerdeContext,
+} from "@aws-sdk/types";
+
+export type XmlUnionsCommandInput = XmlUnionsInputOutput;
+export type XmlUnionsCommandOutput = XmlUnionsInputOutput & __MetadataBearer;
+
+export class XmlUnionsCommand extends $Command<
+  XmlUnionsCommandInput,
+  XmlUnionsCommandOutput,
+  RestXmlProtocolClientResolvedConfig
+> {
+  // Start section: command_properties
+  // End section: command_properties
+
+  constructor(readonly input: XmlUnionsCommandInput) {
+    // Start section: command_constructor
+    super();
+    // End section: command_constructor
+  }
+
+  /**
+   * @internal
+   */
+  resolveMiddleware(
+    clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
+    configuration: RestXmlProtocolClientResolvedConfig,
+    options?: __HttpHandlerOptions
+  ): Handler<XmlUnionsCommandInput, XmlUnionsCommandOutput> {
+    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+
+    const stack = clientStack.concat(this.middlewareStack);
+
+    const { logger } = configuration;
+    const clientName = "RestXmlProtocolClient";
+    const commandName = "XmlUnionsCommand";
+    const handlerExecutionContext: HandlerExecutionContext = {
+      logger,
+      clientName,
+      commandName,
+      inputFilterSensitiveLog: XmlUnionsInputOutput.filterSensitiveLog,
+      outputFilterSensitiveLog: XmlUnionsInputOutput.filterSensitiveLog,
+    };
+    const { requestHandler } = configuration;
+    return stack.resolve(
+      (request: FinalizeHandlerArguments<any>) =>
+        requestHandler.handle(request.request as __HttpRequest, options || {}),
+      handlerExecutionContext
+    );
+  }
+
+  private serialize(input: XmlUnionsCommandInput, context: __SerdeContext): Promise<__HttpRequest> {
+    return serializeAws_restXmlXmlUnionsCommand(input, context);
+  }
+
+  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<XmlUnionsCommandOutput> {
+    return deserializeAws_restXmlXmlUnionsCommand(output, context);
+  }
+
+  // Start section: command_body_extra
+  // End section: command_body_extra
+}

--- a/protocol_tests/aws-restxml/index.ts
+++ b/protocol_tests/aws-restxml/index.ts
@@ -43,4 +43,5 @@ export * from "./commands/XmlMapsCommand";
 export * from "./commands/XmlMapsXmlNameCommand";
 export * from "./commands/XmlNamespacesCommand";
 export * from "./commands/XmlTimestampsCommand";
+export * from "./commands/XmlUnionsCommand";
 export * from "./models/index";

--- a/protocol_tests/aws-restxml/models/models_0.ts
+++ b/protocol_tests/aws-restxml/models/models_0.ts
@@ -598,6 +598,234 @@ export namespace XmlTimestampsInputOutput {
   });
 }
 
+export interface XmlNestedUnionStruct {
+  stringValue?: string;
+  booleanValue?: boolean;
+  byteValue?: number;
+  shortValue?: number;
+  integerValue?: number;
+  longValue?: number;
+  floatValue?: number;
+  doubleValue?: number;
+}
+
+export namespace XmlNestedUnionStruct {
+  export const filterSensitiveLog = (obj: XmlNestedUnionStruct): any => ({
+    ...obj,
+  });
+}
+
+export type XmlUnionShape =
+  | XmlUnionShape.BooleanValueMember
+  | XmlUnionShape.ByteValueMember
+  | XmlUnionShape.DoubleValueMember
+  | XmlUnionShape.FloatValueMember
+  | XmlUnionShape.IntegerValueMember
+  | XmlUnionShape.LongValueMember
+  | XmlUnionShape.ShortValueMember
+  | XmlUnionShape.StringValueMember
+  | XmlUnionShape.StructValueMember
+  | XmlUnionShape.UnionValueMember
+  | XmlUnionShape.$UnknownMember;
+
+export namespace XmlUnionShape {
+  export interface StringValueMember {
+    stringValue: string;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface BooleanValueMember {
+    stringValue?: never;
+    booleanValue: boolean;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface ByteValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue: number;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface ShortValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue: number;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface IntegerValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue: number;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface LongValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue: number;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface FloatValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue: number;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface DoubleValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue: number;
+    unionValue?: never;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface UnionValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue: XmlUnionShape;
+    structValue?: never;
+    $unknown?: never;
+  }
+
+  export interface StructValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue: XmlNestedUnionStruct;
+    $unknown?: never;
+  }
+
+  export interface $UnknownMember {
+    stringValue?: never;
+    booleanValue?: never;
+    byteValue?: never;
+    shortValue?: never;
+    integerValue?: never;
+    longValue?: never;
+    floatValue?: never;
+    doubleValue?: never;
+    unionValue?: never;
+    structValue?: never;
+    $unknown: [string, any];
+  }
+
+  export interface Visitor<T> {
+    stringValue: (value: string) => T;
+    booleanValue: (value: boolean) => T;
+    byteValue: (value: number) => T;
+    shortValue: (value: number) => T;
+    integerValue: (value: number) => T;
+    longValue: (value: number) => T;
+    floatValue: (value: number) => T;
+    doubleValue: (value: number) => T;
+    unionValue: (value: XmlUnionShape) => T;
+    structValue: (value: XmlNestedUnionStruct) => T;
+    _: (name: string, value: any) => T;
+  }
+
+  export const visit = <T>(value: XmlUnionShape, visitor: Visitor<T>): T => {
+    if (value.stringValue !== undefined) return visitor.stringValue(value.stringValue);
+    if (value.booleanValue !== undefined) return visitor.booleanValue(value.booleanValue);
+    if (value.byteValue !== undefined) return visitor.byteValue(value.byteValue);
+    if (value.shortValue !== undefined) return visitor.shortValue(value.shortValue);
+    if (value.integerValue !== undefined) return visitor.integerValue(value.integerValue);
+    if (value.longValue !== undefined) return visitor.longValue(value.longValue);
+    if (value.floatValue !== undefined) return visitor.floatValue(value.floatValue);
+    if (value.doubleValue !== undefined) return visitor.doubleValue(value.doubleValue);
+    if (value.unionValue !== undefined) return visitor.unionValue(value.unionValue);
+    if (value.structValue !== undefined) return visitor.structValue(value.structValue);
+    return visitor._(value.$unknown[0], value.$unknown[1]);
+  };
+
+  export const filterSensitiveLog = (obj: XmlUnionShape): any => {
+    if (obj.stringValue !== undefined) return { stringValue: obj.stringValue };
+    if (obj.booleanValue !== undefined) return { booleanValue: obj.booleanValue };
+    if (obj.byteValue !== undefined) return { byteValue: obj.byteValue };
+    if (obj.shortValue !== undefined) return { shortValue: obj.shortValue };
+    if (obj.integerValue !== undefined) return { integerValue: obj.integerValue };
+    if (obj.longValue !== undefined) return { longValue: obj.longValue };
+    if (obj.floatValue !== undefined) return { floatValue: obj.floatValue };
+    if (obj.doubleValue !== undefined) return { doubleValue: obj.doubleValue };
+    if (obj.unionValue !== undefined) return { unionValue: XmlUnionShape.filterSensitiveLog(obj.unionValue) };
+    if (obj.structValue !== undefined) return { structValue: XmlNestedUnionStruct.filterSensitiveLog(obj.structValue) };
+    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
+  };
+}
+
 export interface RecursiveShapesInputOutputNested1 {
   foo?: string;
   nested?: RecursiveShapesInputOutputNested2;
@@ -617,6 +845,17 @@ export interface RecursiveShapesInputOutputNested2 {
 export namespace RecursiveShapesInputOutputNested2 {
   export const filterSensitiveLog = (obj: RecursiveShapesInputOutputNested2): any => ({
     ...obj,
+  });
+}
+
+export interface XmlUnionsInputOutput {
+  unionValue?: XmlUnionShape;
+}
+
+export namespace XmlUnionsInputOutput {
+  export const filterSensitiveLog = (obj: XmlUnionsInputOutput): any => ({
+    ...obj,
+    ...(obj.unionValue && { unionValue: XmlUnionShape.filterSensitiveLog(obj.unionValue) }),
   });
 }
 

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -110,6 +110,7 @@ import { XmlMapsCommandInput, XmlMapsCommandOutput } from "../commands/XmlMapsCo
 import { XmlMapsXmlNameCommandInput, XmlMapsXmlNameCommandOutput } from "../commands/XmlMapsXmlNameCommand";
 import { XmlNamespacesCommandInput, XmlNamespacesCommandOutput } from "../commands/XmlNamespacesCommand";
 import { XmlTimestampsCommandInput, XmlTimestampsCommandOutput } from "../commands/XmlTimestampsCommand";
+import { XmlUnionsCommandInput, XmlUnionsCommandOutput } from "../commands/XmlUnionsCommand";
 import {
   ComplexError,
   ComplexNestedErrorData,
@@ -125,6 +126,8 @@ import {
   StructureListMember,
   XmlAttributesInputOutput,
   XmlNamespaceNested,
+  XmlNestedUnionStruct,
+  XmlUnionShape,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
@@ -1777,6 +1780,34 @@ export const serializeAws_restXmlXmlTimestampsCommand = async (
     hostname,
     port,
     method: "POST",
+    headers,
+    path: resolvedPath,
+    body,
+  });
+};
+
+export const serializeAws_restXmlXmlUnionsCommand = async (
+  input: XmlUnionsCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const headers: any = {
+    "content-type": "application/xml",
+  };
+  let resolvedPath = "/XmlUnions";
+  let body: any;
+  body = '<?xml version="1.0" encoding="UTF-8"?>';
+  const bodyNode = new __XmlNode("XmlUnionsInputOutput");
+  if (input.unionValue !== undefined) {
+    const node = serializeAws_restXmlXmlUnionShape(input.unionValue, context).withName("unionValue");
+    bodyNode.addChildNode(node);
+  }
+  body += bodyNode.toString();
+  const { hostname, protocol = "https", port } = await context.endpoint();
+  return new __HttpRequest({
+    protocol,
+    hostname,
+    port,
+    method: "PUT",
     headers,
     path: resolvedPath,
     body,
@@ -4248,6 +4279,53 @@ const deserializeAws_restXmlXmlTimestampsCommandError = async (
   return Promise.reject(Object.assign(new Error(message), response));
 };
 
+export const deserializeAws_restXmlXmlUnionsCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlUnionsCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return deserializeAws_restXmlXmlUnionsCommandError(output, context);
+  }
+  const contents: XmlUnionsCommandOutput = {
+    $metadata: deserializeMetadata(output),
+    unionValue: undefined,
+  };
+  const data: any = await parseBody(output.body, context);
+  if (data["unionValue"] !== undefined) {
+    contents.unionValue = deserializeAws_restXmlXmlUnionShape(data["unionValue"], context);
+  }
+  return Promise.resolve(contents);
+};
+
+const deserializeAws_restXmlXmlUnionsCommandError = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlUnionsCommandOutput> => {
+  const parsedOutput: any = {
+    ...output,
+    body: await parseBody(output.body, context),
+  };
+  let response: __SmithyException & __MetadataBearer & { [key: string]: any };
+  let errorCode: string = "UnknownError";
+  errorCode = loadRestXmlErrorCode(output, parsedOutput.body);
+  switch (errorCode) {
+    default:
+      const parsedBody = parsedOutput.body;
+      errorCode = parsedBody.Error.code || parsedBody.Error.Code || errorCode;
+      response = {
+        ...parsedBody.Error,
+        name: `${errorCode}`,
+        message: parsedBody.Error.message || parsedBody.Error.Message || errorCode,
+        $fault: "client",
+        $metadata: deserializeMetadata(output),
+      } as any;
+  }
+  const message = response.message || response.Message || errorCode;
+  response.message = message;
+  delete response.Message;
+  return Promise.reject(Object.assign(new Error(message), response));
+};
+
 const deserializeAws_restXmlComplexErrorResponse = async (
   parsedOutput: any,
   context: __SerdeContext
@@ -4524,6 +4602,100 @@ const serializeAws_restXmlXmlNamespaceNested = (input: XmlNamespaceNested, conte
     });
     bodyNode.addChildNode(containerNode);
   }
+  return bodyNode;
+};
+
+const serializeAws_restXmlXmlNestedUnionStruct = (input: XmlNestedUnionStruct, context: __SerdeContext): any => {
+  const bodyNode = new __XmlNode("XmlNestedUnionStruct");
+  if (input.stringValue !== undefined && input.stringValue !== null) {
+    const node = new __XmlNode("String").addChildNode(new __XmlText(input.stringValue)).withName("stringValue");
+    bodyNode.addChildNode(node);
+  }
+  if (input.booleanValue !== undefined && input.booleanValue !== null) {
+    const node = new __XmlNode("Boolean")
+      .addChildNode(new __XmlText(String(input.booleanValue)))
+      .withName("booleanValue");
+    bodyNode.addChildNode(node);
+  }
+  if (input.byteValue !== undefined && input.byteValue !== null) {
+    const node = new __XmlNode("Byte").addChildNode(new __XmlText(String(input.byteValue))).withName("byteValue");
+    bodyNode.addChildNode(node);
+  }
+  if (input.shortValue !== undefined && input.shortValue !== null) {
+    const node = new __XmlNode("Short").addChildNode(new __XmlText(String(input.shortValue))).withName("shortValue");
+    bodyNode.addChildNode(node);
+  }
+  if (input.integerValue !== undefined && input.integerValue !== null) {
+    const node = new __XmlNode("Integer")
+      .addChildNode(new __XmlText(String(input.integerValue)))
+      .withName("integerValue");
+    bodyNode.addChildNode(node);
+  }
+  if (input.longValue !== undefined && input.longValue !== null) {
+    const node = new __XmlNode("Long").addChildNode(new __XmlText(String(input.longValue))).withName("longValue");
+    bodyNode.addChildNode(node);
+  }
+  if (input.floatValue !== undefined && input.floatValue !== null) {
+    const node = new __XmlNode("Float").addChildNode(new __XmlText(String(input.floatValue))).withName("floatValue");
+    bodyNode.addChildNode(node);
+  }
+  if (input.doubleValue !== undefined && input.doubleValue !== null) {
+    const node = new __XmlNode("Double").addChildNode(new __XmlText(String(input.doubleValue))).withName("doubleValue");
+    bodyNode.addChildNode(node);
+  }
+  return bodyNode;
+};
+
+const serializeAws_restXmlXmlUnionShape = (input: XmlUnionShape, context: __SerdeContext): any => {
+  const bodyNode = new __XmlNode("XmlUnionShape");
+  XmlUnionShape.visit(input, {
+    stringValue: (value) => {
+      const node = new __XmlNode("String").addChildNode(new __XmlText(value)).withName("stringValue");
+      bodyNode.addChildNode(node);
+    },
+    booleanValue: (value) => {
+      const node = new __XmlNode("Boolean").addChildNode(new __XmlText(String(value))).withName("booleanValue");
+      bodyNode.addChildNode(node);
+    },
+    byteValue: (value) => {
+      const node = new __XmlNode("Byte").addChildNode(new __XmlText(String(value))).withName("byteValue");
+      bodyNode.addChildNode(node);
+    },
+    shortValue: (value) => {
+      const node = new __XmlNode("Short").addChildNode(new __XmlText(String(value))).withName("shortValue");
+      bodyNode.addChildNode(node);
+    },
+    integerValue: (value) => {
+      const node = new __XmlNode("Integer").addChildNode(new __XmlText(String(value))).withName("integerValue");
+      bodyNode.addChildNode(node);
+    },
+    longValue: (value) => {
+      const node = new __XmlNode("Long").addChildNode(new __XmlText(String(value))).withName("longValue");
+      bodyNode.addChildNode(node);
+    },
+    floatValue: (value) => {
+      const node = new __XmlNode("Float").addChildNode(new __XmlText(String(value))).withName("floatValue");
+      bodyNode.addChildNode(node);
+    },
+    doubleValue: (value) => {
+      const node = new __XmlNode("Double").addChildNode(new __XmlText(String(value))).withName("doubleValue");
+      bodyNode.addChildNode(node);
+    },
+    unionValue: (value) => {
+      const node = serializeAws_restXmlXmlUnionShape(value, context).withName("unionValue");
+      bodyNode.addChildNode(node);
+    },
+    structValue: (value) => {
+      const node = serializeAws_restXmlXmlNestedUnionStruct(value, context).withName("structValue");
+      bodyNode.addChildNode(node);
+    },
+    _: (name: string, value: any) => {
+      if (!(value instanceof __XmlNode || value instanceof __XmlText)) {
+        throw new Error("Unable to serialize unknown union members in XML.");
+      }
+      bodyNode.addChildNode(new __XmlNode(name).addChildNode(value));
+    },
+  });
   return bodyNode;
 };
 
@@ -4909,6 +5081,98 @@ const deserializeAws_restXmlXmlNamespaceNested = (output: any, context: __SerdeC
     );
   }
   return contents;
+};
+
+const deserializeAws_restXmlXmlNestedUnionStruct = (output: any, context: __SerdeContext): XmlNestedUnionStruct => {
+  let contents: any = {
+    stringValue: undefined,
+    booleanValue: undefined,
+    byteValue: undefined,
+    shortValue: undefined,
+    integerValue: undefined,
+    longValue: undefined,
+    floatValue: undefined,
+    doubleValue: undefined,
+  };
+  if (output["stringValue"] !== undefined) {
+    contents.stringValue = output["stringValue"];
+  }
+  if (output["booleanValue"] !== undefined) {
+    contents.booleanValue = output["booleanValue"] == "true";
+  }
+  if (output["byteValue"] !== undefined) {
+    contents.byteValue = parseInt(output["byteValue"]);
+  }
+  if (output["shortValue"] !== undefined) {
+    contents.shortValue = parseInt(output["shortValue"]);
+  }
+  if (output["integerValue"] !== undefined) {
+    contents.integerValue = parseInt(output["integerValue"]);
+  }
+  if (output["longValue"] !== undefined) {
+    contents.longValue = parseInt(output["longValue"]);
+  }
+  if (output["floatValue"] !== undefined) {
+    contents.floatValue = parseFloat(output["floatValue"]);
+  }
+  if (output["doubleValue"] !== undefined) {
+    contents.doubleValue = parseFloat(output["doubleValue"]);
+  }
+  return contents;
+};
+
+const deserializeAws_restXmlXmlUnionShape = (output: any, context: __SerdeContext): XmlUnionShape => {
+  if (output["stringValue"] !== undefined) {
+    return {
+      stringValue: output["stringValue"],
+    };
+  }
+  if (output["booleanValue"] !== undefined) {
+    return {
+      booleanValue: output["booleanValue"] == "true",
+    };
+  }
+  if (output["byteValue"] !== undefined) {
+    return {
+      byteValue: parseInt(output["byteValue"]),
+    };
+  }
+  if (output["shortValue"] !== undefined) {
+    return {
+      shortValue: parseInt(output["shortValue"]),
+    };
+  }
+  if (output["integerValue"] !== undefined) {
+    return {
+      integerValue: parseInt(output["integerValue"]),
+    };
+  }
+  if (output["longValue"] !== undefined) {
+    return {
+      longValue: parseInt(output["longValue"]),
+    };
+  }
+  if (output["floatValue"] !== undefined) {
+    return {
+      floatValue: parseFloat(output["floatValue"]),
+    };
+  }
+  if (output["doubleValue"] !== undefined) {
+    return {
+      doubleValue: parseFloat(output["doubleValue"]),
+    };
+  }
+  if (output["unionValue"] !== undefined) {
+    return {
+      unionValue: deserializeAws_restXmlXmlUnionShape(output["unionValue"], context),
+    };
+  }
+  if (output["structValue"] !== undefined) {
+    return {
+      structValue: deserializeAws_restXmlXmlNestedUnionStruct(output["structValue"], context),
+    };
+  }
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeAws_restXmlBooleanList = (output: any, context: __SerdeContext): boolean[] => {

--- a/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
@@ -41,6 +41,7 @@ import { XmlMapsCommand } from "../../commands/XmlMapsCommand";
 import { XmlMapsXmlNameCommand } from "../../commands/XmlMapsXmlNameCommand";
 import { XmlNamespacesCommand } from "../../commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../commands/XmlTimestampsCommand";
+import { XmlUnionsCommand } from "../../commands/XmlUnionsCommand";
 import { ComplexError, InvalidGreeting } from "../../models/models_0";
 import { buildQueryString } from "@aws-sdk/querystring-builder";
 import { parse as xmlParse } from "fast-xml-parser";
@@ -468,7 +469,7 @@ it("FlattenedXmlMap:Request", async () => {
             <value>Baz</value>
         </myMap>
     </FlattenedXmlMapInputOutput>`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -567,7 +568,7 @@ it("FlattenedXmlMapWithXmlName:Request", async () => {
             <V>B</V>
         </KVP>
     </FlattenedXmlMapWithXmlNameInputOutput>`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -855,7 +856,9 @@ it("HttpPayloadTraitsWithBlob:Request", async () => {
     expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
+    const bodyString = `blobby blob blob`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -1003,7 +1006,9 @@ it("HttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
     expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
-    expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
+    const bodyString = `blobby blob blob`;
+    const unequalParts: any = compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body);
+    expect(unequalParts).toBeUndefined();
   }
 });
 
@@ -1087,7 +1092,7 @@ it("HttpPayloadWithStructure:Request", async () => {
         <name>Phreddy</name>
     </NestedPayload>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1171,7 +1176,7 @@ it("HttpPayloadWithXmlName:Request", async () => {
 
     expect(r.body).toBeDefined();
     const bodyString = `<Hello><name>Phreddy</name></Hello>`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1251,7 +1256,7 @@ it("HttpPayloadWithXmlNamespace:Request", async () => {
     const bodyString = `<PayloadWithXmlNamespace xmlns=\"http://foo.com\">
         <name>Phreddy</name>
     </PayloadWithXmlNamespace>`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -1333,7 +1338,7 @@ it("HttpPayloadWithXmlNamespaceAndPrefix:Request", async () => {
     const bodyString = `<PayloadWithXmlNamespaceAndPrefix xmlns:baz=\"http://foo.com\">
         <name>Phreddy</name>
     </PayloadWithXmlNamespaceAndPrefix>`;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2453,7 +2458,7 @@ it("RecursiveShapes:Request", async () => {
         </nested>
     </RecursiveShapesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2585,7 +2590,7 @@ it("SimpleScalarProperties:Request", async () => {
         <DoubleDribble>6.5</DoubleDribble>
     </SimpleScalarPropertiesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2627,7 +2632,7 @@ it("SimpleScalarPropertiesWithEscapedCharacter:Request", async () => {
         <stringValue>&lt;string&gt;</stringValue>
     </SimpleScalarPropertiesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -2669,7 +2674,7 @@ it("SimpleScalarPropertiesWithWhiteSpace:Request", async () => {
         <stringValue>string with white    space</stringValue>
     </SimpleScalarPropertiesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3025,7 +3030,7 @@ it("XmlAttributes:Request", async () => {
         <foo>hi</foo>
     </XmlAttributesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3065,7 +3070,7 @@ it("XmlAttributesWithEscaping:Request", async () => {
         <foo>hi</foo>
     </XmlAttributesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3150,7 +3155,7 @@ it("XmlAttributesOnPayload:Request", async () => {
         <foo>hi</foo>
     </XmlAttributesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3233,7 +3238,7 @@ it("XmlBlobs:Request", async () => {
         <data>dmFsdWU=</data>
     </XmlBlobsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3397,7 +3402,7 @@ it("XmlEmptyLists:Request", async () => {
             <stringSet></stringSet>
     </XmlListsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3479,7 +3484,7 @@ it("XmlEmptyMaps:Request", async () => {
         <myMap></myMap>
     </XmlMapsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3599,7 +3604,7 @@ it("XmlEmptyStrings:Request", async () => {
         <emptyString></emptyString>
     </XmlEmptyStringsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3753,7 +3758,7 @@ it("XmlEnums:Request", async () => {
         </fooEnumMap>
     </XmlEnumsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -3953,7 +3958,7 @@ it("XmlLists:Request", async () => {
         </myStructureList>
     </XmlListsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4148,7 +4153,7 @@ it("XmlMaps:Request", async () => {
         </myMap>
     </XmlMapsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4269,7 +4274,7 @@ it("XmlMapsXmlName:Request", async () => {
         </myMap>
     </XmlMapsXmlNameInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4379,7 +4384,7 @@ it("XmlNamespaces:Request", async () => {
         </nested>
     </XmlNamespacesInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4468,7 +4473,7 @@ it("XmlTimestamps:Request", async () => {
         <normal>2014-04-29T18:30:38Z</normal>
     </XmlTimestampsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4506,7 +4511,7 @@ it("XmlTimestampsWithDateTimeFormat:Request", async () => {
         <dateTime>2014-04-29T18:30:38Z</dateTime>
     </XmlTimestampsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4544,7 +4549,7 @@ it("XmlTimestampsWithEpochSecondsFormat:Request", async () => {
         <epochSeconds>1398796238</epochSeconds>
     </XmlTimestampsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4582,7 +4587,7 @@ it("XmlTimestampsWithHttpDateFormat:Request", async () => {
         <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
     </XmlTimestampsInputOutput>
     `;
-    const unequalParts: any = compareEquivalentBodies(bodyString, r.body.toString());
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }
 });
@@ -4752,10 +4757,433 @@ it("XmlTimestampsWithHttpDateFormat:Response", async () => {
 });
 
 /**
+ * Serializes union struct member
+ */
+it("XmlUnionsWithStructMember:Request", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new RequestSerializationTestHandler(),
+  });
+
+  const command = new XmlUnionsCommand({
+    unionValue: {
+      structValue: {
+        stringValue: "string",
+
+        booleanValue: true,
+
+        byteValue: 1,
+
+        shortValue: 2,
+
+        integerValue: 3,
+
+        longValue: 4,
+
+        floatValue: 5.5,
+
+        doubleValue: 6.5,
+      } as any,
+    } as any,
+  } as any);
+  try {
+    await client.send(command);
+    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    return;
+  } catch (err) {
+    if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+      fail(err);
+      return;
+    }
+    const r = err.request;
+    expect(r.method).toBe("PUT");
+    expect(r.path).toBe("/XmlUnions");
+
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/xml");
+
+    expect(r.body).toBeDefined();
+    const bodyString = `<XmlUnionsInputOutput>
+        <unionValue>
+           <structValue>
+              <stringValue>string</stringValue>
+              <booleanValue>true</booleanValue>
+              <byteValue>1</byteValue>
+              <shortValue>2</shortValue>
+              <integerValue>3</integerValue>
+              <longValue>4</longValue>
+              <floatValue>5.5</floatValue>
+              <doubleValue>6.5</doubleValue>
+           </structValue>
+        </unionValue>
+    </XmlUnionsInputOutput>
+    `;
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
+    expect(unequalParts).toBeUndefined();
+  }
+});
+
+/**
+ * serialize union string member
+ */
+it("XmlUnionsWithStringMember:Request", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new RequestSerializationTestHandler(),
+  });
+
+  const command = new XmlUnionsCommand({
+    unionValue: {
+      stringValue: "some string",
+    } as any,
+  } as any);
+  try {
+    await client.send(command);
+    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    return;
+  } catch (err) {
+    if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+      fail(err);
+      return;
+    }
+    const r = err.request;
+    expect(r.method).toBe("PUT");
+    expect(r.path).toBe("/XmlUnions");
+
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/xml");
+
+    expect(r.body).toBeDefined();
+    const bodyString = `<XmlUnionsInputOutput>
+       <unionValue>
+          <stringValue>some string</stringValue>
+       </unionValue>
+    </XmlUnionsInputOutput>
+    `;
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
+    expect(unequalParts).toBeUndefined();
+  }
+});
+
+/**
+ * Serializes union boolean member
+ */
+it("XmlUnionsWithBooleanMember:Request", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new RequestSerializationTestHandler(),
+  });
+
+  const command = new XmlUnionsCommand({
+    unionValue: {
+      booleanValue: true,
+    } as any,
+  } as any);
+  try {
+    await client.send(command);
+    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    return;
+  } catch (err) {
+    if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+      fail(err);
+      return;
+    }
+    const r = err.request;
+    expect(r.method).toBe("PUT");
+    expect(r.path).toBe("/XmlUnions");
+
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/xml");
+
+    expect(r.body).toBeDefined();
+    const bodyString = `<XmlUnionsInputOutput>
+       <unionValue>
+          <booleanValue>true</booleanValue>
+       </unionValue>
+    </XmlUnionsInputOutput>
+    `;
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
+    expect(unequalParts).toBeUndefined();
+  }
+});
+
+/**
+ * Serializes union union member
+ */
+it("XmlUnionsWithUnionMember:Request", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new RequestSerializationTestHandler(),
+  });
+
+  const command = new XmlUnionsCommand({
+    unionValue: {
+      unionValue: {
+        booleanValue: true,
+      } as any,
+    } as any,
+  } as any);
+  try {
+    await client.send(command);
+    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    return;
+  } catch (err) {
+    if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+      fail(err);
+      return;
+    }
+    const r = err.request;
+    expect(r.method).toBe("PUT");
+    expect(r.path).toBe("/XmlUnions");
+
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/xml");
+
+    expect(r.body).toBeDefined();
+    const bodyString = `<XmlUnionsInputOutput>
+       <unionValue>
+          <unionValue>
+             <booleanValue>true</booleanValue>
+          </unionValue>
+       </unionValue>
+    </XmlUnionsInputOutput>
+    `;
+    const unequalParts: any = compareEquivalentXmlBodies(bodyString, r.body.toString());
+    expect(unequalParts).toBeUndefined();
+  }
+});
+
+/**
+ * Serializes union struct member
+ */
+it("XmlUnionsWithStructMember:Response", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "application/xml",
+      },
+      `<XmlUnionsInputOutput>
+          <unionValue>
+             <structValue>
+                <stringValue>string</stringValue>
+                <booleanValue>true</booleanValue>
+                <byteValue>1</byteValue>
+                <shortValue>2</shortValue>
+                <integerValue>3</integerValue>
+                <longValue>4</longValue>
+                <floatValue>5.5</floatValue>
+                <doubleValue>6.5</doubleValue>
+             </structValue>
+          </unionValue>
+      </XmlUnionsInputOutput>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlUnionsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got err.");
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      unionValue: {
+        structValue: {
+          stringValue: "string",
+
+          booleanValue: true,
+
+          byteValue: 1,
+
+          shortValue: 2,
+
+          integerValue: 3,
+
+          longValue: 4,
+
+          floatValue: 5.5,
+
+          doubleValue: 6.5,
+        },
+      },
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
+ * Serializes union string member
+ */
+it("XmlUnionsWithStringMember:Response", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "application/xml",
+      },
+      `<XmlUnionsInputOutput>
+         <unionValue>
+            <stringValue>some string</stringValue>
+         </unionValue>
+      </XmlUnionsInputOutput>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlUnionsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got err.");
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      unionValue: {
+        stringValue: "some string",
+      },
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
+ * Serializes union boolean member
+ */
+it("XmlUnionsWithBooleanMember:Response", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "application/xml",
+      },
+      `<XmlUnionsInputOutput>
+         <unionValue>
+            <booleanValue>true</booleanValue>
+         </unionValue>
+      </XmlUnionsInputOutput>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlUnionsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got err.");
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      unionValue: {
+        booleanValue: true,
+      },
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
+ * Serializes union union member
+ */
+it("XmlUnionsWithUnionMember:Response", async () => {
+  const client = new RestXmlProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "application/xml",
+      },
+      `<XmlUnionsInputOutput>
+         <unionValue>
+            <unionValue>
+               <booleanValue>true</booleanValue>
+            </unionValue>
+         </unionValue>
+      </XmlUnionsInputOutput>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlUnionsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got err.");
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      unionValue: {
+        unionValue: {
+          booleanValue: true,
+        },
+      },
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentUnknownTypeBodies = (
+  config: any,
+  expectedBody: string,
+  generatedBody: string | Uint8Array
+): Object => {
+  const expectedParts = { Value: expectedBody };
+  const generatedParts = {
+    Value: generatedBody instanceof Uint8Array ? config.utf8Encoder(generatedBody) : generatedBody,
+  };
+
+  return compareParts(expectedParts, generatedParts);
+};
+
+/**
+ * Returns a map of key names that were un-equal to value objects showing the
+ * discrepancies between the components.
+ */
+const compareEquivalentXmlBodies = (expectedBody: string, generatedBody: string): Object => {
   const decodeEscapedXml = (str: string) => {
     return str
       .replace(/&amp;/g, "&")


### PR DESCRIPTION
### Description
[Code generation for protocol test updates](https://github.com/awslabs/smithy-typescript/pull/268)

### Testing
`yarn test:protocols`

### Additional context
awslabs/smithy-typescript#268

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
