### PR TITLE
docs(credential-provider-ini): docs typo

### DIFF
--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -61,7 +61,7 @@ export interface SourceProfileInit extends SharedConfigInit {
 
 export interface FromIniInit extends SourceProfileInit {
   /**
-   * A function that returna a promise fulfilled with an MFA token code for
+   * A function that returns a promise fulfilled with an MFA token code for
    * the provided MFA Serial code. If a profile requires an MFA code and
    * `mfaCodeProvider` is not a valid function, the credential provider
    * promise will be rejected.


### PR DESCRIPTION
### Issue
Simple typo in the docs/comments

### Description
Changing "returna" to returns


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
