### PR TITLE
docs(contributing): correct codegen link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ To run the tests for a specific package, you can run `yarn test` from within the
 
 ### Generating Service Clients
 
-Please refer [sdk-codegen](./codegen/sdk-codegen/README.md)
+Please refer [codegen](./codegen/README.md)
 
 [issues]: https://github.com/aws/aws-sdk-js-v3/issues
 [pr]: https://github.com/aws/aws-sdk-js-v3/pulls


### PR DESCRIPTION
### Issue
na

### Description
The codegen link currently results in a 404 error, as the /codegen/sdk-codegen folder does not contain a README file.  
This change simply moves the link to the codegen/README file which correctly explains how to run the scripts.

### Testing
Verified in github new link points to  a valid location that correctly explains codegen


### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
