### PR TITLE
feat(client-lex-runtime-v2): add http2 support

### DIFF
--- a/clients/client-lex-runtime-v2/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/runtimeConfig.ts
@@ -8,7 +8,7 @@ import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
 import { Hash } from "@aws-sdk/hash-node";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
-import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
+import { NodeHttp2Handler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
@@ -34,7 +34,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   eventStreamSerdeProvider,
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-  requestHandler: new NodeHttpHandler(),
+  requestHandler: new NodeHttp2Handler(),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 
 public class AddHttp2Dependency implements TypeScriptIntegration {
@@ -57,6 +58,6 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
         String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
         // TODO: Add "Kinesis" service to http2 applicable, but blocked by potential breaking change.
         // Reference: https://github.com/aws/aws-sdk-js-v3/issues/1206
-        return serviceId.equals("Transcribe Streaming");
+        return ListUtils.of("Lex Runtime V2", "Transcribe Streaming").contains(serviceId);
     }
 }


### PR DESCRIPTION
This cutomization should be merged with next Smithy model update. It adds Http2 support for Lex Runtime V2 client to support bidirectional streaming.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
