### PR TITLE
fix(clients): generate jest.config.js

### DIFF
--- a/clients/client-accessanalyzer/.gitignore
+++ b/clients/client-accessanalyzer/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-accessanalyzer/jest.config.js
+++ b/clients/client-accessanalyzer/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-acm-pca/.gitignore
+++ b/clients/client-acm-pca/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-acm-pca/jest.config.js
+++ b/clients/client-acm-pca/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-acm/.gitignore
+++ b/clients/client-acm/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-acm/jest.config.js
+++ b/clients/client-acm/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-alexa-for-business/.gitignore
+++ b/clients/client-alexa-for-business/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-alexa-for-business/jest.config.js
+++ b/clients/client-alexa-for-business/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-amplify/.gitignore
+++ b/clients/client-amplify/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-amplify/jest.config.js
+++ b/clients/client-amplify/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-amplifybackend/.gitignore
+++ b/clients/client-amplifybackend/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-amplifybackend/jest.config.js
+++ b/clients/client-amplifybackend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-api-gateway/.gitignore
+++ b/clients/client-api-gateway/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-api-gateway/jest.config.js
+++ b/clients/client-api-gateway/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-apigatewaymanagementapi/.gitignore
+++ b/clients/client-apigatewaymanagementapi/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-apigatewaymanagementapi/jest.config.js
+++ b/clients/client-apigatewaymanagementapi/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-apigatewayv2/.gitignore
+++ b/clients/client-apigatewayv2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-apigatewayv2/jest.config.js
+++ b/clients/client-apigatewayv2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-app-mesh/.gitignore
+++ b/clients/client-app-mesh/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-app-mesh/jest.config.js
+++ b/clients/client-app-mesh/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-appconfig/.gitignore
+++ b/clients/client-appconfig/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-appconfig/jest.config.js
+++ b/clients/client-appconfig/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-appflow/.gitignore
+++ b/clients/client-appflow/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-appflow/jest.config.js
+++ b/clients/client-appflow/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-appintegrations/.gitignore
+++ b/clients/client-appintegrations/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-appintegrations/jest.config.js
+++ b/clients/client-appintegrations/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-application-auto-scaling/.gitignore
+++ b/clients/client-application-auto-scaling/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-application-auto-scaling/jest.config.js
+++ b/clients/client-application-auto-scaling/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-application-discovery-service/.gitignore
+++ b/clients/client-application-discovery-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-application-discovery-service/jest.config.js
+++ b/clients/client-application-discovery-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-application-insights/.gitignore
+++ b/clients/client-application-insights/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-application-insights/jest.config.js
+++ b/clients/client-application-insights/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-appstream/.gitignore
+++ b/clients/client-appstream/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-appstream/jest.config.js
+++ b/clients/client-appstream/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-appsync/.gitignore
+++ b/clients/client-appsync/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-appsync/jest.config.js
+++ b/clients/client-appsync/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-athena/.gitignore
+++ b/clients/client-athena/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-athena/jest.config.js
+++ b/clients/client-athena/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-auditmanager/.gitignore
+++ b/clients/client-auditmanager/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-auditmanager/jest.config.js
+++ b/clients/client-auditmanager/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-auto-scaling-plans/.gitignore
+++ b/clients/client-auto-scaling-plans/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-auto-scaling-plans/jest.config.js
+++ b/clients/client-auto-scaling-plans/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-auto-scaling/.gitignore
+++ b/clients/client-auto-scaling/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-auto-scaling/jest.config.js
+++ b/clients/client-auto-scaling/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-backup/.gitignore
+++ b/clients/client-backup/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-backup/jest.config.js
+++ b/clients/client-backup/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-batch/.gitignore
+++ b/clients/client-batch/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-batch/jest.config.js
+++ b/clients/client-batch/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-braket/.gitignore
+++ b/clients/client-braket/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-braket/jest.config.js
+++ b/clients/client-braket/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-budgets/.gitignore
+++ b/clients/client-budgets/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-budgets/jest.config.js
+++ b/clients/client-budgets/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-chime/.gitignore
+++ b/clients/client-chime/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-chime/jest.config.js
+++ b/clients/client-chime/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloud9/.gitignore
+++ b/clients/client-cloud9/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloud9/jest.config.js
+++ b/clients/client-cloud9/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-clouddirectory/.gitignore
+++ b/clients/client-clouddirectory/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-clouddirectory/jest.config.js
+++ b/clients/client-clouddirectory/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudformation/.gitignore
+++ b/clients/client-cloudformation/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudformation/jest.config.js
+++ b/clients/client-cloudformation/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudfront/.gitignore
+++ b/clients/client-cloudfront/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudfront/jest.config.js
+++ b/clients/client-cloudfront/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudhsm-v2/.gitignore
+++ b/clients/client-cloudhsm-v2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudhsm-v2/jest.config.js
+++ b/clients/client-cloudhsm-v2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudhsm/.gitignore
+++ b/clients/client-cloudhsm/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudhsm/jest.config.js
+++ b/clients/client-cloudhsm/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudsearch-domain/.gitignore
+++ b/clients/client-cloudsearch-domain/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudsearch-domain/jest.config.js
+++ b/clients/client-cloudsearch-domain/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudsearch/.gitignore
+++ b/clients/client-cloudsearch/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudsearch/jest.config.js
+++ b/clients/client-cloudsearch/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudtrail/.gitignore
+++ b/clients/client-cloudtrail/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudtrail/jest.config.js
+++ b/clients/client-cloudtrail/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudwatch-events/.gitignore
+++ b/clients/client-cloudwatch-events/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudwatch-events/jest.config.js
+++ b/clients/client-cloudwatch-events/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudwatch-logs/.gitignore
+++ b/clients/client-cloudwatch-logs/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudwatch-logs/jest.config.js
+++ b/clients/client-cloudwatch-logs/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cloudwatch/.gitignore
+++ b/clients/client-cloudwatch/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cloudwatch/jest.config.js
+++ b/clients/client-cloudwatch/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codeartifact/.gitignore
+++ b/clients/client-codeartifact/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codeartifact/jest.config.js
+++ b/clients/client-codeartifact/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codebuild/.gitignore
+++ b/clients/client-codebuild/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codebuild/jest.config.js
+++ b/clients/client-codebuild/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codecommit/.gitignore
+++ b/clients/client-codecommit/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codecommit/jest.config.js
+++ b/clients/client-codecommit/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codedeploy/.gitignore
+++ b/clients/client-codedeploy/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codedeploy/jest.config.js
+++ b/clients/client-codedeploy/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codeguru-reviewer/.gitignore
+++ b/clients/client-codeguru-reviewer/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codeguru-reviewer/jest.config.js
+++ b/clients/client-codeguru-reviewer/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codeguruprofiler/.gitignore
+++ b/clients/client-codeguruprofiler/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codeguruprofiler/jest.config.js
+++ b/clients/client-codeguruprofiler/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codepipeline/.gitignore
+++ b/clients/client-codepipeline/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codepipeline/jest.config.js
+++ b/clients/client-codepipeline/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codestar-connections/.gitignore
+++ b/clients/client-codestar-connections/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codestar-connections/jest.config.js
+++ b/clients/client-codestar-connections/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codestar-notifications/.gitignore
+++ b/clients/client-codestar-notifications/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codestar-notifications/jest.config.js
+++ b/clients/client-codestar-notifications/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-codestar/.gitignore
+++ b/clients/client-codestar/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-codestar/jest.config.js
+++ b/clients/client-codestar/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cognito-identity-provider/.gitignore
+++ b/clients/client-cognito-identity-provider/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cognito-identity-provider/jest.config.js
+++ b/clients/client-cognito-identity-provider/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cognito-identity/.gitignore
+++ b/clients/client-cognito-identity/.gitignore
@@ -7,8 +7,4 @@
 *.tgz
 *.log
 package-lock.json
