### PR TITLE
chore(buildspec): use runtime-versions nodejs

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,14 +1,14 @@
 version: 0.2
 
 phases:
+  install:
+    runtime-versions:
+      nodejs: 10
   build:
     commands:
       # Fake credentials for protocol tests to get past signing.
       - export AWS_ACCESS_KEY_ID=foo
       - export AWS_SECRET_ACCESS_KEY=bar
-      # Switch to runtime-versions nodejs 10 once codebuild upgrades its docker images
-      # Refs: https://github.com/aws/aws-codebuild-docker-images/pull/400
-      - n 10
       - echo Building...
       - yarn --frozen-lockfile
       # Run the actual tests.


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-codebuild-docker-images/pull/400

### Description
use runtime-versions nodejs in buildspec, as it's updated in ubuntu/standard/4.0/Dockerfile

### Testing
Verify that CI is successfully run.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
