### PR TITLE
fix(middleware-signing): memoize temporary credentials

### DIFF
--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -24,6 +24,7 @@
     "typescript": "~4.1.2"
   },
   "dependencies": {
+    "@aws-sdk/property-provider": "3.8.0",
     "@aws-sdk/protocol-http": "3.6.1",
     "@aws-sdk/signature-v4": "3.6.1",
     "@aws-sdk/types": "3.6.1",

--- a/packages/middleware-signing/src/configuration.spec.ts
+++ b/packages/middleware-signing/src/configuration.spec.ts
@@ -1,0 +1,55 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+
+import { resolveAwsAuthConfig } from "./configurations";
+
+describe("resolveAwsAuthConfig", () => {
+  const inputParams = {
+    credentialDefaultProvider: () => () => Promise.resolve({ accessKeyId: "key", secretAccessKey: "secret" }),
+    region: jest.fn().mockImplementation(() => Promise.resolve("us-foo-1")),
+    regionInfoProvider: () => Promise.resolve({ hostname: "foo.com", partition: "aws" }),
+    serviceId: "foo",
+    sha256: jest.fn().mockReturnValue({
+      update: jest.fn(),
+      digest: jest.fn().mockReturnValue("SHA256 hash"),
+    }),
+    credentials: jest.fn().mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should memoize custom credential provider", async () => {
+    const { signer: signerProvider } = resolveAwsAuthConfig(inputParams);
+    const signer = await signerProvider();
+    const request = new HttpRequest({});
+    const repeats = 10;
+    for (let i = 0; i < repeats; i++) {
+      await signer.sign(request);
+    }
+    expect(inputParams.credentials).toBeCalledTimes(1);
+  });
+
+  it("should refresh custom credential provider if expired", async () => {
+    const FOUR_MINUTES_AND_59_SEC = 299 * 1000;
+    const input = {
+      ...inputParams,
+      credentials: jest
+        .fn()
+        .mockResolvedValueOnce({
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          expiration: new Date(Date.now() + FOUR_MINUTES_AND_59_SEC),
+        })
+        .mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
+    };
+    const { signer: signerProvider } = resolveAwsAuthConfig(input);
+    const signer = await signerProvider();
+    const request = new HttpRequest({});
+    const repeats = 10;
+    for (let i = 0; i < repeats; i++) {
+      await signer.sign(request);
+    }
+    expect(input.credentials).toBeCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Issue
Resolves #2107

### Description
It turns out not difficult to fix. When resolving the credentails in the `resolveAwsAuthConfig()`, if the user supplies a customer credential provider, the client will memoize the resolved value. If the resolved value is expired, the credential will be reloaded. If the credential provider only returns a static credential(never expires), the credential will keep memoized.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