-
-*.d.ts
-*.js
 !karma.conf.js
-*.js.map

--- a/clients/client-cognito-identity/jest.config.js
+++ b/clients/client-cognito-identity/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cognito-identity/jest.config.js
+++ b/clients/client-cognito-identity/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+  // filedoesnotexist.spec.ts is added to avoid jest error "Your test suite must contain at least one test."
+  // replace it with **/*.spec.ts once we have a decision on test infrastructure for clients.
+  testMatch: ["filedoesnotexist.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
 };

--- a/clients/client-cognito-sync/.gitignore
+++ b/clients/client-cognito-sync/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cognito-sync/jest.config.js
+++ b/clients/client-cognito-sync/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-comprehend/.gitignore
+++ b/clients/client-comprehend/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-comprehend/jest.config.js
+++ b/clients/client-comprehend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-comprehendmedical/.gitignore
+++ b/clients/client-comprehendmedical/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-comprehendmedical/jest.config.js
+++ b/clients/client-comprehendmedical/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-compute-optimizer/.gitignore
+++ b/clients/client-compute-optimizer/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-compute-optimizer/jest.config.js
+++ b/clients/client-compute-optimizer/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-config-service/.gitignore
+++ b/clients/client-config-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-config-service/jest.config.js
+++ b/clients/client-config-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-connect-contact-lens/.gitignore
+++ b/clients/client-connect-contact-lens/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-connect-contact-lens/jest.config.js
+++ b/clients/client-connect-contact-lens/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-connect/.gitignore
+++ b/clients/client-connect/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-connect/jest.config.js
+++ b/clients/client-connect/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-connectparticipant/.gitignore
+++ b/clients/client-connectparticipant/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-connectparticipant/jest.config.js
+++ b/clients/client-connectparticipant/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cost-and-usage-report-service/.gitignore
+++ b/clients/client-cost-and-usage-report-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cost-and-usage-report-service/jest.config.js
+++ b/clients/client-cost-and-usage-report-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-cost-explorer/.gitignore
+++ b/clients/client-cost-explorer/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-cost-explorer/jest.config.js
+++ b/clients/client-cost-explorer/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-customer-profiles/.gitignore
+++ b/clients/client-customer-profiles/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-customer-profiles/jest.config.js
+++ b/clients/client-customer-profiles/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-data-pipeline/.gitignore
+++ b/clients/client-data-pipeline/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-data-pipeline/jest.config.js
+++ b/clients/client-data-pipeline/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-database-migration-service/.gitignore
+++ b/clients/client-database-migration-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-database-migration-service/jest.config.js
+++ b/clients/client-database-migration-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-databrew/.gitignore
+++ b/clients/client-databrew/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-databrew/jest.config.js
+++ b/clients/client-databrew/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-dataexchange/.gitignore
+++ b/clients/client-dataexchange/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-dataexchange/jest.config.js
+++ b/clients/client-dataexchange/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-datasync/.gitignore
+++ b/clients/client-datasync/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-datasync/jest.config.js
+++ b/clients/client-datasync/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-dax/.gitignore
+++ b/clients/client-dax/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-dax/jest.config.js
+++ b/clients/client-dax/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-detective/.gitignore
+++ b/clients/client-detective/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-detective/jest.config.js
+++ b/clients/client-detective/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-device-farm/.gitignore
+++ b/clients/client-device-farm/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-device-farm/jest.config.js
+++ b/clients/client-device-farm/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-devops-guru/.gitignore
+++ b/clients/client-devops-guru/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-devops-guru/jest.config.js
+++ b/clients/client-devops-guru/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-direct-connect/.gitignore
+++ b/clients/client-direct-connect/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-direct-connect/jest.config.js
+++ b/clients/client-direct-connect/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-directory-service/.gitignore
+++ b/clients/client-directory-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-directory-service/jest.config.js
+++ b/clients/client-directory-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-dlm/.gitignore
+++ b/clients/client-dlm/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-dlm/jest.config.js
+++ b/clients/client-dlm/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-docdb/.gitignore
+++ b/clients/client-docdb/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-docdb/jest.config.js
+++ b/clients/client-docdb/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-dynamodb-streams/.gitignore
+++ b/clients/client-dynamodb-streams/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-dynamodb-streams/jest.config.js
+++ b/clients/client-dynamodb-streams/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-dynamodb/.gitignore
+++ b/clients/client-dynamodb/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-dynamodb/jest.config.js
+++ b/clients/client-dynamodb/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ebs/.gitignore
+++ b/clients/client-ebs/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ebs/jest.config.js
+++ b/clients/client-ebs/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ec2-instance-connect/.gitignore
+++ b/clients/client-ec2-instance-connect/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ec2-instance-connect/jest.config.js
+++ b/clients/client-ec2-instance-connect/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ec2/.gitignore
+++ b/clients/client-ec2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ec2/jest.config.js
+++ b/clients/client-ec2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ecr-public/.gitignore
+++ b/clients/client-ecr-public/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ecr-public/jest.config.js
+++ b/clients/client-ecr-public/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ecr/.gitignore
+++ b/clients/client-ecr/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ecr/jest.config.js
+++ b/clients/client-ecr/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ecs/.gitignore
+++ b/clients/client-ecs/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ecs/jest.config.js
+++ b/clients/client-ecs/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-efs/.gitignore
+++ b/clients/client-efs/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-efs/jest.config.js
+++ b/clients/client-efs/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-eks/.gitignore
+++ b/clients/client-eks/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-eks/jest.config.js
+++ b/clients/client-eks/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-elastic-beanstalk/.gitignore
+++ b/clients/client-elastic-beanstalk/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-elastic-beanstalk/jest.config.js
+++ b/clients/client-elastic-beanstalk/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-elastic-inference/.gitignore
+++ b/clients/client-elastic-inference/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-elastic-inference/jest.config.js
+++ b/clients/client-elastic-inference/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-elastic-load-balancing-v2/.gitignore
+++ b/clients/client-elastic-load-balancing-v2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-elastic-load-balancing-v2/jest.config.js
+++ b/clients/client-elastic-load-balancing-v2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-elastic-load-balancing/.gitignore
+++ b/clients/client-elastic-load-balancing/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-elastic-load-balancing/jest.config.js
+++ b/clients/client-elastic-load-balancing/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-elastic-transcoder/.gitignore
+++ b/clients/client-elastic-transcoder/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-elastic-transcoder/jest.config.js
+++ b/clients/client-elastic-transcoder/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-elasticache/.gitignore
+++ b/clients/client-elasticache/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-elasticache/jest.config.js
+++ b/clients/client-elasticache/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-elasticsearch-service/.gitignore
+++ b/clients/client-elasticsearch-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-elasticsearch-service/jest.config.js
+++ b/clients/client-elasticsearch-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-emr-containers/.gitignore
+++ b/clients/client-emr-containers/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-emr-containers/jest.config.js
+++ b/clients/client-emr-containers/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-emr/.gitignore
+++ b/clients/client-emr/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-emr/jest.config.js
+++ b/clients/client-emr/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-eventbridge/.gitignore
+++ b/clients/client-eventbridge/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-eventbridge/jest.config.js
+++ b/clients/client-eventbridge/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-firehose/.gitignore
+++ b/clients/client-firehose/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-firehose/jest.config.js
+++ b/clients/client-firehose/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-fms/.gitignore
+++ b/clients/client-fms/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-fms/jest.config.js
+++ b/clients/client-fms/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-forecast/.gitignore
+++ b/clients/client-forecast/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-forecast/jest.config.js
+++ b/clients/client-forecast/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-forecastquery/.gitignore
+++ b/clients/client-forecastquery/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-forecastquery/jest.config.js
+++ b/clients/client-forecastquery/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-frauddetector/.gitignore
+++ b/clients/client-frauddetector/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-frauddetector/jest.config.js
+++ b/clients/client-frauddetector/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-fsx/.gitignore
+++ b/clients/client-fsx/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-fsx/jest.config.js
+++ b/clients/client-fsx/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-gamelift/.gitignore
+++ b/clients/client-gamelift/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-gamelift/jest.config.js
+++ b/clients/client-gamelift/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-glacier/.gitignore
+++ b/clients/client-glacier/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-glacier/jest.config.js
+++ b/clients/client-glacier/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-global-accelerator/.gitignore
+++ b/clients/client-global-accelerator/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-global-accelerator/jest.config.js
+++ b/clients/client-global-accelerator/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-glue/.gitignore
+++ b/clients/client-glue/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-glue/jest.config.js
+++ b/clients/client-glue/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-greengrass/.gitignore
+++ b/clients/client-greengrass/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-greengrass/jest.config.js
+++ b/clients/client-greengrass/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-groundstation/.gitignore
+++ b/clients/client-groundstation/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-groundstation/jest.config.js
+++ b/clients/client-groundstation/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-guardduty/.gitignore
+++ b/clients/client-guardduty/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-guardduty/jest.config.js
+++ b/clients/client-guardduty/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-health/.gitignore
+++ b/clients/client-health/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-health/jest.config.js
+++ b/clients/client-health/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-healthlake/.gitignore
+++ b/clients/client-healthlake/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-healthlake/jest.config.js
+++ b/clients/client-healthlake/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-honeycode/.gitignore
+++ b/clients/client-honeycode/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-honeycode/jest.config.js
+++ b/clients/client-honeycode/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iam/.gitignore
+++ b/clients/client-iam/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iam/jest.config.js
+++ b/clients/client-iam/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-identitystore/.gitignore
+++ b/clients/client-identitystore/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-identitystore/jest.config.js
+++ b/clients/client-identitystore/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-imagebuilder/.gitignore
+++ b/clients/client-imagebuilder/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-imagebuilder/jest.config.js
+++ b/clients/client-imagebuilder/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-inspector/.gitignore
+++ b/clients/client-inspector/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-inspector/jest.config.js
+++ b/clients/client-inspector/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iot-1click-devices-service/.gitignore
+++ b/clients/client-iot-1click-devices-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iot-1click-devices-service/jest.config.js
+++ b/clients/client-iot-1click-devices-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iot-1click-projects/.gitignore
+++ b/clients/client-iot-1click-projects/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iot-1click-projects/jest.config.js
+++ b/clients/client-iot-1click-projects/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iot-data-plane/.gitignore
+++ b/clients/client-iot-data-plane/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iot-data-plane/jest.config.js
+++ b/clients/client-iot-data-plane/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iot-events-data/.gitignore
+++ b/clients/client-iot-events-data/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iot-events-data/jest.config.js
+++ b/clients/client-iot-events-data/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iot-events/.gitignore
+++ b/clients/client-iot-events/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iot-events/jest.config.js
+++ b/clients/client-iot-events/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iot-jobs-data-plane/.gitignore
+++ b/clients/client-iot-jobs-data-plane/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iot-jobs-data-plane/jest.config.js
+++ b/clients/client-iot-jobs-data-plane/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iot/.gitignore
+++ b/clients/client-iot/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iot/jest.config.js
+++ b/clients/client-iot/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iotanalytics/.gitignore
+++ b/clients/client-iotanalytics/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iotanalytics/jest.config.js
+++ b/clients/client-iotanalytics/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iotsecuretunneling/.gitignore
+++ b/clients/client-iotsecuretunneling/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iotsecuretunneling/jest.config.js
+++ b/clients/client-iotsecuretunneling/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iotsitewise/.gitignore
+++ b/clients/client-iotsitewise/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iotsitewise/jest.config.js
+++ b/clients/client-iotsitewise/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-iotthingsgraph/.gitignore
+++ b/clients/client-iotthingsgraph/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-iotthingsgraph/jest.config.js
+++ b/clients/client-iotthingsgraph/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ivs/.gitignore
+++ b/clients/client-ivs/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ivs/jest.config.js
+++ b/clients/client-ivs/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kafka/.gitignore
+++ b/clients/client-kafka/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kafka/jest.config.js
+++ b/clients/client-kafka/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kendra/.gitignore
+++ b/clients/client-kendra/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kendra/jest.config.js
+++ b/clients/client-kendra/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis-analytics-v2/.gitignore
+++ b/clients/client-kinesis-analytics-v2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kinesis-analytics-v2/jest.config.js
+++ b/clients/client-kinesis-analytics-v2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis-analytics/.gitignore
+++ b/clients/client-kinesis-analytics/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kinesis-analytics/jest.config.js
+++ b/clients/client-kinesis-analytics/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis-video-archived-media/.gitignore
+++ b/clients/client-kinesis-video-archived-media/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kinesis-video-archived-media/jest.config.js
+++ b/clients/client-kinesis-video-archived-media/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis-video-media/.gitignore
+++ b/clients/client-kinesis-video-media/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kinesis-video-media/jest.config.js
+++ b/clients/client-kinesis-video-media/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis-video-signaling/.gitignore
+++ b/clients/client-kinesis-video-signaling/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kinesis-video-signaling/jest.config.js
+++ b/clients/client-kinesis-video-signaling/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis-video/.gitignore
+++ b/clients/client-kinesis-video/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kinesis-video/jest.config.js
+++ b/clients/client-kinesis-video/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis/.gitignore
+++ b/clients/client-kinesis/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kinesis/jest.config.js
+++ b/clients/client-kinesis/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-kms/.gitignore
+++ b/clients/client-kms/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-kms/jest.config.js
+++ b/clients/client-kms/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-lakeformation/.gitignore
+++ b/clients/client-lakeformation/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-lakeformation/jest.config.js
+++ b/clients/client-lakeformation/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-lambda/.gitignore
+++ b/clients/client-lambda/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-lambda/jest.config.js
+++ b/clients/client-lambda/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-lex-model-building-service/.gitignore
+++ b/clients/client-lex-model-building-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-lex-model-building-service/jest.config.js
+++ b/clients/client-lex-model-building-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-lex-runtime-service/.gitignore
+++ b/clients/client-lex-runtime-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-lex-runtime-service/jest.config.js
+++ b/clients/client-lex-runtime-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-license-manager/.gitignore
+++ b/clients/client-license-manager/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-license-manager/jest.config.js
+++ b/clients/client-license-manager/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-lightsail/.gitignore
+++ b/clients/client-lightsail/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-lightsail/jest.config.js
+++ b/clients/client-lightsail/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-lookoutvision/.gitignore
+++ b/clients/client-lookoutvision/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-lookoutvision/jest.config.js
+++ b/clients/client-lookoutvision/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-machine-learning/.gitignore
+++ b/clients/client-machine-learning/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-machine-learning/jest.config.js
+++ b/clients/client-machine-learning/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-macie/.gitignore
+++ b/clients/client-macie/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-macie/jest.config.js
+++ b/clients/client-macie/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-macie2/.gitignore
+++ b/clients/client-macie2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-macie2/jest.config.js
+++ b/clients/client-macie2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-managedblockchain/.gitignore
+++ b/clients/client-managedblockchain/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-managedblockchain/jest.config.js
+++ b/clients/client-managedblockchain/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-marketplace-catalog/.gitignore
+++ b/clients/client-marketplace-catalog/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-marketplace-catalog/jest.config.js
+++ b/clients/client-marketplace-catalog/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-marketplace-commerce-analytics/.gitignore
+++ b/clients/client-marketplace-commerce-analytics/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-marketplace-commerce-analytics/jest.config.js
+++ b/clients/client-marketplace-commerce-analytics/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-marketplace-entitlement-service/.gitignore
+++ b/clients/client-marketplace-entitlement-service/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-marketplace-entitlement-service/jest.config.js
+++ b/clients/client-marketplace-entitlement-service/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-marketplace-metering/.gitignore
+++ b/clients/client-marketplace-metering/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-marketplace-metering/jest.config.js
+++ b/clients/client-marketplace-metering/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mediaconnect/.gitignore
+++ b/clients/client-mediaconnect/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mediaconnect/jest.config.js
+++ b/clients/client-mediaconnect/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mediaconvert/.gitignore
+++ b/clients/client-mediaconvert/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mediaconvert/jest.config.js
+++ b/clients/client-mediaconvert/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-medialive/.gitignore
+++ b/clients/client-medialive/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-medialive/jest.config.js
+++ b/clients/client-medialive/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mediapackage-vod/.gitignore
+++ b/clients/client-mediapackage-vod/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mediapackage-vod/jest.config.js
+++ b/clients/client-mediapackage-vod/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mediapackage/.gitignore
+++ b/clients/client-mediapackage/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mediapackage/jest.config.js
+++ b/clients/client-mediapackage/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mediastore-data/.gitignore
+++ b/clients/client-mediastore-data/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mediastore-data/jest.config.js
+++ b/clients/client-mediastore-data/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mediastore/.gitignore
+++ b/clients/client-mediastore/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mediastore/jest.config.js
+++ b/clients/client-mediastore/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mediatailor/.gitignore
+++ b/clients/client-mediatailor/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mediatailor/jest.config.js
+++ b/clients/client-mediatailor/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-migration-hub/.gitignore
+++ b/clients/client-migration-hub/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-migration-hub/jest.config.js
+++ b/clients/client-migration-hub/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-migrationhub-config/.gitignore
+++ b/clients/client-migrationhub-config/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-migrationhub-config/jest.config.js
+++ b/clients/client-migrationhub-config/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mobile/.gitignore
+++ b/clients/client-mobile/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mobile/jest.config.js
+++ b/clients/client-mobile/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mq/.gitignore
+++ b/clients/client-mq/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mq/jest.config.js
+++ b/clients/client-mq/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-mturk/.gitignore
+++ b/clients/client-mturk/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-mturk/jest.config.js
+++ b/clients/client-mturk/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-neptune/.gitignore
+++ b/clients/client-neptune/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-neptune/jest.config.js
+++ b/clients/client-neptune/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-network-firewall/.gitignore
+++ b/clients/client-network-firewall/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-network-firewall/jest.config.js
+++ b/clients/client-network-firewall/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-networkmanager/.gitignore
+++ b/clients/client-networkmanager/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-networkmanager/jest.config.js
+++ b/clients/client-networkmanager/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-opsworks/.gitignore
+++ b/clients/client-opsworks/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-opsworks/jest.config.js
+++ b/clients/client-opsworks/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-opsworkscm/.gitignore
+++ b/clients/client-opsworkscm/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-opsworkscm/jest.config.js
+++ b/clients/client-opsworkscm/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-organizations/.gitignore
+++ b/clients/client-organizations/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-organizations/jest.config.js
+++ b/clients/client-organizations/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-outposts/.gitignore
+++ b/clients/client-outposts/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-outposts/jest.config.js
+++ b/clients/client-outposts/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-personalize-events/.gitignore
+++ b/clients/client-personalize-events/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-personalize-events/jest.config.js
+++ b/clients/client-personalize-events/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-personalize-runtime/.gitignore
+++ b/clients/client-personalize-runtime/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-personalize-runtime/jest.config.js
+++ b/clients/client-personalize-runtime/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-personalize/.gitignore
+++ b/clients/client-personalize/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-personalize/jest.config.js
+++ b/clients/client-personalize/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-pi/.gitignore
+++ b/clients/client-pi/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-pi/jest.config.js
+++ b/clients/client-pi/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-pinpoint-email/.gitignore
+++ b/clients/client-pinpoint-email/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-pinpoint-email/jest.config.js
+++ b/clients/client-pinpoint-email/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-pinpoint-sms-voice/.gitignore
+++ b/clients/client-pinpoint-sms-voice/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-pinpoint-sms-voice/jest.config.js
+++ b/clients/client-pinpoint-sms-voice/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-pinpoint/.gitignore
+++ b/clients/client-pinpoint/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-pinpoint/jest.config.js
+++ b/clients/client-pinpoint/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-polly/.gitignore
+++ b/clients/client-polly/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-polly/jest.config.js
+++ b/clients/client-polly/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-pricing/.gitignore
+++ b/clients/client-pricing/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-pricing/jest.config.js
+++ b/clients/client-pricing/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-qldb-session/.gitignore
+++ b/clients/client-qldb-session/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-qldb-session/jest.config.js
+++ b/clients/client-qldb-session/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-qldb/.gitignore
+++ b/clients/client-qldb/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-qldb/jest.config.js
+++ b/clients/client-qldb/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-quicksight/.gitignore
+++ b/clients/client-quicksight/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-quicksight/jest.config.js
+++ b/clients/client-quicksight/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ram/.gitignore
+++ b/clients/client-ram/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ram/jest.config.js
+++ b/clients/client-ram/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-rds-data/.gitignore
+++ b/clients/client-rds-data/.gitignore
@@ -8,8 +8,4 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map
-
 !rollup.*.js

