### PR TITLE
fix(middleware-bucket-endpoint): revert add support for s3 object lamdbas

### DIFF
--- a/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
@@ -87,10 +87,8 @@ export const validateArnEndpointOptions = (options: {
 };
 
 export const validateService = (service: string) => {
-  if (service !== "s3" 
-      && service !== "s3-outposts"
-      && service !== "s3-object-lambda") {
-    throw new Error("Expect 's3' or 's3-outposts' or 's3-object-lambda' in ARN service component");
+  if (service !== "s3" && service !== "s3-outposts") {
+    throw new Error("Expect 's3' or 's3-outposts' in ARN service component");
   }
 };
 


### PR DESCRIPTION
### Issue
The commit 01bd1a073022eff77f003a3fd310bac2c54dbcb4 was mistakenly merged to main branch, we're investigating why it happened. It's part of PR which is not ready yet https://github.com/aws/aws-sdk-js-v3/pull/2093

This commit is causing CI to fail on main branch and PRs. Examples:
* https://us-west-2.console.aws.amazon.com/codebuild/home?region=us-west-2#/builds/sdk-staging-test:aca5254e-9f72-48ff-82a1-9103054d0242/view/new
* https://us-west-2.console.aws.amazon.com/codebuild/home?region=us-west-2#/builds/sdk-staging-test:4843e6bf-d55c-48d0-b14e-e4f4161baf9c/view/new

### Description
This reverts commit 01bd1a073022eff77f003a3fd310bac2c54dbcb4.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
