### PR TITLE
chore: move types from `types/` folder to `dist/types`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ codegen/sdk-codegen/smithy-build.json
 
 coverage
 dist
-types
-!packages/types
 
 /verdaccio/*
 !/verdaccio/config.yaml

--- a/clients/client-accessanalyzer/.gitignore
+++ b/clients/client-accessanalyzer/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-accessanalyzer/tsconfig.json
+++ b/clients/client-accessanalyzer/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-acm-pca/.gitignore
+++ b/clients/client-acm-pca/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm-pca/tsconfig.json
+++ b/clients/client-acm-pca/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-acm/.gitignore
+++ b/clients/client-acm/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm/tsconfig.json
+++ b/clients/client-acm/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-alexa-for-business/.gitignore
+++ b/clients/client-alexa-for-business/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-alexa-for-business/tsconfig.json
+++ b/clients/client-alexa-for-business/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-amplify/.gitignore
+++ b/clients/client-amplify/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplify/tsconfig.json
+++ b/clients/client-amplify/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-amplifybackend/.gitignore
+++ b/clients/client-amplifybackend/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplifybackend/tsconfig.json
+++ b/clients/client-amplifybackend/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-api-gateway/.gitignore
+++ b/clients/client-api-gateway/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-api-gateway/tsconfig.json
+++ b/clients/client-api-gateway/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-apigatewaymanagementapi/.gitignore
+++ b/clients/client-apigatewaymanagementapi/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewaymanagementapi/tsconfig.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-apigatewayv2/.gitignore
+++ b/clients/client-apigatewayv2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewayv2/tsconfig.json
+++ b/clients/client-apigatewayv2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-app-mesh/.gitignore
+++ b/clients/client-app-mesh/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-app-mesh/tsconfig.json
+++ b/clients/client-app-mesh/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-appconfig/.gitignore
+++ b/clients/client-appconfig/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appconfig/tsconfig.json
+++ b/clients/client-appconfig/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-appflow/.gitignore
+++ b/clients/client-appflow/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appflow/tsconfig.json
+++ b/clients/client-appflow/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-appintegrations/.gitignore
+++ b/clients/client-appintegrations/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appintegrations/tsconfig.json
+++ b/clients/client-appintegrations/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-application-auto-scaling/.gitignore
+++ b/clients/client-application-auto-scaling/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-auto-scaling/tsconfig.json
+++ b/clients/client-application-auto-scaling/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-application-discovery-service/.gitignore
+++ b/clients/client-application-discovery-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-discovery-service/tsconfig.json
+++ b/clients/client-application-discovery-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-application-insights/.gitignore
+++ b/clients/client-application-insights/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-insights/tsconfig.json
+++ b/clients/client-application-insights/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-appstream/.gitignore
+++ b/clients/client-appstream/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appstream/tsconfig.json
+++ b/clients/client-appstream/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-appsync/.gitignore
+++ b/clients/client-appsync/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appsync/tsconfig.json
+++ b/clients/client-appsync/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-athena/.gitignore
+++ b/clients/client-athena/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-athena/tsconfig.json
+++ b/clients/client-athena/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-auditmanager/.gitignore
+++ b/clients/client-auditmanager/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auditmanager/tsconfig.json
+++ b/clients/client-auditmanager/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-auto-scaling-plans/.gitignore
+++ b/clients/client-auto-scaling-plans/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling-plans/tsconfig.json
+++ b/clients/client-auto-scaling-plans/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-auto-scaling/.gitignore
+++ b/clients/client-auto-scaling/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling/tsconfig.json
+++ b/clients/client-auto-scaling/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-backup/.gitignore
+++ b/clients/client-backup/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-backup/tsconfig.json
+++ b/clients/client-backup/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-batch/.gitignore
+++ b/clients/client-batch/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-batch/tsconfig.json
+++ b/clients/client-batch/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-braket/.gitignore
+++ b/clients/client-braket/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-braket/tsconfig.json
+++ b/clients/client-braket/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-budgets/.gitignore
+++ b/clients/client-budgets/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-budgets/tsconfig.json
+++ b/clients/client-budgets/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-chime/.gitignore
+++ b/clients/client-chime/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-chime/tsconfig.json
+++ b/clients/client-chime/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloud9/.gitignore
+++ b/clients/client-cloud9/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloud9/tsconfig.json
+++ b/clients/client-cloud9/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-clouddirectory/.gitignore
+++ b/clients/client-clouddirectory/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-clouddirectory/tsconfig.json
+++ b/clients/client-clouddirectory/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudformation/.gitignore
+++ b/clients/client-cloudformation/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudformation/tsconfig.json
+++ b/clients/client-cloudformation/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudfront/.gitignore
+++ b/clients/client-cloudfront/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudfront/tsconfig.json
+++ b/clients/client-cloudfront/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudhsm-v2/.gitignore
+++ b/clients/client-cloudhsm-v2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm-v2/tsconfig.json
+++ b/clients/client-cloudhsm-v2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudhsm/.gitignore
+++ b/clients/client-cloudhsm/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm/tsconfig.json
+++ b/clients/client-cloudhsm/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudsearch-domain/.gitignore
+++ b/clients/client-cloudsearch-domain/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch-domain/tsconfig.json
+++ b/clients/client-cloudsearch-domain/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudsearch/.gitignore
+++ b/clients/client-cloudsearch/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch/tsconfig.json
+++ b/clients/client-cloudsearch/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudtrail/.gitignore
+++ b/clients/client-cloudtrail/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudtrail/tsconfig.json
+++ b/clients/client-cloudtrail/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudwatch-events/.gitignore
+++ b/clients/client-cloudwatch-events/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-events/tsconfig.json
+++ b/clients/client-cloudwatch-events/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudwatch-logs/.gitignore
+++ b/clients/client-cloudwatch-logs/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-logs/tsconfig.json
+++ b/clients/client-cloudwatch-logs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cloudwatch/.gitignore
+++ b/clients/client-cloudwatch/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch/tsconfig.json
+++ b/clients/client-cloudwatch/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codeartifact/.gitignore
+++ b/clients/client-codeartifact/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeartifact/tsconfig.json
+++ b/clients/client-codeartifact/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codebuild/.gitignore
+++ b/clients/client-codebuild/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codebuild/tsconfig.json
+++ b/clients/client-codebuild/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codecommit/.gitignore
+++ b/clients/client-codecommit/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codecommit/tsconfig.json
+++ b/clients/client-codecommit/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codedeploy/.gitignore
+++ b/clients/client-codedeploy/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codedeploy/tsconfig.json
+++ b/clients/client-codedeploy/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codeguru-reviewer/.gitignore
+++ b/clients/client-codeguru-reviewer/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguru-reviewer/tsconfig.json
+++ b/clients/client-codeguru-reviewer/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codeguruprofiler/.gitignore
+++ b/clients/client-codeguruprofiler/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguruprofiler/tsconfig.json
+++ b/clients/client-codeguruprofiler/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codepipeline/.gitignore
+++ b/clients/client-codepipeline/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codepipeline/tsconfig.json
+++ b/clients/client-codepipeline/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codestar-connections/.gitignore
+++ b/clients/client-codestar-connections/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-connections/tsconfig.json
+++ b/clients/client-codestar-connections/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codestar-notifications/.gitignore
+++ b/clients/client-codestar-notifications/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-notifications/tsconfig.json
+++ b/clients/client-codestar-notifications/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-codestar/.gitignore
+++ b/clients/client-codestar/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar/tsconfig.json
+++ b/clients/client-codestar/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cognito-identity-provider/.gitignore
+++ b/clients/client-cognito-identity-provider/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity-provider/tsconfig.json
+++ b/clients/client-cognito-identity-provider/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cognito-identity/.gitignore
+++ b/clients/client-cognito-identity/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -18,7 +18,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -14,7 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "dist/types": ["mocha", "node"]
+    "types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -12,9 +12,9 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "types": ["mocha", "node"]
+    "dist/types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-cognito-sync/.gitignore
+++ b/clients/client-cognito-sync/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-sync/tsconfig.json
+++ b/clients/client-cognito-sync/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-comprehend/.gitignore
+++ b/clients/client-comprehend/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehend/tsconfig.json
+++ b/clients/client-comprehend/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-comprehendmedical/.gitignore
+++ b/clients/client-comprehendmedical/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehendmedical/tsconfig.json
+++ b/clients/client-comprehendmedical/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-compute-optimizer/.gitignore
+++ b/clients/client-compute-optimizer/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-compute-optimizer/tsconfig.json
+++ b/clients/client-compute-optimizer/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-config-service/.gitignore
+++ b/clients/client-config-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-config-service/tsconfig.json
+++ b/clients/client-config-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-connect-contact-lens/.gitignore
+++ b/clients/client-connect-contact-lens/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect-contact-lens/tsconfig.json
+++ b/clients/client-connect-contact-lens/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-connect/.gitignore
+++ b/clients/client-connect/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect/tsconfig.json
+++ b/clients/client-connect/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-connectparticipant/.gitignore
+++ b/clients/client-connectparticipant/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connectparticipant/tsconfig.json
+++ b/clients/client-connectparticipant/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cost-and-usage-report-service/.gitignore
+++ b/clients/client-cost-and-usage-report-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-and-usage-report-service/tsconfig.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-cost-explorer/.gitignore
+++ b/clients/client-cost-explorer/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-explorer/tsconfig.json
+++ b/clients/client-cost-explorer/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-customer-profiles/.gitignore
+++ b/clients/client-customer-profiles/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-customer-profiles/tsconfig.json
+++ b/clients/client-customer-profiles/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-data-pipeline/.gitignore
+++ b/clients/client-data-pipeline/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-data-pipeline/tsconfig.json
+++ b/clients/client-data-pipeline/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-database-migration-service/.gitignore
+++ b/clients/client-database-migration-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-database-migration-service/tsconfig.json
+++ b/clients/client-database-migration-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-databrew/.gitignore
+++ b/clients/client-databrew/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-databrew/tsconfig.json
+++ b/clients/client-databrew/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-dataexchange/.gitignore
+++ b/clients/client-dataexchange/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dataexchange/tsconfig.json
+++ b/clients/client-dataexchange/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-datasync/.gitignore
+++ b/clients/client-datasync/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-datasync/tsconfig.json
+++ b/clients/client-datasync/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-dax/.gitignore
+++ b/clients/client-dax/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dax/tsconfig.json
+++ b/clients/client-dax/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-detective/.gitignore
+++ b/clients/client-detective/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-detective/tsconfig.json
+++ b/clients/client-detective/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-device-farm/.gitignore
+++ b/clients/client-device-farm/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-device-farm/tsconfig.json
+++ b/clients/client-device-farm/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-devops-guru/.gitignore
+++ b/clients/client-devops-guru/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-devops-guru/tsconfig.json
+++ b/clients/client-devops-guru/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-direct-connect/.gitignore
+++ b/clients/client-direct-connect/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-direct-connect/tsconfig.json
+++ b/clients/client-direct-connect/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-directory-service/.gitignore
+++ b/clients/client-directory-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-directory-service/tsconfig.json
+++ b/clients/client-directory-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-dlm/.gitignore
+++ b/clients/client-dlm/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dlm/tsconfig.json
+++ b/clients/client-dlm/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-docdb/.gitignore
+++ b/clients/client-docdb/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-docdb/tsconfig.json
+++ b/clients/client-docdb/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-dynamodb-streams/.gitignore
+++ b/clients/client-dynamodb-streams/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb-streams/tsconfig.json
+++ b/clients/client-dynamodb-streams/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-dynamodb/.gitignore
+++ b/clients/client-dynamodb/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb/tsconfig.json
+++ b/clients/client-dynamodb/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ebs/.gitignore
+++ b/clients/client-ebs/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ebs/tsconfig.json
+++ b/clients/client-ebs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ec2-instance-connect/.gitignore
+++ b/clients/client-ec2-instance-connect/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2-instance-connect/tsconfig.json
+++ b/clients/client-ec2-instance-connect/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ec2/.gitignore
+++ b/clients/client-ec2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2/tsconfig.json
+++ b/clients/client-ec2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ecr-public/.gitignore
+++ b/clients/client-ecr-public/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr-public/tsconfig.json
+++ b/clients/client-ecr-public/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ecr/.gitignore
+++ b/clients/client-ecr/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr/tsconfig.json
+++ b/clients/client-ecr/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ecs/.gitignore
+++ b/clients/client-ecs/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecs/tsconfig.json
+++ b/clients/client-ecs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-efs/.gitignore
+++ b/clients/client-efs/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-efs/tsconfig.json
+++ b/clients/client-efs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-eks/.gitignore
+++ b/clients/client-eks/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eks/tsconfig.json
+++ b/clients/client-eks/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-elastic-beanstalk/.gitignore
+++ b/clients/client-elastic-beanstalk/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-beanstalk/tsconfig.json
+++ b/clients/client-elastic-beanstalk/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-elastic-inference/.gitignore
+++ b/clients/client-elastic-inference/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-inference/tsconfig.json
+++ b/clients/client-elastic-inference/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-elastic-load-balancing-v2/.gitignore
+++ b/clients/client-elastic-load-balancing-v2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/tsconfig.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-elastic-load-balancing/.gitignore
+++ b/clients/client-elastic-load-balancing/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing/tsconfig.json
+++ b/clients/client-elastic-load-balancing/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-elastic-transcoder/.gitignore
+++ b/clients/client-elastic-transcoder/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-transcoder/tsconfig.json
+++ b/clients/client-elastic-transcoder/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-elasticache/.gitignore
+++ b/clients/client-elasticache/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticache/tsconfig.json
+++ b/clients/client-elasticache/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-elasticsearch-service/.gitignore
+++ b/clients/client-elasticsearch-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticsearch-service/tsconfig.json
+++ b/clients/client-elasticsearch-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-emr-containers/.gitignore
+++ b/clients/client-emr-containers/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr-containers/tsconfig.json
+++ b/clients/client-emr-containers/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-emr/.gitignore
+++ b/clients/client-emr/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr/tsconfig.json
+++ b/clients/client-emr/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-eventbridge/.gitignore
+++ b/clients/client-eventbridge/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eventbridge/tsconfig.json
+++ b/clients/client-eventbridge/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-firehose/.gitignore
+++ b/clients/client-firehose/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-firehose/tsconfig.json
+++ b/clients/client-firehose/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-fms/.gitignore
+++ b/clients/client-fms/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fms/tsconfig.json
+++ b/clients/client-fms/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-forecast/.gitignore
+++ b/clients/client-forecast/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecast/tsconfig.json
+++ b/clients/client-forecast/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-forecastquery/.gitignore
+++ b/clients/client-forecastquery/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecastquery/tsconfig.json
+++ b/clients/client-forecastquery/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-frauddetector/.gitignore
+++ b/clients/client-frauddetector/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-frauddetector/tsconfig.json
+++ b/clients/client-frauddetector/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-fsx/.gitignore
+++ b/clients/client-fsx/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fsx/tsconfig.json
+++ b/clients/client-fsx/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-gamelift/.gitignore
+++ b/clients/client-gamelift/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-gamelift/tsconfig.json
+++ b/clients/client-gamelift/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-glacier/.gitignore
+++ b/clients/client-glacier/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glacier/tsconfig.json
+++ b/clients/client-glacier/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-global-accelerator/.gitignore
+++ b/clients/client-global-accelerator/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-global-accelerator/tsconfig.json
+++ b/clients/client-global-accelerator/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-glue/.gitignore
+++ b/clients/client-glue/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glue/tsconfig.json
+++ b/clients/client-glue/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-greengrass/.gitignore
+++ b/clients/client-greengrass/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-greengrass/tsconfig.json
+++ b/clients/client-greengrass/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-groundstation/.gitignore
+++ b/clients/client-groundstation/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-groundstation/tsconfig.json
+++ b/clients/client-groundstation/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-guardduty/.gitignore
+++ b/clients/client-guardduty/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-guardduty/tsconfig.json
+++ b/clients/client-guardduty/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-health/.gitignore
+++ b/clients/client-health/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-health/tsconfig.json
+++ b/clients/client-health/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-healthlake/.gitignore
+++ b/clients/client-healthlake/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-healthlake/tsconfig.json
+++ b/clients/client-healthlake/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-honeycode/.gitignore
+++ b/clients/client-honeycode/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-honeycode/tsconfig.json
+++ b/clients/client-honeycode/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iam/.gitignore
+++ b/clients/client-iam/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iam/tsconfig.json
+++ b/clients/client-iam/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-identitystore/.gitignore
+++ b/clients/client-identitystore/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-identitystore/tsconfig.json
+++ b/clients/client-identitystore/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-imagebuilder/.gitignore
+++ b/clients/client-imagebuilder/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-imagebuilder/tsconfig.json
+++ b/clients/client-imagebuilder/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-inspector/.gitignore
+++ b/clients/client-inspector/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-inspector/tsconfig.json
+++ b/clients/client-inspector/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iot-1click-devices-service/.gitignore
+++ b/clients/client-iot-1click-devices-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-devices-service/tsconfig.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iot-1click-projects/.gitignore
+++ b/clients/client-iot-1click-projects/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-projects/tsconfig.json
+++ b/clients/client-iot-1click-projects/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iot-data-plane/.gitignore
+++ b/clients/client-iot-data-plane/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-data-plane/tsconfig.json
+++ b/clients/client-iot-data-plane/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iot-events-data/.gitignore
+++ b/clients/client-iot-events-data/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events-data/tsconfig.json
+++ b/clients/client-iot-events-data/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iot-events/.gitignore
+++ b/clients/client-iot-events/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events/tsconfig.json
+++ b/clients/client-iot-events/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iot-jobs-data-plane/.gitignore
+++ b/clients/client-iot-jobs-data-plane/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-jobs-data-plane/tsconfig.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iot/.gitignore
+++ b/clients/client-iot/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot/tsconfig.json
+++ b/clients/client-iot/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iotanalytics/.gitignore
+++ b/clients/client-iotanalytics/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotanalytics/tsconfig.json
+++ b/clients/client-iotanalytics/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iotsecuretunneling/.gitignore
+++ b/clients/client-iotsecuretunneling/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsecuretunneling/tsconfig.json
+++ b/clients/client-iotsecuretunneling/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iotsitewise/.gitignore
+++ b/clients/client-iotsitewise/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsitewise/tsconfig.json
+++ b/clients/client-iotsitewise/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-iotthingsgraph/.gitignore
+++ b/clients/client-iotthingsgraph/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotthingsgraph/tsconfig.json
+++ b/clients/client-iotthingsgraph/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ivs/.gitignore
+++ b/clients/client-ivs/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ivs/tsconfig.json
+++ b/clients/client-ivs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kafka/.gitignore
+++ b/clients/client-kafka/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kafka/tsconfig.json
+++ b/clients/client-kafka/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kendra/.gitignore
+++ b/clients/client-kendra/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kendra/tsconfig.json
+++ b/clients/client-kendra/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kinesis-analytics-v2/.gitignore
+++ b/clients/client-kinesis-analytics-v2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics-v2/tsconfig.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kinesis-analytics/.gitignore
+++ b/clients/client-kinesis-analytics/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics/tsconfig.json
+++ b/clients/client-kinesis-analytics/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kinesis-video-archived-media/.gitignore
+++ b/clients/client-kinesis-video-archived-media/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-archived-media/tsconfig.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kinesis-video-media/.gitignore
+++ b/clients/client-kinesis-video-media/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-media/tsconfig.json
+++ b/clients/client-kinesis-video-media/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kinesis-video-signaling/.gitignore
+++ b/clients/client-kinesis-video-signaling/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-signaling/tsconfig.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kinesis-video/.gitignore
+++ b/clients/client-kinesis-video/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video/tsconfig.json
+++ b/clients/client-kinesis-video/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kinesis/.gitignore
+++ b/clients/client-kinesis/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis/tsconfig.json
+++ b/clients/client-kinesis/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-kms/.gitignore
+++ b/clients/client-kms/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kms/tsconfig.json
+++ b/clients/client-kms/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-lakeformation/.gitignore
+++ b/clients/client-lakeformation/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lakeformation/tsconfig.json
+++ b/clients/client-lakeformation/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-lambda/.gitignore
+++ b/clients/client-lambda/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lambda/tsconfig.json
+++ b/clients/client-lambda/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-lex-model-building-service/.gitignore
+++ b/clients/client-lex-model-building-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-model-building-service/tsconfig.json
+++ b/clients/client-lex-model-building-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-lex-runtime-service/.gitignore
+++ b/clients/client-lex-runtime-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -17,7 +17,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -14,7 +14,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-runtime-service/tsconfig.json
+++ b/clients/client-lex-runtime-service/tsconfig.json
@@ -14,7 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "dist/types": ["mocha", "node"]
+    "types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-lex-runtime-service/tsconfig.json
+++ b/clients/client-lex-runtime-service/tsconfig.json
@@ -12,9 +12,9 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "types": ["mocha", "node"]
+    "dist/types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-license-manager/.gitignore
+++ b/clients/client-license-manager/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-license-manager/tsconfig.json
+++ b/clients/client-license-manager/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-lightsail/.gitignore
+++ b/clients/client-lightsail/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lightsail/tsconfig.json
+++ b/clients/client-lightsail/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-lookoutvision/.gitignore
+++ b/clients/client-lookoutvision/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutvision/tsconfig.json
+++ b/clients/client-lookoutvision/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-machine-learning/.gitignore
+++ b/clients/client-machine-learning/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-machine-learning/tsconfig.json
+++ b/clients/client-machine-learning/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-macie/.gitignore
+++ b/clients/client-macie/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie/tsconfig.json
+++ b/clients/client-macie/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-macie2/.gitignore
+++ b/clients/client-macie2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie2/tsconfig.json
+++ b/clients/client-macie2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-managedblockchain/.gitignore
+++ b/clients/client-managedblockchain/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-managedblockchain/tsconfig.json
+++ b/clients/client-managedblockchain/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-marketplace-catalog/.gitignore
+++ b/clients/client-marketplace-catalog/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-catalog/tsconfig.json
+++ b/clients/client-marketplace-catalog/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-marketplace-commerce-analytics/.gitignore
+++ b/clients/client-marketplace-commerce-analytics/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-commerce-analytics/tsconfig.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-marketplace-entitlement-service/.gitignore
+++ b/clients/client-marketplace-entitlement-service/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-entitlement-service/tsconfig.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-marketplace-metering/.gitignore
+++ b/clients/client-marketplace-metering/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-metering/tsconfig.json
+++ b/clients/client-marketplace-metering/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mediaconnect/.gitignore
+++ b/clients/client-mediaconnect/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconnect/tsconfig.json
+++ b/clients/client-mediaconnect/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mediaconvert/.gitignore
+++ b/clients/client-mediaconvert/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconvert/tsconfig.json
+++ b/clients/client-mediaconvert/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-medialive/.gitignore
+++ b/clients/client-medialive/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-medialive/tsconfig.json
+++ b/clients/client-medialive/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mediapackage-vod/.gitignore
+++ b/clients/client-mediapackage-vod/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage-vod/tsconfig.json
+++ b/clients/client-mediapackage-vod/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mediapackage/.gitignore
+++ b/clients/client-mediapackage/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage/tsconfig.json
+++ b/clients/client-mediapackage/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mediastore-data/.gitignore
+++ b/clients/client-mediastore-data/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -17,7 +17,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -14,7 +14,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore-data/tsconfig.json
+++ b/clients/client-mediastore-data/tsconfig.json
@@ -14,7 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "dist/types": ["mocha"]
+    "types": ["mocha"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-mediastore-data/tsconfig.json
+++ b/clients/client-mediastore-data/tsconfig.json
@@ -12,9 +12,9 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "types": ["mocha"]
+    "dist/types": ["mocha"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-mediastore/.gitignore
+++ b/clients/client-mediastore/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore/tsconfig.json
+++ b/clients/client-mediastore/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mediatailor/.gitignore
+++ b/clients/client-mediatailor/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediatailor/tsconfig.json
+++ b/clients/client-mediatailor/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-migration-hub/.gitignore
+++ b/clients/client-migration-hub/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migration-hub/tsconfig.json
+++ b/clients/client-migration-hub/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-migrationhub-config/.gitignore
+++ b/clients/client-migrationhub-config/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migrationhub-config/tsconfig.json
+++ b/clients/client-migrationhub-config/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mobile/.gitignore
+++ b/clients/client-mobile/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mobile/tsconfig.json
+++ b/clients/client-mobile/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mq/.gitignore
+++ b/clients/client-mq/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mq/tsconfig.json
+++ b/clients/client-mq/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-mturk/.gitignore
+++ b/clients/client-mturk/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mturk/tsconfig.json
+++ b/clients/client-mturk/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-neptune/.gitignore
+++ b/clients/client-neptune/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-neptune/tsconfig.json
+++ b/clients/client-neptune/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-network-firewall/.gitignore
+++ b/clients/client-network-firewall/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-network-firewall/tsconfig.json
+++ b/clients/client-network-firewall/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-networkmanager/.gitignore
+++ b/clients/client-networkmanager/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-networkmanager/tsconfig.json
+++ b/clients/client-networkmanager/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-opsworks/.gitignore
+++ b/clients/client-opsworks/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworks/tsconfig.json
+++ b/clients/client-opsworks/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-opsworkscm/.gitignore
+++ b/clients/client-opsworkscm/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworkscm/tsconfig.json
+++ b/clients/client-opsworkscm/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-organizations/.gitignore
+++ b/clients/client-organizations/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-organizations/tsconfig.json
+++ b/clients/client-organizations/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-outposts/.gitignore
+++ b/clients/client-outposts/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-outposts/tsconfig.json
+++ b/clients/client-outposts/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-personalize-events/.gitignore
+++ b/clients/client-personalize-events/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-events/tsconfig.json
+++ b/clients/client-personalize-events/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-personalize-runtime/.gitignore
+++ b/clients/client-personalize-runtime/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-runtime/tsconfig.json
+++ b/clients/client-personalize-runtime/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-personalize/.gitignore
+++ b/clients/client-personalize/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize/tsconfig.json
+++ b/clients/client-personalize/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-pi/.gitignore
+++ b/clients/client-pi/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pi/tsconfig.json
+++ b/clients/client-pi/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-pinpoint-email/.gitignore
+++ b/clients/client-pinpoint-email/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-email/tsconfig.json
+++ b/clients/client-pinpoint-email/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-pinpoint-sms-voice/.gitignore
+++ b/clients/client-pinpoint-sms-voice/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice/tsconfig.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-pinpoint/.gitignore
+++ b/clients/client-pinpoint/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint/tsconfig.json
+++ b/clients/client-pinpoint/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-polly/.gitignore
+++ b/clients/client-polly/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-polly/tsconfig.json
+++ b/clients/client-polly/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-pricing/.gitignore
+++ b/clients/client-pricing/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pricing/tsconfig.json
+++ b/clients/client-pricing/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-qldb-session/.gitignore
+++ b/clients/client-qldb-session/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb-session/tsconfig.json
+++ b/clients/client-qldb-session/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-qldb/.gitignore
+++ b/clients/client-qldb/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb/tsconfig.json
+++ b/clients/client-qldb/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-quicksight/.gitignore
+++ b/clients/client-quicksight/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-quicksight/tsconfig.json
+++ b/clients/client-quicksight/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ram/.gitignore
+++ b/clients/client-ram/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ram/tsconfig.json
+++ b/clients/client-ram/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-rds-data/.gitignore
+++ b/clients/client-rds-data/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds-data/tsconfig.json
+++ b/clients/client-rds-data/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-rds/.gitignore
+++ b/clients/client-rds/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds/tsconfig.json
+++ b/clients/client-rds/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-redshift-data/.gitignore
+++ b/clients/client-redshift-data/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift-data/tsconfig.json
+++ b/clients/client-redshift-data/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-redshift/.gitignore
+++ b/clients/client-redshift/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift/tsconfig.json
+++ b/clients/client-redshift/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-rekognition/.gitignore
+++ b/clients/client-rekognition/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rekognition/tsconfig.json
+++ b/clients/client-rekognition/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-resource-groups-tagging-api/.gitignore
+++ b/clients/client-resource-groups-tagging-api/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups-tagging-api/tsconfig.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-resource-groups/.gitignore
+++ b/clients/client-resource-groups/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups/tsconfig.json
+++ b/clients/client-resource-groups/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-robomaker/.gitignore
+++ b/clients/client-robomaker/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-robomaker/tsconfig.json
+++ b/clients/client-robomaker/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-route-53-domains/.gitignore
+++ b/clients/client-route-53-domains/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53-domains/tsconfig.json
+++ b/clients/client-route-53-domains/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-route-53/.gitignore
+++ b/clients/client-route-53/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53/tsconfig.json
+++ b/clients/client-route-53/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-route53resolver/.gitignore
+++ b/clients/client-route53resolver/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route53resolver/tsconfig.json
+++ b/clients/client-route53resolver/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-s3-control/.gitignore
+++ b/clients/client-s3-control/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -17,7 +17,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -14,7 +14,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3-control/tsconfig.json
+++ b/clients/client-s3-control/tsconfig.json
@@ -14,7 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "dist/types": ["mocha", "node"]
+    "types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-s3-control/tsconfig.json
+++ b/clients/client-s3-control/tsconfig.json
@@ -12,9 +12,9 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "types": ["mocha", "node"]
+    "dist/types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-s3/.gitignore
+++ b/clients/client-s3/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -18,7 +18,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -14,7 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "dist/types": ["mocha", "node"]
+    "types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -12,9 +12,9 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
-    "types": ["mocha", "node"]
+    "dist/types": ["mocha", "node"]
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "./protocols/*.ts", "./e2e/*.ts", "./endpoints.ts"],

--- a/clients/client-s3outposts/.gitignore
+++ b/clients/client-s3outposts/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3outposts/tsconfig.json
+++ b/clients/client-s3outposts/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sagemaker-a2i-runtime/.gitignore
+++ b/clients/client-sagemaker-a2i-runtime/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sagemaker-edge/.gitignore
+++ b/clients/client-sagemaker-edge/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-edge/tsconfig.json
+++ b/clients/client-sagemaker-edge/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sagemaker-featurestore-runtime/.gitignore
+++ b/clients/client-sagemaker-featurestore-runtime/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sagemaker-runtime/.gitignore
+++ b/clients/client-sagemaker-runtime/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-runtime/tsconfig.json
+++ b/clients/client-sagemaker-runtime/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sagemaker/.gitignore
+++ b/clients/client-sagemaker/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker/tsconfig.json
+++ b/clients/client-sagemaker/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-savingsplans/.gitignore
+++ b/clients/client-savingsplans/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-savingsplans/tsconfig.json
+++ b/clients/client-savingsplans/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-schemas/.gitignore
+++ b/clients/client-schemas/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-schemas/tsconfig.json
+++ b/clients/client-schemas/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-secrets-manager/.gitignore
+++ b/clients/client-secrets-manager/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-secrets-manager/tsconfig.json
+++ b/clients/client-secrets-manager/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-securityhub/.gitignore
+++ b/clients/client-securityhub/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-securityhub/tsconfig.json
+++ b/clients/client-securityhub/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-serverlessapplicationrepository/.gitignore
+++ b/clients/client-serverlessapplicationrepository/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-serverlessapplicationrepository/tsconfig.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-service-catalog-appregistry/.gitignore
+++ b/clients/client-service-catalog-appregistry/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/tsconfig.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-service-catalog/.gitignore
+++ b/clients/client-service-catalog/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog/tsconfig.json
+++ b/clients/client-service-catalog/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-service-quotas/.gitignore
+++ b/clients/client-service-quotas/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-quotas/tsconfig.json
+++ b/clients/client-service-quotas/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-servicediscovery/.gitignore
+++ b/clients/client-servicediscovery/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-servicediscovery/tsconfig.json
+++ b/clients/client-servicediscovery/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ses/.gitignore
+++ b/clients/client-ses/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ses/tsconfig.json
+++ b/clients/client-ses/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sesv2/.gitignore
+++ b/clients/client-sesv2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sesv2/tsconfig.json
+++ b/clients/client-sesv2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sfn/.gitignore
+++ b/clients/client-sfn/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sfn/tsconfig.json
+++ b/clients/client-sfn/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-shield/.gitignore
+++ b/clients/client-shield/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-shield/tsconfig.json
+++ b/clients/client-shield/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-signer/.gitignore
+++ b/clients/client-signer/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-signer/tsconfig.json
+++ b/clients/client-signer/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sms/.gitignore
+++ b/clients/client-sms/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sms/tsconfig.json
+++ b/clients/client-sms/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-snowball/.gitignore
+++ b/clients/client-snowball/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-snowball/tsconfig.json
+++ b/clients/client-snowball/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sns/.gitignore
+++ b/clients/client-sns/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sns/tsconfig.json
+++ b/clients/client-sns/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sqs/.gitignore
+++ b/clients/client-sqs/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sqs/tsconfig.json
+++ b/clients/client-sqs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-ssm/.gitignore
+++ b/clients/client-ssm/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm/tsconfig.json
+++ b/clients/client-ssm/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sso-admin/.gitignore
+++ b/clients/client-sso-admin/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso-admin/tsconfig.json
+++ b/clients/client-sso-admin/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sso-oidc/.gitignore
+++ b/clients/client-sso-oidc/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso-oidc/tsconfig.json
+++ b/clients/client-sso-oidc/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sso/.gitignore
+++ b/clients/client-sso/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso/tsconfig.json
+++ b/clients/client-sso/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-storage-gateway/.gitignore
+++ b/clients/client-storage-gateway/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-storage-gateway/tsconfig.json
+++ b/clients/client-storage-gateway/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-sts/.gitignore
+++ b/clients/client-sts/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sts/tsconfig.json
+++ b/clients/client-sts/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-support/.gitignore
+++ b/clients/client-support/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-support/tsconfig.json
+++ b/clients/client-support/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-swf/.gitignore
+++ b/clients/client-swf/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-swf/tsconfig.json
+++ b/clients/client-swf/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-synthetics/.gitignore
+++ b/clients/client-synthetics/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-synthetics/tsconfig.json
+++ b/clients/client-synthetics/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-textract/.gitignore
+++ b/clients/client-textract/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-textract/tsconfig.json
+++ b/clients/client-textract/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-timestream-query/.gitignore
+++ b/clients/client-timestream-query/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-query/tsconfig.json
+++ b/clients/client-timestream-query/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-timestream-write/.gitignore
+++ b/clients/client-timestream-write/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-write/tsconfig.json
+++ b/clients/client-timestream-write/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-transcribe-streaming/.gitignore
+++ b/clients/client-transcribe-streaming/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -18,7 +18,7 @@
     "postbuild": "cp test/speech.wav dist/cjs/test"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-transcribe-streaming/tsconfig.json
+++ b/clients/client-transcribe-streaming/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-transcribe/.gitignore
+++ b/clients/client-transcribe/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transcribe/tsconfig.json
+++ b/clients/client-transcribe/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-transfer/.gitignore
+++ b/clients/client-transfer/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transfer/tsconfig.json
+++ b/clients/client-transfer/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-translate/.gitignore
+++ b/clients/client-translate/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-translate/tsconfig.json
+++ b/clients/client-translate/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-waf-regional/.gitignore
+++ b/clients/client-waf-regional/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf-regional/tsconfig.json
+++ b/clients/client-waf-regional/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-waf/.gitignore
+++ b/clients/client-waf/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf/tsconfig.json
+++ b/clients/client-waf/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-wafv2/.gitignore
+++ b/clients/client-wafv2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-wafv2/tsconfig.json
+++ b/clients/client-wafv2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-workdocs/.gitignore
+++ b/clients/client-workdocs/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workdocs/tsconfig.json
+++ b/clients/client-workdocs/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-worklink/.gitignore
+++ b/clients/client-worklink/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-worklink/tsconfig.json
+++ b/clients/client-worklink/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-workmail/.gitignore
+++ b/clients/client-workmail/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmail/tsconfig.json
+++ b/clients/client-workmail/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-workmailmessageflow/.gitignore
+++ b/clients/client-workmailmessageflow/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmailmessageflow/tsconfig.json
+++ b/clients/client-workmailmessageflow/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-workspaces/.gitignore
+++ b/clients/client-workspaces/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workspaces/tsconfig.json
+++ b/clients/client-workspaces/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/clients/client-xray/.gitignore
+++ b/clients/client-xray/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-xray/tsconfig.json
+++ b/clients/client-xray/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/gitignore
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -10,7 +10,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "engines": {

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -4,7 +4,7 @@
   "description": "The document client simplifies working with items in Amazon DynamoDB by abstracting away the notion of attribute values.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "prepublishOnly": "yarn build:cjs && yarn build:es",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/lib/lib-dynamodb/tsconfig.cjs.json
+++ b/lib/lib-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "declaration": true,
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -4,7 +4,7 @@
   "description": "Storage higher order operation",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "prepublishOnly": "yarn build:cjs && yarn build:es",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -10,7 +10,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "engines": {

--- a/lib/lib-storage/tsconfig.cjs.json
+++ b/lib/lib-storage/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "declaration": true,
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/lib/lib-storage/tsconfig.es.json
+++ b/lib/lib-storage/tsconfig.es.json
@@ -5,7 +5,7 @@
     "sourceMap": false,
     "declaration": true,
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -4,7 +4,7 @@
   "description": "A simple abort controller library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "prepublishOnly": "yarn build:cjs && yarn build:es",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -10,7 +10,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/body-checksum-browser/tsconfig.es.json
+++ b/packages/body-checksum-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/body-checksum-node/tsconfig.es.json
+++ b/packages/body-checksum-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-blob-reader-native/tsconfig.es.json
+++ b/packages/chunked-blob-reader-native/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-blob-reader/tsconfig.es.json
+++ b/packages/chunked-blob-reader/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-stream-reader-node/tsconfig.es.json
+++ b/packages/chunked-stream-reader-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,

--- a/packages/client-documentation-generator/tsconfig.es.json
+++ b/packages/client-documentation-generator/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "experimentalDecorators": true,

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/config-resolver/tsconfig.es.json
+++ b/packages/config-resolver/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/core-packages-documentation-generator/tsconfig.cjs.json
+++ b/packages/core-packages-documentation-generator/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,

--- a/packages/core-packages-documentation-generator/tsconfig.es.json
+++ b/packages/core-packages-documentation-generator/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "experimentalDecorators": true,

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "sideEffects": false,
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noUnusedLocals": true,

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "noUnusedLocals": true,

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -32,7 +32,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -33,7 +33,7 @@
     "nock": "^13.0.2",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -33,7 +33,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -41,7 +41,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "typesVersions": {
     "<4.0": {
       "types/*": [

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -12,7 +12,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-node/tsconfig.es.json
+++ b/packages/credential-provider-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -34,7 +34,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -35,7 +35,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-sso/tsconfig.cjs.json
+++ b/packages/credential-provider-sso/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-sso/tsconfig.es.json
+++ b/packages/credential-provider-sso/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-handler-node/tsconfig.es.json
+++ b/packages/eventstream-handler-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-marshaller/tsconfig.es.json
+++ b/packages/eventstream-marshaller/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-browser/tsconfig.es.json
+++ b/packages/eventstream-serde-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable", "DOM"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-config-resolver/tsconfig.es.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-node/tsconfig.es.json
+++ b/packages/eventstream-serde-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-universal/tsconfig.es.json
+++ b/packages/eventstream-serde-universal/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.6.1",
     "@aws-sdk/querystring-builder": "3.6.1",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage && karma start karma.conf.js"
   },
   "author": {

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/fetch-http-handler/tsconfig.es.json
+++ b/packages/fetch-http-handler/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "karma start karma.conf.js"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-blob-browser/tsconfig.es.json
+++ b/packages/hash-blob-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-node/tsconfig.es.json
+++ b/packages/hash-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-stream-node/tsconfig.es.json
+++ b/packages/hash-stream-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/invalid-dependency/tsconfig.es.json
+++ b/packages/invalid-dependency/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -22,7 +22,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "dependencies": {
     "tslib": "^1.8.0"
   },

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/md5-js/tsconfig.es.json
+++ b/packages/md5-js/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-apply-body-checksum/tsconfig.es.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-bucket-endpoint/tsconfig.es.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-content-length/tsconfig.es.json
+++ b/packages/middleware-content-length/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-eventstream/tsconfig.es.json
+++ b/packages/middleware-eventstream/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-expect-continue/tsconfig.es.json
+++ b/packages/middleware-expect-continue/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-header-default/tsconfig.es.json
+++ b/packages/middleware-header-default/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-host-header/tsconfig.es.json
+++ b/packages/middleware-host-header/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-location-constraint/tsconfig.es.json
+++ b/packages/middleware-location-constraint/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "dependencies": {
     "@aws-sdk/types": "3.6.1",
     "tslib": "^1.8.0"

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-retry/tsconfig.es.json
+++ b/packages/middleware-retry/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-api-gateway/tsconfig.es.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-ec2/tsconfig.es.json
+++ b/packages/middleware-sdk-ec2/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-glacier/tsconfig.es.json
+++ b/packages/middleware-sdk-glacier/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-machinelearning/tsconfig.es.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-rds/tsconfig.es.json
+++ b/packages/middleware-sdk-rds/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-route53/tsconfig.es.json
+++ b/packages/middleware-sdk-route53/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3-control/tsconfig.es.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3/tsconfig.es.json
+++ b/packages/middleware-sdk-s3/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-sqs/tsconfig.es.json
+++ b/packages/middleware-sdk-sqs/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -3,7 +3,7 @@
   "version": "3.8.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -8,7 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "prepublishOnly": "yarn build",
     "pretest": "yarn build",
     "test": "jest --passWithNoTests"

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": ".",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-serde/tsconfig.es.json
+++ b/packages/middleware-serde/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-signing/tsconfig.es.json
+++ b/packages/middleware-signing/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-ssec/tsconfig.es.json
+++ b/packages/middleware-ssec/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "dependencies": {
     "tslib": "^1.8.0"
   },

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-stack/tsconfig.es.json
+++ b/packages/middleware-stack/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-user-agent/tsconfig.es.json
+++ b/packages/middleware-user-agent/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "dependencies": {
     "@aws-sdk/property-provider": "3.8.0",
     "@aws-sdk/shared-ini-file-loader": "3.8.0",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/node-config-provider/tsconfig.es.json
+++ b/packages/node-config-provider/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },
   "author": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "dependencies": {
     "@aws-sdk/abort-controller": "3.6.1",
     "@aws-sdk/protocol-http": "3.6.1",

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/node-http-handler/tsconfig.es.json
+++ b/packages/node-http-handler/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/polly-request-presigner/tsconfig.cjs.json
+++ b/packages/polly-request-presigner/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/polly-request-presigner/tsconfig.es.json
+++ b/packages/polly-request-presigner/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/property-provider/tsconfig.es.json
+++ b/packages/property-provider/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "email": "",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/protocol-http/tsconfig.es.json
+++ b/packages/protocol-http/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/querystring-builder/tsconfig.es.json
+++ b/packages/querystring-builder/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/querystring-parser/tsconfig.es.json
+++ b/packages/querystring-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/s3-presigned-post/tsconfig.cjs.json
+++ b/packages/s3-presigned-post/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/s3-request-presigner/tsconfig.es.json
+++ b/packages/s3-request-presigner/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/service-error-classification/tsconfig.es.json
+++ b/packages/service-error-classification/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.collection", "es2015.iterable"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/sha256-tree-hash/tsconfig.es.json
+++ b/packages/sha256-tree-hash/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/signature-v4/.gitignore
+++ b/packages/signature-v4/.gitignore
@@ -3,7 +3,6 @@
 /dist/
 /coverage/
 /docs/
-/types/
 *.tsbuildinfo
 *.tgz
 *.log

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -4,7 +4,7 @@
   "description": "A standalone implementation of the AWS Signature V4 request signing algorithm",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "prepublishOnly": "yarn build",
     "pretest": "yarn build",
     "test": "jest --coverage"

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noUnusedLocals": true,

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "noUnusedLocals": true,

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/smithy-client/tsconfig.es.json
+++ b/packages/smithy-client/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,7 @@
   "version": "3.6.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "description": "Types for the AWS SDK",
   "devDependencies": {
     "typescript": "~4.1.2"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },
   "author": {

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/types/tsconfig.es.json
+++ b/packages/types/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/url-parser-native/package.json
+++ b/packages/url-parser-native/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/url-parser-native/package.json
+++ b/packages/url-parser-native/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/url-parser-native/tsconfig.cjs.json
+++ b/packages/url-parser-native/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/url-parser-native/tsconfig.es.json
+++ b/packages/url-parser-native/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/url-parser/tsconfig.cjs.json
+++ b/packages/url-parser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/url-parser/tsconfig.es.json
+++ b/packages/url-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -26,7 +26,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-arn-parser/tsconfig.es.json
+++ b/packages/util-arn-parser/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -26,7 +26,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "typesVersions": {
     "<4.0": {
       "types/*": [

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-base64-browser/tsconfig.es.json
+++ b/packages/util-base64-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -27,7 +27,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-base64-node/tsconfig.es.json
+++ b/packages/util-base64-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-body-length-browser/tsconfig.es.json
+++ b/packages/util-body-length-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -18,7 +18,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-body-length-node/tsconfig.es.json
+++ b/packages/util-body-length-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -26,7 +26,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-create-request/tsconfig.es.json
+++ b/packages/util-create-request/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-format-url/tsconfig.es.json
+++ b/packages/util-format-url/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -25,7 +25,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-locate-window/tsconfig.es.json
+++ b/packages/util-locate-window/tsconfig.es.json
@@ -6,7 +6,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "lib": ["dom", "es5", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-uri-escape/tsconfig.es.json
+++ b/packages/util-uri-escape/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-user-agent-browser/tsconfig.es.json
+++ b/packages/util-user-agent-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-user-agent-node/tsconfig.es.json
+++ b/packages/util-user-agent-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -25,7 +25,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "typesVersions": {
     "<4.0": {
       "types/*": [

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-utf8-browser/tsconfig.es.json
+++ b/packages/util-utf8-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -30,7 +30,7 @@
   "jest": {
     "testEnvironment": "node"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-utf8-node/tsconfig.es.json
+++ b/packages/util-utf8-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -17,7 +17,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-waiter/tsconfig.cjs.json
+++ b/packages/util-waiter/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-waiter/tsconfig.es.json
+++ b/packages/util-waiter/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts types types/ts3.4",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/xml-builder/tsconfig.es.json
+++ b/packages/xml-builder/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/protocol_tests/aws-ec2/.gitignore
+++ b/protocol_tests/aws-ec2/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-ec2/tsconfig.json
+++ b/protocol_tests/aws-ec2/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/protocol_tests/aws-json/.gitignore
+++ b/protocol_tests/aws-json/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json/tsconfig.json
+++ b/protocol_tests/aws-json/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/protocol_tests/aws-query/.gitignore
+++ b/protocol_tests/aws-query/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-query/tsconfig.json
+++ b/protocol_tests/aws-query/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/protocol_tests/aws-restjson/.gitignore
+++ b/protocol_tests/aws-restjson/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restjson/tsconfig.json
+++ b/protocol_tests/aws-restjson/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {

--- a/protocol_tests/aws-restxml/.gitignore
+++ b/protocol_tests/aws-restxml/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /coverage/
 /docs/
-/types/
 /dist/
 *.tsbuildinfo
 *.tgz

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -16,7 +16,7 @@
     "postbuild": "downlevel-dts types types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "downlevel-dts types types/ts3.4"
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restxml/tsconfig.json
+++ b/protocol_tests/aws-restxml/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./types",
+    "declarationDir": "./dist/types",
     "outDir": "dist/cjs"
   },
   "typedocOptions": {


### PR DESCRIPTION
### Issue
Follow-up to:
* https://github.com/aws/aws-sdk-js-v3/pull/1938
* https://github.com/aws/aws-sdk-js-v3/pull/1942
* test failures in https://github.com/aws/aws-sdk-js-v3/pull/2172

### Description
This PR moves types to dist folder for the following reasons so that only `dist` folder can be ignored in:
* `.gitignore` - ensuring that types folder in rest of the code is not ignored by git, fixed in https://github.com/aws/aws-sdk-js-v3/pull/1942
* jest config - types doesn't have to be explicitly ignored in https://github.com/aws/aws-sdk-js-v3/pull/2172

The dist folder already contains `cjs` and `es` folders which contains commonjs and es output. the `types` folder will now contain types. 

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