--- a/clients/client-rds-data/jest.config.js
+++ b/clients/client-rds-data/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-rds/.gitignore
+++ b/clients/client-rds/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-rds/jest.config.js
+++ b/clients/client-rds/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-redshift-data/.gitignore
+++ b/clients/client-redshift-data/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-redshift-data/jest.config.js
+++ b/clients/client-redshift-data/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-redshift/.gitignore
+++ b/clients/client-redshift/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-redshift/jest.config.js
+++ b/clients/client-redshift/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-rekognition/.gitignore
+++ b/clients/client-rekognition/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-rekognition/jest.config.js
+++ b/clients/client-rekognition/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-resource-groups-tagging-api/.gitignore
+++ b/clients/client-resource-groups-tagging-api/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-resource-groups-tagging-api/jest.config.js
+++ b/clients/client-resource-groups-tagging-api/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-resource-groups/.gitignore
+++ b/clients/client-resource-groups/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-resource-groups/jest.config.js
+++ b/clients/client-resource-groups/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-robomaker/.gitignore
+++ b/clients/client-robomaker/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-robomaker/jest.config.js
+++ b/clients/client-robomaker/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-route-53-domains/.gitignore
+++ b/clients/client-route-53-domains/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-route-53-domains/jest.config.js
+++ b/clients/client-route-53-domains/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-route-53/.gitignore
+++ b/clients/client-route-53/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-route-53/jest.config.js
+++ b/clients/client-route-53/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-route53resolver/.gitignore
+++ b/clients/client-route53resolver/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-route53resolver/jest.config.js
+++ b/clients/client-route53resolver/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-s3-control/.gitignore
+++ b/clients/client-s3-control/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-s3-control/jest.config.js
+++ b/clients/client-s3-control/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-s3/.gitignore
+++ b/clients/client-s3/.gitignore
@@ -7,8 +7,4 @@
 *.tgz
 *.log
 package-lock.json
