### PR TITLE
chore(codegen): update calls to deprecated model.getKnowledge

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -138,7 +138,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
             OperationShape operationShape,
             Set<String> expectedMemberNames
     ) {
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(model);
         return operationIndex.getInput(operationShape)
                 .filter(input -> input.getMemberNames().stream().anyMatch(expectedMemberNames::contains))
                 .isPresent();

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
@@ -129,9 +129,9 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
     }
 
     private static boolean hasEventStreamInput(Model model, ServiceShape service) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
-        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         for (OperationShape operation : operations) {
             if (eventStreamIndex.getInputInfo(operation).isPresent()) {
                 return true;
@@ -141,7 +141,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
     }
 
     private static boolean hasEventStreamInput(Model model, ServiceShape service, OperationShape operation) {
-        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         return eventStreamIndex.getInputInfo(operation).isPresent();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -74,7 +74,7 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
                     .collect(Collectors.joining("\n"));
             resource = resource.replaceAll(Pattern.quote("${documentation}"), documentation);
 
-            TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+            TopDownIndex topDownIndex = TopDownIndex.of(model);
             OperationShape firstOperation = topDownIndex.getContainedOperations(service).iterator().next();
             String operationName = firstOperation.getId().getName();
             resource = resource.replaceAll(Pattern.quote("${commandName}"), operationName);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -80,7 +80,7 @@ final class AwsProtocolUtils {
             ShapeVisitor<Void> visitor
     ) {
         // Walk all the shapes within those in the document and generate for them as well.
-        Walker shapeWalker = new Walker(context.getModel().getKnowledge(NeighborProviderIndex.class).getProvider());
+        Walker shapeWalker = new Walker(NeighborProviderIndex.of(context.getModel()).getProvider());
         Set<Shape> shapesToGenerate = new TreeSet<>(shapes);
         shapes.forEach(shape -> shapesToGenerate.addAll(shapeWalker.walkShapes(shape)));
         shapesToGenerate.forEach(shape -> shape.accept(visitor));
@@ -264,7 +264,7 @@ final class AwsProtocolUtils {
             Format defaultFormat,
             String inputLocation
     ) {
-        HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
+        HttpBindingIndex httpIndex = HttpBindingIndex.of(context.getModel());
         TimestampFormatTrait.Format format = httpIndex.determineTimestampFormat(memberShape, DOCUMENT, defaultFormat);
         return HttpProtocolGeneratorUtils.getTimestampInputParam(context, inputLocation, memberShape, format);
     }


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/awslabs/smithy-typescript/pull/257

### Description
Removes calls to deprecated model.getKnowledge

Regular expression used for search 'model.getKnowledge\(([^\.]*).class\)'
and replaced with $1.of(model)

### Testing
Build is successful:
```console
./gradlew clean smithy-aws-typescript-codegen:build protocol-test-codegen:build -Plog-tests
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
