### PR TITLE
fix(deps): pin fast-xml-parser to v3.17.4

### DIFF
--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0",
     "uuid": "^3.0.0"
   },

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
     "@aws-sdk/xml-builder": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/util-user-agent-node": "3.7.0",
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0",
     "uuid": "^3.0.0"
   },

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/util-user-agent-node": "3.7.0",
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/xml-builder": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -60,7 +60,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/xml-builder": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0",
     "uuid": "^3.0.0"
   },

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -73,7 +73,7 @@
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
     "@aws-sdk/xml-builder": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/util-waiter": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/util-user-agent-node": "3.7.0",
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-user-agent-node": "3.7.0",
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/util-user-agent-node": "3.7.0",
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -52,7 +52,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser", "^1.0.0-rc.1"),
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node", "^1.0.0-rc.1"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder", "^1.0.0-rc.1"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "^3.16.0"),
+    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "3.17.4"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^3.0.0"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^3.0.0"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream", "^1.0.0-rc.1"),

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/util-user-agent-node": "3.7.0",
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0",
     "uuid": "^3.0.0"
   },

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/util-user-agent-node": "3.7.0",
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0",
     "uuid": "^3.0.0"
   },

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-browser": "3.6.1",
     "@aws-sdk/util-utf8-node": "3.6.1",
     "@aws-sdk/xml-builder": "3.6.1",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "3.17.4",
     "tslib": "^2.0.0",
     "uuid": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,10 +4972,10 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-xml-parser@^3.16.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.18.0.tgz#b77f4a494cd64e6f44aadfa68fbde30cd922b2df"
-  integrity sha512-tRrwShhppv0K5GKEtuVs92W0VGDaVltZAwtHbpjNF+JOT7cjIFySBGTEOmdBslXYyWYaZwEX/g4Su8ZeKg0LKQ==
+fast-xml-parser@3.17.4:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz#d668495fb3e4bbcf7970f3c24ac0019d82e76477"
+  integrity sha512-qudnQuyYBgnvzf5Lj/yxMcf4L9NcVWihXJg7CiU1L+oUCq8MUnFEfH2/nXR/W5uq+yvUN1h7z6s7vs2v1WkL1A==
 
 fastq@^1.6.0:
   version "1.10.1"


### PR DESCRIPTION
### Issue
N/A

### Description
Pinning fast-xml-parser to v3.17.4 as the project switched to modified MIT License in >=v3.17.5 in https://github.com/NaturalIntelligence/fast-xml-parser/commit/5d4e95188c4d3bf57ee1b2f5489c017ca3be627c

### Testing
CI. Integration tests.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