-
-*.d.ts
-*.js
 !karma.conf.js
-*.js.map

--- a/clients/client-s3/jest.config.js
+++ b/clients/client-s3/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-s3/jest.config.js
+++ b/clients/client-s3/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+  // filedoesnotexist.spec.ts is added to avoid jest error "Your test suite must contain at least one test."
+  // replace it with **/*.spec.ts once we have a decision on test infrastructure for clients.
+  testMatch: ["filedoesnotexist.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
 };

--- a/clients/client-s3outposts/.gitignore
+++ b/clients/client-s3outposts/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-s3outposts/jest.config.js
+++ b/clients/client-s3outposts/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sagemaker-a2i-runtime/.gitignore
+++ b/clients/client-sagemaker-a2i-runtime/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sagemaker-a2i-runtime/jest.config.js
+++ b/clients/client-sagemaker-a2i-runtime/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sagemaker-edge/.gitignore
+++ b/clients/client-sagemaker-edge/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sagemaker-edge/jest.config.js
+++ b/clients/client-sagemaker-edge/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sagemaker-featurestore-runtime/.gitignore
+++ b/clients/client-sagemaker-featurestore-runtime/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sagemaker-featurestore-runtime/jest.config.js
+++ b/clients/client-sagemaker-featurestore-runtime/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sagemaker-runtime/.gitignore
+++ b/clients/client-sagemaker-runtime/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sagemaker-runtime/jest.config.js
+++ b/clients/client-sagemaker-runtime/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sagemaker/.gitignore
+++ b/clients/client-sagemaker/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sagemaker/jest.config.js
+++ b/clients/client-sagemaker/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-savingsplans/.gitignore
+++ b/clients/client-savingsplans/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-savingsplans/jest.config.js
+++ b/clients/client-savingsplans/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-schemas/.gitignore
+++ b/clients/client-schemas/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-schemas/jest.config.js
+++ b/clients/client-schemas/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-secrets-manager/.gitignore
+++ b/clients/client-secrets-manager/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-secrets-manager/jest.config.js
+++ b/clients/client-secrets-manager/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-securityhub/.gitignore
+++ b/clients/client-securityhub/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-securityhub/jest.config.js
+++ b/clients/client-securityhub/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-serverlessapplicationrepository/.gitignore
+++ b/clients/client-serverlessapplicationrepository/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-serverlessapplicationrepository/jest.config.js
+++ b/clients/client-serverlessapplicationrepository/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-service-catalog-appregistry/.gitignore
+++ b/clients/client-service-catalog-appregistry/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-service-catalog-appregistry/jest.config.js
+++ b/clients/client-service-catalog-appregistry/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-service-catalog/.gitignore
+++ b/clients/client-service-catalog/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-service-catalog/jest.config.js
+++ b/clients/client-service-catalog/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-service-quotas/.gitignore
+++ b/clients/client-service-quotas/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-service-quotas/jest.config.js
+++ b/clients/client-service-quotas/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-servicediscovery/.gitignore
+++ b/clients/client-servicediscovery/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-servicediscovery/jest.config.js
+++ b/clients/client-servicediscovery/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ses/.gitignore
+++ b/clients/client-ses/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ses/jest.config.js
+++ b/clients/client-ses/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sesv2/.gitignore
+++ b/clients/client-sesv2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sesv2/jest.config.js
+++ b/clients/client-sesv2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sfn/.gitignore
+++ b/clients/client-sfn/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sfn/jest.config.js
+++ b/clients/client-sfn/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-shield/.gitignore
+++ b/clients/client-shield/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-shield/jest.config.js
+++ b/clients/client-shield/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-signer/.gitignore
+++ b/clients/client-signer/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-signer/jest.config.js
+++ b/clients/client-signer/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sms/.gitignore
+++ b/clients/client-sms/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sms/jest.config.js
+++ b/clients/client-sms/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-snowball/.gitignore
+++ b/clients/client-snowball/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-snowball/jest.config.js
+++ b/clients/client-snowball/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sns/.gitignore
+++ b/clients/client-sns/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sns/jest.config.js
+++ b/clients/client-sns/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sqs/.gitignore
+++ b/clients/client-sqs/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sqs/jest.config.js
+++ b/clients/client-sqs/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-ssm/.gitignore
+++ b/clients/client-ssm/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-ssm/jest.config.js
+++ b/clients/client-ssm/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sso-admin/.gitignore
+++ b/clients/client-sso-admin/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sso-admin/jest.config.js
+++ b/clients/client-sso-admin/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sso-oidc/.gitignore
+++ b/clients/client-sso-oidc/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sso-oidc/jest.config.js
+++ b/clients/client-sso-oidc/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sso/.gitignore
+++ b/clients/client-sso/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sso/jest.config.js
+++ b/clients/client-sso/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-storage-gateway/.gitignore
+++ b/clients/client-storage-gateway/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-storage-gateway/jest.config.js
+++ b/clients/client-storage-gateway/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-sts/.gitignore
+++ b/clients/client-sts/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-sts/jest.config.js
+++ b/clients/client-sts/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-support/.gitignore
+++ b/clients/client-support/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-support/jest.config.js
+++ b/clients/client-support/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-swf/.gitignore
+++ b/clients/client-swf/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-swf/jest.config.js
+++ b/clients/client-swf/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-synthetics/.gitignore
+++ b/clients/client-synthetics/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-synthetics/jest.config.js
+++ b/clients/client-synthetics/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-textract/.gitignore
+++ b/clients/client-textract/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-textract/jest.config.js
+++ b/clients/client-textract/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-timestream-query/.gitignore
+++ b/clients/client-timestream-query/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-timestream-query/jest.config.js
+++ b/clients/client-timestream-query/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-timestream-write/.gitignore
+++ b/clients/client-timestream-write/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-timestream-write/jest.config.js
+++ b/clients/client-timestream-write/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-transcribe-streaming/.gitignore
+++ b/clients/client-transcribe-streaming/.gitignore
@@ -7,8 +7,4 @@
 *.tgz
 *.log
 package-lock.json
