### PR TITLE
chore(protocol_tests): move auth to standalone plugin

### DIFF
--- a/protocol_tests/aws-ec2/EC2ProtocolClient.ts
+++ b/protocol_tests/aws-ec2/EC2ProtocolClient.ts
@@ -193,11 +193,6 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * Default credentials provider; Not available in browser runtime
-   */
-  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
-
-  /**
    * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
@@ -211,6 +206,11 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;
+
+  /**
+   * Default credentials provider; Not available in browser runtime.
+   */
+  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
 
   /**
    * Fetch related hostname, signing name or signing region with given region.
@@ -228,18 +228,18 @@ export type EC2ProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
-  AwsAuthInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
+  AwsAuthInputConfig &
   UserAgentInputConfig;
 
 export type EC2ProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
-  AwsAuthResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
+  AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
 
 /**
@@ -260,17 +260,17 @@ export class EC2ProtocolClient extends __Client<
     };
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
-    let _config_3 = resolveAwsAuthConfig(_config_2);
-    let _config_4 = resolveRetryConfig(_config_3);
-    let _config_5 = resolveHostHeaderConfig(_config_4);
+    let _config_3 = resolveRetryConfig(_config_2);
+    let _config_4 = resolveHostHeaderConfig(_config_3);
+    let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
+    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 

--- a/protocol_tests/aws-json/JsonProtocolClient.ts
+++ b/protocol_tests/aws-json/JsonProtocolClient.ts
@@ -160,11 +160,6 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * Default credentials provider; Not available in browser runtime
-   */
-  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
-
-  /**
    * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
@@ -178,6 +173,11 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;
+
+  /**
+   * Default credentials provider; Not available in browser runtime.
+   */
+  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
 
   /**
    * Fetch related hostname, signing name or signing region with given region.
@@ -195,18 +195,18 @@ export type JsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
-  AwsAuthInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
+  AwsAuthInputConfig &
   UserAgentInputConfig;
 
 export type JsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
-  AwsAuthResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
+  AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
 
 export class JsonProtocolClient extends __Client<
@@ -224,17 +224,17 @@ export class JsonProtocolClient extends __Client<
     };
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
-    let _config_3 = resolveAwsAuthConfig(_config_2);
-    let _config_4 = resolveRetryConfig(_config_3);
-    let _config_5 = resolveHostHeaderConfig(_config_4);
+    let _config_3 = resolveRetryConfig(_config_2);
+    let _config_4 = resolveHostHeaderConfig(_config_3);
+    let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
+    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 

--- a/protocol_tests/aws-query/QueryProtocolClient.ts
+++ b/protocol_tests/aws-query/QueryProtocolClient.ts
@@ -223,11 +223,6 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * Default credentials provider; Not available in browser runtime
-   */
-  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
-
-  /**
    * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
@@ -241,6 +236,11 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;
+
+  /**
+   * Default credentials provider; Not available in browser runtime.
+   */
+  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
 
   /**
    * Fetch related hostname, signing name or signing region with given region.
@@ -258,18 +258,18 @@ export type QueryProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHand
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
-  AwsAuthInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
+  AwsAuthInputConfig &
   UserAgentInputConfig;
 
 export type QueryProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
-  AwsAuthResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
+  AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
 
 /**
@@ -290,17 +290,17 @@ export class QueryProtocolClient extends __Client<
     };
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
-    let _config_3 = resolveAwsAuthConfig(_config_2);
-    let _config_4 = resolveRetryConfig(_config_3);
-    let _config_5 = resolveHostHeaderConfig(_config_4);
+    let _config_3 = resolveRetryConfig(_config_2);
+    let _config_4 = resolveHostHeaderConfig(_config_3);
+    let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
+    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 

--- a/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
+++ b/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
@@ -301,11 +301,6 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * Default credentials provider; Not available in browser runtime
-   */
-  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
-
-  /**
    * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
@@ -319,6 +314,11 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;
+
+  /**
+   * Default credentials provider; Not available in browser runtime.
+   */
+  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
 
   /**
    * Fetch related hostname, signing name or signing region with given region.
@@ -336,18 +336,18 @@ export type RestJsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpH
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
-  AwsAuthInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
+  AwsAuthInputConfig &
   UserAgentInputConfig;
 
 export type RestJsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
-  AwsAuthResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
+  AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
 
 /**
@@ -368,17 +368,17 @@ export class RestJsonProtocolClient extends __Client<
     };
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
-    let _config_3 = resolveAwsAuthConfig(_config_2);
-    let _config_4 = resolveRetryConfig(_config_3);
-    let _config_5 = resolveHostHeaderConfig(_config_4);
+    let _config_3 = resolveRetryConfig(_config_2);
+    let _config_4 = resolveHostHeaderConfig(_config_3);
+    let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
+    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 

--- a/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
@@ -334,11 +334,6 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * Default credentials provider; Not available in browser runtime
-   */
-  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
-
-  /**
    * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
@@ -352,6 +347,11 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;
+
+  /**
+   * Default credentials provider; Not available in browser runtime.
+   */
+  credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;
 
   /**
    * Fetch related hostname, signing name or signing region with given region.
@@ -369,18 +369,18 @@ export type RestXmlProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHa
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
-  AwsAuthInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
+  AwsAuthInputConfig &
   UserAgentInputConfig;
 
 export type RestXmlProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
-  AwsAuthResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
+  AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
 
 /**
@@ -401,17 +401,17 @@ export class RestXmlProtocolClient extends __Client<
     };
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
-    let _config_3 = resolveAwsAuthConfig(_config_2);
-    let _config_4 = resolveRetryConfig(_config_3);
-    let _config_5 = resolveHostHeaderConfig(_config_4);
+    let _config_3 = resolveRetryConfig(_config_2);
+    let _config_4 = resolveHostHeaderConfig(_config_3);
+    let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
+    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 


### PR DESCRIPTION
### Issue
Missed in https://github.com/aws/aws-sdk-js-v3/pull/2076

### Description
chore(protocol_tests): move auth to standalone plugin

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
