### PR TITLE
fix: call filterSensitiveLog for missing structures

### DIFF
--- a/clients/client-budgets/models/models_0.ts
+++ b/clients/client-budgets/models/models_0.ts
@@ -356,6 +356,7 @@ export interface ActionHistoryDetails {
 export namespace ActionHistoryDetails {
   export const filterSensitiveLog = (obj: ActionHistoryDetails): any => ({
     ...obj,
+    ...(obj.Action && { Action: Action.filterSensitiveLog(obj.Action) }),
   });
 }
 
@@ -403,6 +404,9 @@ export interface ActionHistory {
 export namespace ActionHistory {
   export const filterSensitiveLog = (obj: ActionHistory): any => ({
     ...obj,
+    ...(obj.ActionHistoryDetails && {
+      ActionHistoryDetails: ActionHistoryDetails.filterSensitiveLog(obj.ActionHistoryDetails),
+    }),
   });
 }
 
@@ -1147,6 +1151,7 @@ export interface DeleteBudgetActionResponse {
 export namespace DeleteBudgetActionResponse {
   export const filterSensitiveLog = (obj: DeleteBudgetActionResponse): any => ({
     ...obj,
+    ...(obj.Action && { Action: Action.filterSensitiveLog(obj.Action) }),
   });
 }
 
@@ -1333,6 +1338,7 @@ export interface DescribeBudgetActionResponse {
 export namespace DescribeBudgetActionResponse {
   export const filterSensitiveLog = (obj: DescribeBudgetActionResponse): any => ({
     ...obj,
+    ...(obj.Action && { Action: Action.filterSensitiveLog(obj.Action) }),
   });
 }
 
@@ -1997,6 +2003,8 @@ export interface UpdateBudgetActionResponse {
 export namespace UpdateBudgetActionResponse {
   export const filterSensitiveLog = (obj: UpdateBudgetActionResponse): any => ({
     ...obj,
+    ...(obj.OldAction && { OldAction: Action.filterSensitiveLog(obj.OldAction) }),
+    ...(obj.NewAction && { NewAction: Action.filterSensitiveLog(obj.NewAction) }),
   });
 }
 

--- a/clients/client-chime/models/models_0.ts
+++ b/clients/client-chime/models/models_0.ts
@@ -2808,6 +2808,7 @@ export interface CreateProxySessionResponse {
 export namespace CreateProxySessionResponse {
   export const filterSensitiveLog = (obj: CreateProxySessionResponse): any => ({
     ...obj,
+    ...(obj.ProxySession && { ProxySession: ProxySession.filterSensitiveLog(obj.ProxySession) }),
   });
 }
 
@@ -5183,6 +5184,7 @@ export interface GetProxySessionResponse {
 export namespace GetProxySessionResponse {
   export const filterSensitiveLog = (obj: GetProxySessionResponse): any => ({
     ...obj,
+    ...(obj.ProxySession && { ProxySession: ProxySession.filterSensitiveLog(obj.ProxySession) }),
   });
 }
 

--- a/clients/client-chime/models/models_1.ts
+++ b/clients/client-chime/models/models_1.ts
@@ -2757,6 +2757,7 @@ export interface UpdateProxySessionResponse {
 export namespace UpdateProxySessionResponse {
   export const filterSensitiveLog = (obj: UpdateProxySessionResponse): any => ({
     ...obj,
+    ...(obj.ProxySession && { ProxySession: ProxySession.filterSensitiveLog(obj.ProxySession) }),
   });
 }
 

--- a/clients/client-dynamodb/models/models_0.ts
+++ b/clients/client-dynamodb/models/models_0.ts
@@ -7484,6 +7484,15 @@ export interface TransactWriteItemsOutput {
 export namespace TransactWriteItemsOutput {
   export const filterSensitiveLog = (obj: TransactWriteItemsOutput): any => ({
     ...obj,
+    ...(obj.ItemCollectionMetrics && {
+      ItemCollectionMetrics: Object.entries(obj.ItemCollectionMetrics).reduce(
+        (acc: any, [key, value]: [string, ItemCollectionMetrics[]]) => ({
+          ...acc,
+          [key]: value.map((item) => ItemCollectionMetrics.filterSensitiveLog(item)),
+        }),
+        {}
+      ),
+    }),
   });
 }
 
@@ -8195,6 +8204,23 @@ export interface BatchGetItemOutput {
 export namespace BatchGetItemOutput {
   export const filterSensitiveLog = (obj: BatchGetItemOutput): any => ({
     ...obj,
+    ...(obj.Responses && {
+      Responses: Object.entries(obj.Responses).reduce(
+        (acc: any, [key, value]: [string, { [key: string]: AttributeValue }[]]) => ({
+          ...acc,
+          [key]: value.map((item) =>
+            Object.entries(item).reduce(
+              (acc: any, [key, value]: [string, AttributeValue]) => ({
+                ...acc,
+                [key]: AttributeValue.filterSensitiveLog(value),
+              }),
+              {}
+            )
+          ),
+        }),
+        {}
+      ),
+    }),
   });
 }
 
@@ -8575,6 +8601,15 @@ export interface BatchWriteItemInput {
 export namespace BatchWriteItemInput {
   export const filterSensitiveLog = (obj: BatchWriteItemInput): any => ({
     ...obj,
+    ...(obj.RequestItems && {
+      RequestItems: Object.entries(obj.RequestItems).reduce(
+        (acc: any, [key, value]: [string, WriteRequest[]]) => ({
+          ...acc,
+          [key]: value.map((item) => WriteRequest.filterSensitiveLog(item)),
+        }),
+        {}
+      ),
+    }),
   });
 }
 
@@ -9478,6 +9513,24 @@ export interface BatchWriteItemOutput {
 export namespace BatchWriteItemOutput {
   export const filterSensitiveLog = (obj: BatchWriteItemOutput): any => ({
     ...obj,
+    ...(obj.UnprocessedItems && {
+      UnprocessedItems: Object.entries(obj.UnprocessedItems).reduce(
+        (acc: any, [key, value]: [string, WriteRequest[]]) => ({
+          ...acc,
+          [key]: value.map((item) => WriteRequest.filterSensitiveLog(item)),
+        }),
+        {}
+      ),
+    }),
+    ...(obj.ItemCollectionMetrics && {
+      ItemCollectionMetrics: Object.entries(obj.ItemCollectionMetrics).reduce(
+        (acc: any, [key, value]: [string, ItemCollectionMetrics[]]) => ({
+          ...acc,
+          [key]: value.map((item) => ItemCollectionMetrics.filterSensitiveLog(item)),
+        }),
+        {}
+      ),
+    }),
   });
 }
 

--- a/clients/client-dynamodb/models/models_0.ts
+++ b/clients/client-dynamodb/models/models_0.ts
@@ -6771,6 +6771,7 @@ export interface BatchExecuteStatementInput {
 export namespace BatchExecuteStatementInput {
   export const filterSensitiveLog = (obj: BatchExecuteStatementInput): any => ({
     ...obj,
+    ...(obj.Statements && { Statements: obj.Statements.map((item) => BatchStatementRequest.filterSensitiveLog(item)) }),
   });
 }
 
@@ -6809,6 +6810,9 @@ export interface ExecuteTransactionInput {
 export namespace ExecuteTransactionInput {
   export const filterSensitiveLog = (obj: ExecuteTransactionInput): any => ({
     ...obj,
+    ...(obj.TransactStatements && {
+      TransactStatements: obj.TransactStatements.map((item) => ParameterizedStatement.filterSensitiveLog(item)),
+    }),
   });
 }
 
@@ -7194,6 +7198,15 @@ export interface BatchGetItemInput {
 export namespace BatchGetItemInput {
   export const filterSensitiveLog = (obj: BatchGetItemInput): any => ({
     ...obj,
+    ...(obj.RequestItems && {
+      RequestItems: Object.entries(obj.RequestItems).reduce(
+        (acc: any, [key, value]: [string, KeysAndAttributes]) => ({
+          ...acc,
+          [key]: KeysAndAttributes.filterSensitiveLog(value),
+        }),
+        {}
+      ),
+    }),
   });
 }
 
@@ -8217,6 +8230,15 @@ export namespace BatchGetItemOutput {
               {}
             )
           ),
+        }),
+        {}
+      ),
+    }),
+    ...(obj.UnprocessedKeys && {
+      UnprocessedKeys: Object.entries(obj.UnprocessedKeys).reduce(
+        (acc: any, [key, value]: [string, KeysAndAttributes]) => ({
+          ...acc,
+          [key]: KeysAndAttributes.filterSensitiveLog(value),
         }),
         {}
       ),

--- a/clients/client-honeycode/models/models_0.ts
+++ b/clients/client-honeycode/models/models_0.ts
@@ -1257,6 +1257,7 @@ export namespace ResultSet {
   export const filterSensitiveLog = (obj: ResultSet): any => ({
     ...obj,
     ...(obj.headers && { headers: obj.headers.map((item) => ColumnMetadata.filterSensitiveLog(item)) }),
+    ...(obj.rows && { rows: obj.rows.map((item) => ResultRow.filterSensitiveLog(item)) }),
   });
 }
 
@@ -1587,6 +1588,7 @@ export interface ListTableRowsResult {
 export namespace ListTableRowsResult {
   export const filterSensitiveLog = (obj: ListTableRowsResult): any => ({
     ...obj,
+    ...(obj.rows && { rows: obj.rows.map((item) => TableRow.filterSensitiveLog(item)) }),
   });
 }
 
@@ -1758,6 +1760,7 @@ export interface QueryTableRowsResult {
 export namespace QueryTableRowsResult {
   export const filterSensitiveLog = (obj: QueryTableRowsResult): any => ({
     ...obj,
+    ...(obj.rows && { rows: obj.rows.map((item) => TableRow.filterSensitiveLog(item)) }),
   });
 }
 

--- a/clients/client-organizations/models/models_0.ts
+++ b/clients/client-organizations/models/models_0.ts
@@ -4461,6 +4461,7 @@ export interface AcceptHandshakeResponse {
 export namespace AcceptHandshakeResponse {
   export const filterSensitiveLog = (obj: AcceptHandshakeResponse): any => ({
     ...obj,
+    ...(obj.Handshake && { Handshake: Handshake.filterSensitiveLog(obj.Handshake) }),
   });
 }
 
@@ -4474,6 +4475,7 @@ export interface CancelHandshakeResponse {
 export namespace CancelHandshakeResponse {
   export const filterSensitiveLog = (obj: CancelHandshakeResponse): any => ({
     ...obj,
+    ...(obj.Handshake && { Handshake: Handshake.filterSensitiveLog(obj.Handshake) }),
   });
 }
 
@@ -4488,6 +4490,7 @@ export interface DeclineHandshakeResponse {
 export namespace DeclineHandshakeResponse {
   export const filterSensitiveLog = (obj: DeclineHandshakeResponse): any => ({
     ...obj,
+    ...(obj.Handshake && { Handshake: Handshake.filterSensitiveLog(obj.Handshake) }),
   });
 }
 
@@ -4501,6 +4504,7 @@ export interface DescribeHandshakeResponse {
 export namespace DescribeHandshakeResponse {
   export const filterSensitiveLog = (obj: DescribeHandshakeResponse): any => ({
     ...obj,
+    ...(obj.Handshake && { Handshake: Handshake.filterSensitiveLog(obj.Handshake) }),
   });
 }
 
@@ -4515,6 +4519,7 @@ export interface EnableAllFeaturesResponse {
 export namespace EnableAllFeaturesResponse {
   export const filterSensitiveLog = (obj: EnableAllFeaturesResponse): any => ({
     ...obj,
+    ...(obj.Handshake && { Handshake: Handshake.filterSensitiveLog(obj.Handshake) }),
   });
 }
 
@@ -4529,6 +4534,7 @@ export interface InviteAccountToOrganizationResponse {
 export namespace InviteAccountToOrganizationResponse {
   export const filterSensitiveLog = (obj: InviteAccountToOrganizationResponse): any => ({
     ...obj,
+    ...(obj.Handshake && { Handshake: Handshake.filterSensitiveLog(obj.Handshake) }),
   });
 }
 

--- a/clients/client-rds-data/models/models_0.ts
+++ b/clients/client-rds-data/models/models_0.ts
@@ -1162,6 +1162,9 @@ export interface BatchExecuteStatementRequest {
 export namespace BatchExecuteStatementRequest {
   export const filterSensitiveLog = (obj: BatchExecuteStatementRequest): any => ({
     ...obj,
+    ...(obj.parameterSets && {
+      parameterSets: obj.parameterSets.map((item) => item.map((item) => SqlParameter.filterSensitiveLog(item))),
+    }),
   });
 }
 
@@ -1236,6 +1239,7 @@ export namespace ExecuteStatementResponse {
   export const filterSensitiveLog = (obj: ExecuteStatementResponse): any => ({
     ...obj,
     ...(obj.generatedFields && { generatedFields: obj.generatedFields.map((item) => Field.filterSensitiveLog(item)) }),
+    ...(obj.records && { records: obj.records.map((item) => item.map((item) => Field.filterSensitiveLog(item))) }),
   });
 }
 

--- a/clients/client-rds-data/models/models_0.ts
+++ b/clients/client-rds-data/models/models_0.ts
@@ -1182,6 +1182,7 @@ export interface BatchExecuteStatementResponse {
 export namespace BatchExecuteStatementResponse {
   export const filterSensitiveLog = (obj: BatchExecuteStatementResponse): any => ({
     ...obj,
+    ...(obj.updateResults && { updateResults: obj.updateResults.map((item) => UpdateResult.filterSensitiveLog(item)) }),
   });
 }
 
@@ -1261,6 +1262,7 @@ export interface ResultFrame {
 export namespace ResultFrame {
   export const filterSensitiveLog = (obj: ResultFrame): any => ({
     ...obj,
+    ...(obj.records && { records: obj.records.map((item) => _Record.filterSensitiveLog(item)) }),
   });
 }
 
@@ -1286,6 +1288,7 @@ export interface SqlStatementResult {
 export namespace SqlStatementResult {
   export const filterSensitiveLog = (obj: SqlStatementResult): any => ({
     ...obj,
+    ...(obj.resultFrame && { resultFrame: ResultFrame.filterSensitiveLog(obj.resultFrame) }),
   });
 }
 

--- a/clients/client-redshift-data/models/models_0.ts
+++ b/clients/client-redshift-data/models/models_0.ts
@@ -650,6 +650,7 @@ export interface GetStatementResultResponse {
 export namespace GetStatementResultResponse {
   export const filterSensitiveLog = (obj: GetStatementResultResponse): any => ({
     ...obj,
+    ...(obj.Records && { Records: obj.Records.map((item) => item.map((item) => Field.filterSensitiveLog(item))) }),
   });
 }
 

--- a/clients/client-sagemaker/models/models_2.ts
+++ b/clients/client-sagemaker/models/models_2.ts
@@ -8307,6 +8307,7 @@ export interface SearchResponse {
 export namespace SearchResponse {
   export const filterSensitiveLog = (obj: SearchResponse): any => ({
     ...obj,
+    ...(obj.Results && { Results: obj.Results.map((item) => SearchRecord.filterSensitiveLog(item)) }),
   });
 }
 


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/277

### Description
Added missing filterSensitiveLog operations for some structures.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