-
-*.d.ts
-*.js
 !jest*.config.js
-*.js.map

--- a/clients/client-transcribe-streaming/jest.config.js
+++ b/clients/client-transcribe-streaming/jest.config.js
@@ -1,13 +1,4 @@
-const base = require("../../jest.config.base.js");
-
 module.exports = {
-  ...base,
-  // Only test cjs dist, avoid testing the package twice
-  testPathIgnorePatterns: ["/node_modules/", "/es/", ".*.integ.spec.js"],
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "/commands/",
-    "/protocols/", // protocols tested in protocol protocol_tests folder
-    "endpoints", // endpoint tested in tests/functional/endpoints
-  ],
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
 };

--- a/clients/client-transcribe-streaming/jest.integ.config.js
+++ b/clients/client-transcribe-streaming/jest.integ.config.js
@@ -1,6 +1,4 @@
-const base = require("../../jest.config.base.js");
-
 module.exports = {
-  ...base,
+  preset: "ts-jest",
   testMatch: ["**/*.integ.spec.ts"],
 };

--- a/clients/client-transcribe/.gitignore
+++ b/clients/client-transcribe/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-transcribe/jest.config.js
+++ b/clients/client-transcribe/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-transfer/.gitignore
+++ b/clients/client-transfer/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-transfer/jest.config.js
+++ b/clients/client-transfer/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-translate/.gitignore
+++ b/clients/client-translate/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-translate/jest.config.js
+++ b/clients/client-translate/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-waf-regional/.gitignore
+++ b/clients/client-waf-regional/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-waf-regional/jest.config.js
+++ b/clients/client-waf-regional/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-waf/.gitignore
+++ b/clients/client-waf/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-waf/jest.config.js
+++ b/clients/client-waf/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-wafv2/.gitignore
+++ b/clients/client-wafv2/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-wafv2/jest.config.js
+++ b/clients/client-wafv2/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-workdocs/.gitignore
+++ b/clients/client-workdocs/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-workdocs/jest.config.js
+++ b/clients/client-workdocs/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-worklink/.gitignore
+++ b/clients/client-worklink/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-worklink/jest.config.js
+++ b/clients/client-worklink/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-workmail/.gitignore
+++ b/clients/client-workmail/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-workmail/jest.config.js
+++ b/clients/client-workmail/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-workmailmessageflow/.gitignore
+++ b/clients/client-workmailmessageflow/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-workmailmessageflow/jest.config.js
+++ b/clients/client-workmailmessageflow/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-workspaces/.gitignore
+++ b/clients/client-workspaces/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-workspaces/jest.config.js
+++ b/clients/client-workspaces/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/clients/client-xray/.gitignore
+++ b/clients/client-xray/.gitignore
@@ -8,6 +8,3 @@
 *.log
 package-lock.json
 
-*.d.ts
-*.js
-*.js.map

--- a/clients/client-xray/jest.config.js
+++ b/clients/client-xray/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+};

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/gitignore
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/gitignore
@@ -7,7 +7,3 @@
 *.tgz
 *.log
 package-lock.json
-
-*.d.ts
-*.js
-*.js.map

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,5 +1,4 @@
 module.exports = {
-  // remove testMatch once we move to ts-jest
   preset: "ts-jest",
   testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
 };


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1618
Alternative to https://github.com/aws/aws-sdk-js-v3/pull/2163

### Description
Generate jest.config.js per client instead of extending from global config

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
