### PR TITLE
fix(codegen): pin smithy dependencies to minor version 1.6.x

### DIFF
--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.5.0, 2.0[")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.6.0, 1.7.0[")
     compile(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -18,8 +18,8 @@ extra["displayName"] = "Smithy :: AWS :: Typescript :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.aws.typescript.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-aws-traits:[1.5.0, 2.0[")
-    api("software.amazon.smithy:smithy-waiters:[1.5.0, 2.0[")
-    api("software.amazon.smithy:smithy-aws-iam-traits:[1.5.0, 2.0[")
+    api("software.amazon.smithy:smithy-aws-traits:[1.6.0, 1.7.0[")
+    api("software.amazon.smithy:smithy-waiters:[1.6.0, 1.7.0[")
+    api("software.amazon.smithy:smithy-aws-iam-traits:[1.6.0, 1.7.0[")
     api("software.amazon.smithy:smithy-typescript-codegen:0.3.0")
 }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2151
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2152

### Description
Pin smithy dependencies to minor version 1.6.x as both our Java CI as well as generate-clients scripts are failing.

### Testing
Verified that Java CI and generate-clients script was successful.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
