### PR TITLE
fix(credential-provider-cognito-identity): add identityId to return type of fromCognitoIdentity

### DIFF
--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -1,6 +1,6 @@
 import { GetCredentialsForIdentityCommand } from "@aws-sdk/client-cognito-identity";
 import { ProviderError } from "@aws-sdk/property-provider";
-import { CredentialProvider, Credentials } from "@aws-sdk/types";
+import { Credentials, Provider } from "@aws-sdk/types";
 
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
 import { resolveLogins } from "./resolveLogins";
@@ -12,13 +12,15 @@ export interface CognitoIdentityCredentials extends Credentials {
   identityId: string;
 }
 
+export type CognitoIdentityCredentialProvider = Provider<CognitoIdentityCredentials>;
+
 /**
  * Retrieves temporary AWS credentials using Amazon Cognito's
  * `GetCredentialsForIdentity` operation.
  *
  * Results from this function call are not cached internally.
  */
-export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): CredentialProvider {
+export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): CognitoIdentityCredentialProvider {
   return async (): Promise<CognitoIdentityCredentials> => {
     const {
       Credentials: {

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -1,9 +1,8 @@
 import { GetIdCommand } from "@aws-sdk/client-cognito-identity";
 import { ProviderError } from "@aws-sdk/property-provider";
-import { CredentialProvider } from "@aws-sdk/types";
 
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
-import { fromCognitoIdentity } from "./fromCognitoIdentity";
+import { CognitoIdentityCredentialProvider, fromCognitoIdentity } from "./fromCognitoIdentity";
 import { localStorage } from "./localStorage";
 import { resolveLogins } from "./resolveLogins";
 import { Storage } from "./Storage";
@@ -24,10 +23,10 @@ export function fromCognitoIdentityPool({
   identityPoolId,
   logins,
   userIdentifier = !logins || Object.keys(logins).length === 0 ? "ANONYMOUS" : undefined,
-}: FromCognitoIdentityPoolParameters): CredentialProvider {
+}: FromCognitoIdentityPoolParameters): CognitoIdentityCredentialProvider {
   const cacheKey = userIdentifier ? `aws:cognito-identity-credentials:${identityPoolId}:${userIdentifier}` : undefined;
 
-  let provider: CredentialProvider = async () => {
+  let provider: CognitoIdentityCredentialProvider = async () => {
     let identityId = cacheKey && (await cache.getItem(cacheKey));
     if (!identityId) {
       const { IdentityId = throwOnMissingId() } = await client.send(


### PR DESCRIPTION
### Issue


### Description
In #1635, identityId was added to return value of `fromCognitoIdentity` and `fromCognitoIdentityPool` but not to the return type.

### Testing
Check tsc does not report error.

### Additional context

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
