### PR TITLE
fix: write undefined JSON RPC input body

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -108,6 +108,14 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     }
 
     @Override
+    protected boolean writeUndefinedInputBody(GenerationContext context, OperationShape operation) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.write("const body = '{}';");
+        return true;
+    }
+
+    @Override
     protected void writeErrorCodeParser(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 


### PR DESCRIPTION
### Description
Writes an empty JSON object body for requests when an operation in an AWS JSON RPC protocol doesn't have an input.

### Testing
Updated Smithy 1.6.x protocol tests.

### Additional context
Code generation PR reliant on awslabs/smithy#720 and awslabs/smithy-typescript#275. That will supersede #2072.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
