### PR TITLE
fix: gitignore temporary folder .aws-models

### DIFF
--- a/scripts/generate-clients/.gitignore
+++ b/scripts/generate-clients/.gitignore
@@ -1,0 +1,1 @@
+.aws-models/


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2068

### Description
gitignore temporary folder .aws-models

### Testing
Verified that folder `.aws-models` is not added to git untracked files.

```console
$ yarn generate-clients

...
...
./gradlew failed with { code: 1, signal: null }
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

$ git status
On branch gitignore-temp-aws-models
Your branch is up to date with 'origin/gitignore-temp-aws-models'.

nothing to commit, working tree clean

```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
