### PR TITLE
feat(credential-provider-web-identity): add fromTokenFile credentials provider 

### DIFF
--- a/packages/credential-provider-web-identity/LICENSE
+++ b/packages/credential-provider-web-identity/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/credential-provider-web-identity/README.md
+++ b/packages/credential-provider-web-identity/README.md
@@ -5,42 +5,29 @@
 
 ## AWS Credential Provider for Node.js - AssumeRole
 
-This module includes functions which get credentials by calling STS assumeRole\* APIs.
+This module includes functions which get credentials by calling STS assumeRoleWithWebIdentity API.
 
 ## fromTokenFile
 
 The function `fromTokenFile` returns `CredentialProvider` that reads credentials as follows:
 
-- Reads file location of where the OIDC token is stored from either environment or config file parameters.
-- Reads IAM role wanting to be assumed from either environment or config file paramters.
-- Reads optional role session name to be used to distinguish sessions from either environment or config file paramters.
+- Reads file location of where the OIDC token is stored from either provided option `webIdentityTokenFile` or environment variable `AWS_WEB_IDENTITY_TOKEN_FILE`.
+- Reads IAM role wanting to be assumed from either provided option `roleArn` or environment variable `AWS_ROLE_ARN`.
+- Reads optional role session name to be used to distinguish sessions from provided option `roleSessionName` or environment variable `AWS_ROLE_SESSION_NAME`.
   If session name is not defined, it comes up with a role session name.
 - Reads OIDC token from file on disk.
 - Calls sts:AssumeRoleWithWebIdentity via `roleAssumerWithWebIdentity` option to get credentials.
-- Uses credentials of source_profile to assume the role specified if specified.
 
-| **Environment Variable**    | **Config Variable**     | **Required** | **Description**                                   |
-| --------------------------- | ----------------------- | ------------ | ------------------------------------------------- |
-| AWS_WEB_IDENTITY_TOKEN_FILE | web_identity_token_file | true         | File location of where the `OIDC` token is stored |
-| AWS_IAM_ROLE_ARN            | role_arn                | true         | The IAM role wanting to be assumed                |
-| AWS_IAM_ROLE_SESSION_NAME   | role_session_name       | false        | The IAM session name used to distinguish sessions |
+| **Configuration Key** | **Environment Variable**    | **Required** | **Description**                                   |
+| --------------------- | --------------------------- | ------------ | ------------------------------------------------- |
+| webIdentityTokenFile  | AWS_WEB_IDENTITY_TOKEN_FILE | true         | File location of where the `OIDC` token is stored |
+| roleArn               | AWS_IAM_ROLE_ARN            | true         | The IAM role wanting to be assumed                |
+| roleSessionName       | AWS_IAM_ROLE_SESSION_NAME   | false        | The IAM session name used to distinguish sessions |
 
 ### Supported configuration
 
 The following options are supported:
 
-- `profile` - The configuration profile to use. If not specified, the provider
-  will use the value in the `AWS_PROFILE` environment variable or `default` by
-  default.
-- `filepath` - The path to the shared credentials file. If not specified, the
-  provider will use the value in the `AWS_SHARED_CREDENTIALS_FILE` environment
-  variable or `~/.aws/credentials` by default.
-- `configFilepath` - The path to the shared config file. If not specified, the
-  provider will use the value in the `AWS_CONFIG_FILE` environment variable or
-  `~/.aws/config` by default.
-- `roleAssumer` - A function that assumes a role and returns a promise
-  fulfilled with credentials for the assumed role. You may call `sts:assumeRole`
-  API within this function.
 - `roleAssumerWithWebIdentity` - A function that assumes a role with web identity
   and returns a promise fulfilled with credentials for the assumed role. You may call
   `sts:assumeRoleWithWebIdentity` API within this function.
@@ -90,12 +77,17 @@ $ node
 }
 ```
 
-#### Values in configuration files
+#### Values in configuration keys
 
-The values can be defined in configuration files as follows:
+The values can be defined in configuration keys as follows:
 
-```
-[sample-profile]
-web_identity_token_file = /temp/token
-role_session_name = arn:aws:iam::123456789012:role/example-role-arn
+```js
+...
+const client = new FooClient({
+  credentials: fromTokenFile({
+    webIdentityTokenFile: "/temp/token",
+    roleArn: "arn:aws:iam::123456789012:role/example-role-arn",
+    roleAssumerWithWebIdentity
+  });
+});
 ```

--- a/packages/credential-provider-web-identity/README.md
+++ b/packages/credential-provider-web-identity/README.md
@@ -1,0 +1,101 @@
+# @aws-sdk/credential-provider-web-identity
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-web-identity/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-web-identity)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-web-identity.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-web-identity)
+
+## AWS Credential Provider for Node.js - AssumeRole
+
+This module includes functions which get credentials by calling STS assumeRole\* APIs.
+
+## fromTokenFile
+
+The function `fromTokenFile` returns `CredentialProvider` that reads credentials as follows:
+
+- Reads file location of where the OIDC token is stored from either environment or config file parameters.
+- Reads IAM role wanting to be assumed from either environment or config file paramters.
+- Reads optional role session name to be used to distinguish sessions from either environment or config file paramters.
+  If session name is not defined, it comes up with a role session name.
+- Reads OIDC token from file on disk.
+- Calls sts:AssumeRoleWithWebIdentity via `roleAssumerWithWebIdentity` option to get credentials.
+- Uses credentials of source_profile to assume the role specified if specified.
+
+| **Environment Variable**    | **Config Variable**     | **Required** | **Description**                                   |
+| --------------------------- | ----------------------- | ------------ | ------------------------------------------------- |
+| AWS_WEB_IDENTITY_TOKEN_FILE | web_identity_token_file | true         | File location of where the `OIDC` token is stored |
+| AWS_IAM_ROLE_ARN            | role_arn                | true         | The IAM role wanting to be assumed                |
+| AWS_IAM_ROLE_SESSION_NAME   | role_session_name       | false        | The IAM session name used to distinguish sessions |
+
+### Supported configuration
+
+The following options are supported:
+
+- `profile` - The configuration profile to use. If not specified, the provider
+  will use the value in the `AWS_PROFILE` environment variable or `default` by
+  default.
+- `filepath` - The path to the shared credentials file. If not specified, the
+  provider will use the value in the `AWS_SHARED_CREDENTIALS_FILE` environment
+  variable or `~/.aws/credentials` by default.
+- `configFilepath` - The path to the shared config file. If not specified, the
+  provider will use the value in the `AWS_CONFIG_FILE` environment variable or
+  `~/.aws/config` by default.
+- `roleAssumer` - A function that assumes a role and returns a promise
+  fulfilled with credentials for the assumed role. You may call `sts:assumeRole`
+  API within this function.
+- `roleAssumerWithWebIdentity` - A function that assumes a role with web identity
+  and returns a promise fulfilled with credentials for the assumed role. You may call
+  `sts:assumeRoleWithWebIdentity` API within this function.
+
+### Examples
+
+A basic example of using fromTokenFile:
+
+```js
+import { STSClient, AssumeRoleWithWebIdentityCommand } from "@aws-sdk/client-sts";
+import { fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
+
+const stsClient = new STSClient({});
+
+const roleAssumerWithWebIdentity = async (params) => {
+  const { Credentials } = await stsClient.send(
+    new AssumeRoleWithWebIdentityCommand(params)
+  );
+  if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+    throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
+  }
+  return {
+    accessKeyId: Credentials.AccessKeyId,
+    secretAccessKey: Credentials.SecretAccessKey,
+    sessionToken: Credentials.SessionToken,
+    expiration: Credentials.Expiration,
+  };
+};
+
+const client = new FooClient({
+  credentials: fromTokenFile({
+    roleAssumerWithWebIdentity
+  });
+});
+```
+
+#### Values in environment variables
+
+The values can be defined in environment variables as follows:
+
+```console
+$ node
+> Object.fromEntries(Object.entries(process.env).filter(([key, value]) => key.startsWith("AWS_")));
+{
+  AWS_WEB_IDENTITY_TOKEN_FILE: '/temp/token',
+  AWS_ROLE_ARN: 'arn:aws:iam::123456789012:role/example-role-arn'
+}
+```
+
+#### Values in configuration files
+
+The values can be defined in configuration files as follows:
+
+```
+[sample-profile]
+web_identity_token_file = /temp/token
+role_session_name = arn:aws:iam::123456789012:role/example-role-arn
+```

--- a/packages/credential-provider-web-identity/jest.config.js
+++ b/packages/credential-provider-web-identity/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -22,7 +22,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/property-provider": "3.8.0",
     "@aws-sdk/types": "3.6.1",
     "tslib": "^1.8.0"

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -22,10 +22,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/credential-provider-ini": "3.8.0",
     "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/property-provider": "3.8.0",
-    "@aws-sdk/shared-ini-file-loader": "3.8.0",
     "@aws-sdk/types": "3.6.1",
     "tslib": "^1.8.0"
   },

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-sdk/credential-provider-assume-role",
+  "name": "@aws-sdk/credential-provider-web-identity",
   "version": "3.0.0",
   "description": "AWS credential provider that calls STS assumeRole for temporary AWS credentials",
   "main": "./dist/cjs/index.js",
@@ -44,10 +44,10 @@
       ]
     }
   },
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-assume-role",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-web-identity",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
-    "directory": "packages/credential-provider-assume-role"
+    "directory": "packages/credential-provider-web-identity"
   }
 }

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@aws-sdk/credential-provider-assume-role",
+  "version": "3.0.0",
+  "description": "AWS credential provider that calls STS assumeRole for temporary AWS credentials",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "scripts": {
+    "prepublishOnly": "yarn build:cjs && yarn build:es",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build": "yarn build:es && yarn build:cjs",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
+    "test": "jest"
+  },
+  "keywords": [
+    "aws",
+    "credentials"
+  ],
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/credential-provider-ini": "3.8.0",
+    "@aws-sdk/client-sts": "3.9.0",
+    "@aws-sdk/property-provider": "3.8.0",
+    "@aws-sdk/shared-ini-file-loader": "3.8.0",
+    "@aws-sdk/types": "3.6.1",
+    "tslib": "^1.8.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.4",
+    "@types/node": "^10.0.0",
+    "jest": "^26.1.0",
+    "typescript": "~4.1.2"
+  },
+  "types": "./dist/types/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "types/*": [
+        "types/ts3.4/*"
+      ]
+    }
+  },
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-assume-role",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/credential-provider-assume-role"
+  }
+}

--- a/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
@@ -1,5 +1,4 @@
-import { AssumeRoleCommandInput, AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
-import { getMasterProfileName, parseKnownFiles } from "@aws-sdk/credential-provider-ini";
+import { AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
 import { ProviderError } from "@aws-sdk/property-provider";
 import { Credentials } from "@aws-sdk/types";
 import { readFileSync } from "fs";
@@ -11,7 +10,6 @@ const ENV_ROLE_ARN = "AWS_ROLE_ARN";
 const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
 
 jest.mock("fs");
-jest.mock("@aws-sdk/credential-provider-ini");
 
 const MOCK_CREDS = {
   accessKeyId: "accessKeyId",
@@ -34,13 +32,18 @@ describe(fromTokenFile.name, () => {
     jest.restoreAllMocks();
   });
 
-  const testRoleAssumerWithWebIdentityNotDefined = async (errorPrefix: string) => {
+  const testRoleAssumerWithWebIdentityNotDefined = async (init: FromTokenFileInit, roleArn: string) => {
     try {
       // @ts-ignore An argument for 'init' was not provided.
-      await fromTokenFile({})();
+      await fromTokenFile(init)();
       fail(`Expected error to be thrown`);
     } catch (error) {
-      expect(error).toEqual(new ProviderError(`${errorPrefix}, but no role assumption callback was provided.`, false));
+      expect(error).toEqual(
+        new ProviderError(
+          `Role Arn '${roleArn}' needs to be assumed with web identity, but no role assumption callback was provided.`,
+          false
+        )
+      );
     }
   };
 
@@ -51,7 +54,7 @@ describe(fromTokenFile.name, () => {
     });
     try {
       await fromTokenFile(init)();
-      fail(`Exepcted error to be thrown`);
+      fail(`Expected error to be thrown`);
     } catch (error) {
       expect(error).toEqual(readFileSyncError);
     }
@@ -65,11 +68,12 @@ describe(fromTokenFile.name, () => {
     expect(readFileSync).toHaveBeenCalledWith(mockTokenFile, { encoding: "ascii" });
   };
 
-  const testRandomValueForRoleSessionName = async () => {
+  const testRandomValueForRoleSessionName = async (init: FromTokenFileInit) => {
     const mockDateNow = Date.now();
     const spyDateNow = jest.spyOn(Date, "now").mockReturnValueOnce(mockDateNow);
 
     const creds = await fromTokenFile({
+      ...init,
       roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
         expect(params.RoleSessionName).toEqual(`aws-sdk-js-session-${mockDateNow}`);
         return MOCK_CREDS;
@@ -97,9 +101,7 @@ describe(fromTokenFile.name, () => {
     });
 
     it("throws if roleAssumerWithWebIdentity is not defined", async () => {
-      return testRoleAssumerWithWebIdentityNotDefined(
-        `Role Arn '${process.env[ENV_ROLE_ARN]}' needs to be assumed with web identity`
-      );
+      return testRoleAssumerWithWebIdentityNotDefined({}, process.env[ENV_ROLE_ARN]);
     });
 
     it("throws if ENV_TOKEN_FILE read from disk failed", async () => {
@@ -123,192 +125,58 @@ describe(fromTokenFile.name, () => {
 
     it("generates a random value for RoleSessionName if not available", async () => {
       delete process.env[ENV_ROLE_SESSION_NAME];
-      return testRandomValueForRoleSessionName();
+      return testRandomValueForRoleSessionName({});
     });
   });
 
-  describe("reads config from shared ini", () => {
+  describe("reads config from configuration keys", () => {
     const original_ENV_TOKEN_FILE = process.env[ENV_TOKEN_FILE];
-    const masterProfileName = "masterProfileName";
+    const original_ENV_ROLE_ARN = process.env[ENV_ROLE_ARN];
+    const original_ENV_ROLE_SESSION_NAME = process.env[ENV_ROLE_SESSION_NAME];
 
     beforeAll(() => {
       delete process.env[ENV_TOKEN_FILE];
+      delete process.env[ENV_ROLE_ARN];
+      delete process.env[ENV_ROLE_SESSION_NAME];
     });
 
     afterAll(() => {
       process.env[ENV_TOKEN_FILE] = original_ENV_TOKEN_FILE;
+      process.env[ENV_ROLE_ARN] = original_ENV_ROLE_ARN;
+      process.env[ENV_ROLE_SESSION_NAME] = original_ENV_ROLE_SESSION_NAME;
     });
 
-    beforeEach(() => {
-      (getMasterProfileName as jest.Mock).mockReturnValue(masterProfileName);
+    it("throws if roleAssumerWithWebIdentity is not defined", async () => {
+      return testRoleAssumerWithWebIdentityNotDefined({ roleArn: mockRoleArn }, mockRoleArn);
     });
 
-    describe("without source_profile", () => {
-      beforeEach(() => {
-        (parseKnownFiles as jest.Mock).mockResolvedValue({
-          [masterProfileName]: {
-            web_identity_token_file: mockTokenFile,
-            role_arn: mockRoleArn,
-            role_session_name: mockRoleSessionName,
-          },
-        });
-      });
-
-      it("throws if roleAssumerWithWebIdentity is not defined", async () => {
-        return testRoleAssumerWithWebIdentityNotDefined(
-          `Profile '${masterProfileName}' requires a role to be assumed with web identity`
-        );
-      });
-
-      it("throws if web_identity_token_file read from disk failed", async () => {
-        return testReadFileSyncError({
-          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
-            return MOCK_CREDS;
-          },
-        });
-      });
-
-      it("passes values to roleAssumerWithWebIdentity", async () => {
-        return testRoleAssumerWithWebIdentitySuccess({
-          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
-            expect(params.WebIdentityToken).toEqual(mockTokenValue);
-            expect(params.RoleArn).toEqual(mockRoleArn);
-            expect(params.RoleSessionName).toEqual(mockRoleSessionName);
-            return MOCK_CREDS;
-          },
-        });
-      });
-
-      it("generates a random value for RoleSessionName if not available", async () => {
-        (parseKnownFiles as jest.Mock).mockResolvedValue({
-          [masterProfileName]: {
-            web_identity_token_file: mockTokenFile,
-            role_arn: mockRoleArn,
-          },
-        });
-        return testRandomValueForRoleSessionName();
+    it("throws if web_identity_token_file read from disk failed", async () => {
+      return testReadFileSyncError({
+        webIdentityTokenFile: mockTokenFile,
+        roleArn: mockRoleArn,
+        roleSessionName: mockRoleSessionName,
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+          return MOCK_CREDS;
+        },
       });
     });
 
-    describe("with source_profile", () => {
-      const MOCK_SOURCE_CREDS = {
-        accessKeyId: "accessKeyIdSource",
-        secretAccessKey: "secretAccessKeySource",
-        sessionToken: "sessionTokenSource",
-      };
-
-      const sourceProfileName = "sourceProfileName";
-      const mockMasterRoleArn = "mockMasterRoleArn";
-      const mockMasterRoleSessionName = "mockMasterRoleSessionName";
-
-      beforeEach(() => {
-        (parseKnownFiles as jest.Mock).mockResolvedValue({
-          [sourceProfileName]: {
-            web_identity_token_file: mockTokenFile,
-            role_arn: mockRoleArn,
-            role_session_name: mockRoleSessionName,
-          },
-          [masterProfileName]: {
-            source_profile: sourceProfileName,
-            role_arn: mockMasterRoleArn,
-            role_session_name: mockMasterRoleSessionName,
-          },
-        });
+    it("passes values to roleAssumerWithWebIdentity", async () => {
+      return testRoleAssumerWithWebIdentitySuccess({
+        webIdentityTokenFile: mockTokenFile,
+        roleArn: mockRoleArn,
+        roleSessionName: mockRoleSessionName,
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+          expect(params.WebIdentityToken).toEqual(mockTokenValue);
+          expect(params.RoleArn).toEqual(mockRoleArn);
+          expect(params.RoleSessionName).toEqual(mockRoleSessionName);
+          return MOCK_CREDS;
+        },
       });
+    });
 
-      it("throws if roleAssumer is not defined", async () => {
-        try {
-          // @ts-ignore An argument for 'init' was not provided.
-          await fromTokenFile({})();
-          fail(`Expected error to be thrown`);
-        } catch (error) {
-          expect(error).toEqual(
-            new ProviderError(
-              `Profile '${masterProfileName}' requires a role to be assumed, but no role assumption callback was provided.`,
-              false
-            )
-          );
-        }
-      });
-
-      it("throws if roleAssumerWithWebIdentity is not defined", async () => {
-        try {
-          // @ts-ignore An argument for 'init' was not provided.
-          await fromTokenFile({
-            roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
-              return MOCK_CREDS;
-            },
-          })();
-          fail(`Expected error to be thrown`);
-        } catch (error) {
-          expect(error).toEqual(
-            new ProviderError(
-              `Profile '${sourceProfileName}' requires a role to be assumed with web identity, but no role assumption callback was provided.`,
-              false
-            )
-          );
-        }
-      });
-
-      it("throws if web_identity_token_file read from disk failed", async () => {
-        return testReadFileSyncError({
-          roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
-            return MOCK_CREDS;
-          },
-          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
-            return MOCK_SOURCE_CREDS;
-          },
-        });
-      });
-
-      it("passes values to roleAssumerWithWebIdentity", async () => {
-        return testRoleAssumerWithWebIdentitySuccess({
-          roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
-            expect(sourceCreds).toEqual(MOCK_SOURCE_CREDS);
-            expect(params.RoleArn).toEqual(mockMasterRoleArn);
-            expect(params.RoleSessionName).toEqual(mockMasterRoleSessionName);
-            return MOCK_CREDS;
-          },
-          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
-            expect(params.WebIdentityToken).toEqual(mockTokenValue);
-            expect(params.RoleArn).toEqual(mockRoleArn);
-            expect(params.RoleSessionName).toEqual(mockRoleSessionName);
-            return MOCK_SOURCE_CREDS;
-          },
-        });
-      });
-
-      it("generates a random value for RoleSessionName if not available", async () => {
-        (parseKnownFiles as jest.Mock).mockResolvedValue({
-          [sourceProfileName]: {
-            web_identity_token_file: mockTokenFile,
-            role_arn: mockRoleArn,
-          },
-          [masterProfileName]: {
-            source_profile: sourceProfileName,
-            role_arn: mockMasterRoleArn,
-          },
-        });
-        const mockDateNowFirst = Date.now();
-        const mockDateNowSecond = mockDateNowFirst + 1;
-        const spyDateNow = jest
-          .spyOn(Date, "now")
-          .mockReturnValueOnce(mockDateNowFirst)
-          .mockReturnValueOnce(mockDateNowSecond);
-
-        const creds = await fromTokenFile({
-          roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
-            expect(params.RoleSessionName).toEqual(`aws-sdk-js-session-${mockDateNowFirst}`);
-            return MOCK_CREDS;
-          },
-          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
-            expect(params.RoleSessionName).toEqual(`aws-sdk-js-session-${mockDateNowSecond}`);
-            return MOCK_SOURCE_CREDS;
-          },
-        })();
-        expect(creds).toEqual(MOCK_CREDS);
-        expect(spyDateNow).toHaveBeenCalledTimes(2);
-      });
+    it("generates a random value for RoleSessionName if not available", async () => {
+      return testRandomValueForRoleSessionName({ webIdentityTokenFile: mockTokenFile, roleArn: mockRoleArn });
     });
   });
 });

--- a/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
@@ -1,0 +1,314 @@
+import { AssumeRoleCommandInput, AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
+import { getMasterProfileName, parseKnownFiles } from "@aws-sdk/credential-provider-ini";
+import { ProviderError } from "@aws-sdk/property-provider";
+import { Credentials } from "@aws-sdk/types";
+import { readFileSync } from "fs";
+
+import { fromTokenFile, FromTokenFileInit } from "./fromTokenFile";
+
+const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
+const ENV_ROLE_ARN = "AWS_ROLE_ARN";
+const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
+
+jest.mock("fs");
+jest.mock("@aws-sdk/credential-provider-ini");
+
+const MOCK_CREDS = {
+  accessKeyId: "accessKeyId",
+  secretAccessKey: "secretAccessKey",
+  sessionToken: "sessionToken",
+};
+
+const mockTokenFile = "mockTokenFile";
+const mockTokenValue = "exampletoken";
+const mockRoleArn = "mockRoleArn";
+const mockRoleSessionName = "mockRoleSessionName";
+
+describe(fromTokenFile.name, () => {
+  beforeEach(() => {
+    (readFileSync as jest.Mock).mockReturnValue(mockTokenValue);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  const testRoleAssumerWithWebIdentityNotDefined = async (errorPrefix: string) => {
+    try {
+      // @ts-ignore An argument for 'init' was not provided.
+      await fromTokenFile({})();
+      fail(`Expected error to be thrown`);
+    } catch (error) {
+      expect(error).toEqual(new ProviderError(`${errorPrefix}, but no role assumption callback was provided.`, false));
+    }
+  };
+
+  const testReadFileSyncError = async (init: FromTokenFileInit) => {
+    const readFileSyncError = new Error("readFileSyncError");
+    (readFileSync as jest.Mock).mockImplementation(() => {
+      throw readFileSyncError;
+    });
+    try {
+      await fromTokenFile(init)();
+      fail(`Exepcted error to be thrown`);
+    } catch (error) {
+      expect(error).toEqual(readFileSyncError);
+    }
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+  };
+
+  const testRoleAssumerWithWebIdentitySuccess = async (init: FromTokenFileInit) => {
+    const creds = await fromTokenFile(init)();
+    expect(creds).toEqual(MOCK_CREDS);
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+    expect(readFileSync).toHaveBeenCalledWith(mockTokenFile, { encoding: "ascii" });
+  };
+
+  const testRandomValueForRoleSessionName = async () => {
+    const mockDateNow = Date.now();
+    const spyDateNow = jest.spyOn(Date, "now").mockReturnValueOnce(mockDateNow);
+
+    const creds = await fromTokenFile({
+      roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+        expect(params.RoleSessionName).toEqual(`aws-sdk-js-session-${mockDateNow}`);
+        return MOCK_CREDS;
+      },
+    })();
+    expect(creds).toEqual(MOCK_CREDS);
+    expect(spyDateNow).toHaveBeenCalledTimes(1);
+  };
+
+  describe("reads config from env", () => {
+    const original_ENV_TOKEN_FILE = process.env[ENV_TOKEN_FILE];
+    const original_ENV_ROLE_ARN = process.env[ENV_ROLE_ARN];
+    const original_ENV_ROLE_SESSION_NAME = process.env[ENV_ROLE_SESSION_NAME];
+
+    beforeEach(() => {
+      process.env[ENV_TOKEN_FILE] = mockTokenFile;
+      process.env[ENV_ROLE_ARN] = mockRoleArn;
+      process.env[ENV_ROLE_SESSION_NAME] = mockRoleSessionName;
+    });
+
+    afterAll(() => {
+      process.env[ENV_TOKEN_FILE] = original_ENV_TOKEN_FILE;
+      process.env[ENV_ROLE_ARN] = original_ENV_ROLE_ARN;
+      process.env[ENV_ROLE_SESSION_NAME] = original_ENV_ROLE_SESSION_NAME;
+    });
+
+    it("throws if roleAssumerWithWebIdentity is not defined", async () => {
+      return testRoleAssumerWithWebIdentityNotDefined(
+        `Role Arn '${process.env[ENV_ROLE_ARN]}' needs to be assumed with web identity`
+      );
+    });
+
+    it("throws if ENV_TOKEN_FILE read from disk failed", async () => {
+      return testReadFileSyncError({
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+          return MOCK_CREDS;
+        },
+      });
+    });
+
+    it("passes values to roleAssumerWithWebIdentity", async () => {
+      return testRoleAssumerWithWebIdentitySuccess({
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+          expect(params.WebIdentityToken).toEqual(mockTokenValue);
+          expect(params.RoleArn).toEqual(mockRoleArn);
+          expect(params.RoleSessionName).toEqual(mockRoleSessionName);
+          return MOCK_CREDS;
+        },
+      });
+    });
+
+    it("generates a random value for RoleSessionName if not available", async () => {
+      delete process.env[ENV_ROLE_SESSION_NAME];
+      return testRandomValueForRoleSessionName();
+    });
+  });
+
+  describe("reads config from shared ini", () => {
+    const original_ENV_TOKEN_FILE = process.env[ENV_TOKEN_FILE];
+    const masterProfileName = "masterProfileName";
+
+    beforeAll(() => {
+      delete process.env[ENV_TOKEN_FILE];
+    });
+
+    afterAll(() => {
+      process.env[ENV_TOKEN_FILE] = original_ENV_TOKEN_FILE;
+    });
+
+    beforeEach(() => {
+      (getMasterProfileName as jest.Mock).mockReturnValue(masterProfileName);
+    });
+
+    describe("without source_profile", () => {
+      beforeEach(() => {
+        (parseKnownFiles as jest.Mock).mockResolvedValue({
+          [masterProfileName]: {
+            web_identity_token_file: mockTokenFile,
+            role_arn: mockRoleArn,
+            role_session_name: mockRoleSessionName,
+          },
+        });
+      });
+
+      it("throws if roleAssumerWithWebIdentity is not defined", async () => {
+        return testRoleAssumerWithWebIdentityNotDefined(
+          `Profile '${masterProfileName}' requires a role to be assumed with web identity`
+        );
+      });
+
+      it("throws if web_identity_token_file read from disk failed", async () => {
+        return testReadFileSyncError({
+          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+            return MOCK_CREDS;
+          },
+        });
+      });
+
+      it("passes values to roleAssumerWithWebIdentity", async () => {
+        return testRoleAssumerWithWebIdentitySuccess({
+          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+            expect(params.WebIdentityToken).toEqual(mockTokenValue);
+            expect(params.RoleArn).toEqual(mockRoleArn);
+            expect(params.RoleSessionName).toEqual(mockRoleSessionName);
+            return MOCK_CREDS;
+          },
+        });
+      });
+
+      it("generates a random value for RoleSessionName if not available", async () => {
+        (parseKnownFiles as jest.Mock).mockResolvedValue({
+          [masterProfileName]: {
+            web_identity_token_file: mockTokenFile,
+            role_arn: mockRoleArn,
+          },
+        });
+        return testRandomValueForRoleSessionName();
+      });
+    });
+
+    describe("with source_profile", () => {
+      const MOCK_SOURCE_CREDS = {
+        accessKeyId: "accessKeyIdSource",
+        secretAccessKey: "secretAccessKeySource",
+        sessionToken: "sessionTokenSource",
+      };
+
+      const sourceProfileName = "sourceProfileName";
+      const mockMasterRoleArn = "mockMasterRoleArn";
+      const mockMasterRoleSessionName = "mockMasterRoleSessionName";
+
+      beforeEach(() => {
+        (parseKnownFiles as jest.Mock).mockResolvedValue({
+          [sourceProfileName]: {
+            web_identity_token_file: mockTokenFile,
+            role_arn: mockRoleArn,
+            role_session_name: mockRoleSessionName,
+          },
+          [masterProfileName]: {
+            source_profile: sourceProfileName,
+            role_arn: mockMasterRoleArn,
+            role_session_name: mockMasterRoleSessionName,
+          },
+        });
+      });
+
+      it("throws if roleAssumer is not defined", async () => {
+        try {
+          // @ts-ignore An argument for 'init' was not provided.
+          await fromTokenFile({})();
+          fail(`Expected error to be thrown`);
+        } catch (error) {
+          expect(error).toEqual(
+            new ProviderError(
+              `Profile '${masterProfileName}' requires a role to be assumed, but no role assumption callback was provided.`,
+              false
+            )
+          );
+        }
+      });
+
+      it("throws if roleAssumerWithWebIdentity is not defined", async () => {
+        try {
+          // @ts-ignore An argument for 'init' was not provided.
+          await fromTokenFile({
+            roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
+              return MOCK_CREDS;
+            },
+          })();
+          fail(`Expected error to be thrown`);
+        } catch (error) {
+          expect(error).toEqual(
+            new ProviderError(
+              `Profile '${sourceProfileName}' requires a role to be assumed with web identity, but no role assumption callback was provided.`,
+              false
+            )
+          );
+        }
+      });
+
+      it("throws if web_identity_token_file read from disk failed", async () => {
+        return testReadFileSyncError({
+          roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
+            return MOCK_CREDS;
+          },
+          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+            return MOCK_SOURCE_CREDS;
+          },
+        });
+      });
+
+      it("passes values to roleAssumerWithWebIdentity", async () => {
+        return testRoleAssumerWithWebIdentitySuccess({
+          roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
+            expect(sourceCreds).toEqual(MOCK_SOURCE_CREDS);
+            expect(params.RoleArn).toEqual(mockMasterRoleArn);
+            expect(params.RoleSessionName).toEqual(mockMasterRoleSessionName);
+            return MOCK_CREDS;
+          },
+          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+            expect(params.WebIdentityToken).toEqual(mockTokenValue);
+            expect(params.RoleArn).toEqual(mockRoleArn);
+            expect(params.RoleSessionName).toEqual(mockRoleSessionName);
+            return MOCK_SOURCE_CREDS;
+          },
+        });
+      });
+
+      it("generates a random value for RoleSessionName if not available", async () => {
+        (parseKnownFiles as jest.Mock).mockResolvedValue({
+          [sourceProfileName]: {
+            web_identity_token_file: mockTokenFile,
+            role_arn: mockRoleArn,
+          },
+          [masterProfileName]: {
+            source_profile: sourceProfileName,
+            role_arn: mockMasterRoleArn,
+          },
+        });
+        const mockDateNowFirst = Date.now();
+        const mockDateNowSecond = mockDateNowFirst + 1;
+        const spyDateNow = jest
+          .spyOn(Date, "now")
+          .mockReturnValueOnce(mockDateNowFirst)
+          .mockReturnValueOnce(mockDateNowSecond);
+
+        const creds = await fromTokenFile({
+          roleAssumer: async (sourceCreds: Credentials, params: AssumeRoleCommandInput) => {
+            expect(params.RoleSessionName).toEqual(`aws-sdk-js-session-${mockDateNowFirst}`);
+            return MOCK_CREDS;
+          },
+          roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+            expect(params.RoleSessionName).toEqual(`aws-sdk-js-session-${mockDateNowSecond}`);
+            return MOCK_SOURCE_CREDS;
+          },
+        })();
+        expect(creds).toEqual(MOCK_CREDS);
+        expect(spyDateNow).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
@@ -1,9 +1,7 @@
-import { AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
 import { ProviderError } from "@aws-sdk/property-provider";
-import { Credentials } from "@aws-sdk/types";
 import { readFileSync } from "fs";
 
-import { fromTokenFile, FromTokenFileInit } from "./fromTokenFile";
+import { AssumeRoleWithWebIdentityParams, fromTokenFile, FromTokenFileInit } from "./fromTokenFile";
 
 const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 const ENV_ROLE_ARN = "AWS_ROLE_ARN";
@@ -74,7 +72,7 @@ describe(fromTokenFile.name, () => {
 
     const creds = await fromTokenFile({
       ...init,
-      roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+      roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityParams) => {
         expect(params.RoleSessionName).toEqual(`aws-sdk-js-session-${mockDateNow}`);
         return MOCK_CREDS;
       },
@@ -106,7 +104,7 @@ describe(fromTokenFile.name, () => {
 
     it("throws if ENV_TOKEN_FILE read from disk failed", async () => {
       return testReadFileSyncError({
-        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityParams) => {
           return MOCK_CREDS;
         },
       });
@@ -114,7 +112,7 @@ describe(fromTokenFile.name, () => {
 
     it("passes values to roleAssumerWithWebIdentity", async () => {
       return testRoleAssumerWithWebIdentitySuccess({
-        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityParams) => {
           expect(params.WebIdentityToken).toEqual(mockTokenValue);
           expect(params.RoleArn).toEqual(mockRoleArn);
           expect(params.RoleSessionName).toEqual(mockRoleSessionName);
@@ -155,7 +153,7 @@ describe(fromTokenFile.name, () => {
         webIdentityTokenFile: mockTokenFile,
         roleArn: mockRoleArn,
         roleSessionName: mockRoleSessionName,
-        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityParams) => {
           return MOCK_CREDS;
         },
       });
@@ -166,7 +164,7 @@ describe(fromTokenFile.name, () => {
         webIdentityTokenFile: mockTokenFile,
         roleArn: mockRoleArn,
         roleSessionName: mockRoleSessionName,
-        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityCommandInput) => {
+        roleAssumerWithWebIdentity: async (params: AssumeRoleWithWebIdentityParams) => {
           expect(params.WebIdentityToken).toEqual(mockTokenValue);
           expect(params.RoleArn).toEqual(mockRoleArn);
           expect(params.RoleSessionName).toEqual(mockRoleSessionName);

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -1,4 +1,3 @@
-import { AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
 import { ProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { readFileSync } from "fs";
@@ -7,6 +6,30 @@ const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 const ENV_ROLE_ARN = "AWS_ROLE_ARN";
 const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
 
+export interface AssumeRoleWithWebIdentityParams {
+  /**
+   * <p>The Amazon Resource Name (ARN) of the role that the caller is assuming.</p>
+   */
+  RoleArn: string;
+  /**
+   * <p>An identifier for the assumed role session. Typically, you pass the name or identifier
+   *          that is associated with the user who is using your application. That way, the temporary
+   *          security credentials that your application will use are associated with that user. This
+   *          session name is included as part of the ARN and assumed role ID in the
+   *             <code>AssumedRoleUser</code> response element.</p>
+   *          <p>The regex used to validate this parameter is a string of characters
+   *     consisting of upper- and lower-case alphanumeric characters with no spaces. You can
+   *     also include underscores or any of the following characters: =,.@-</p>
+   */
+  RoleSessionName: string;
+  /**
+   * <p>The OAuth 2.0 access token or OpenID Connect ID token that is provided by the identity
+   *          provider. Your application must get this token by authenticating the user who is using your
+   *          application with a web identity provider before the application makes an
+   *             <code>AssumeRoleWithWebIdentity</code> call. </p>
+   */
+  WebIdentityToken: string;
+}
 export interface FromTokenFileInit {
   /**
    * File location of where the `OIDC` token is stored.
@@ -30,7 +53,7 @@ export interface FromTokenFileInit {
    * @param sourceCreds The credentials with which to assume a role.
    * @param params
    */
-  roleAssumerWithWebIdentity?: (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
+  roleAssumerWithWebIdentity?: (params: AssumeRoleWithWebIdentityParams) => Promise<Credentials>;
 }
 
 /**

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -72,7 +72,7 @@ export const fromTokenFile = (init: FromTokenFileInit): CredentialProvider => as
 
   return roleAssumerWithWebIdentity({
     WebIdentityToken: readFileSync(webIdentityTokenFile ?? process.env[ENV_TOKEN_FILE]!, { encoding: "ascii" }),
-    RoleArn: roleArn ?? process.env[ENV_ROLE_ARN],
+    RoleArn: roleArn ?? process.env[ENV_ROLE_ARN]!,
     RoleSessionName: roleSessionName ?? process.env[ENV_ROLE_SESSION_NAME] ?? `aws-sdk-js-session-${Date.now()}`,
   });
 };

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -1,0 +1,126 @@
+import { AssumeRoleCommandInput, AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
+import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/credential-provider-ini";
+import { ProviderError } from "@aws-sdk/property-provider";
+import { ParsedIniData, Profile } from "@aws-sdk/shared-ini-file-loader";
+import { CredentialProvider, Credentials } from "@aws-sdk/types";
+import { readFileSync } from "fs";
+
+const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
+const ENV_ROLE_ARN = "AWS_ROLE_ARN";
+const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
+
+export interface FromTokenFileInit extends SourceProfileInit {
+  /**
+   * A function that assumes a role with web identity and returns a promise fulfilled with
+   * credentials for the assumed role.
+   *
+   * @param sourceCreds The credentials with which to assume a role.
+   * @param params
+   */
+  roleAssumerWithWebIdentity: (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
+  /**
+   * A function that assumes a role and returns a promise fulfilled with
+   * credentials for the assumed role.
+   *
+   * @param sourceCreds The credentials with which to assume a role.
+   * @param params
+   */
+  roleAssumer?: (sourceCreds: Credentials, params: AssumeRoleCommandInput) => Promise<Credentials>;
+}
+
+/**
+ * Represents OIDC credentials from a file on disk.
+ */
+export const fromTokenFile = (init: FromTokenFileInit): CredentialProvider => async () => {
+  if (process.env[ENV_TOKEN_FILE] && process.env[ENV_ROLE_ARN]) {
+    return resolveCredentialsFromEnv(init);
+  }
+  const profiles = await parseKnownFiles(init);
+  return resolveCredentialsFromIni(getMasterProfileName(init), profiles, init);
+};
+
+const resolveCredentialsFromEnv = async (options: FromTokenFileInit) => {
+  if (!options.roleAssumerWithWebIdentity) {
+    throw new ProviderError(
+      `Role Arn '${process.env[ENV_ROLE_ARN]}' needs to be assumed with web identity,` +
+        ` but no role assumption callback was provided.`,
+      false
+    );
+  }
+  return options.roleAssumerWithWebIdentity({
+    WebIdentityToken: readFileSync(process.env[ENV_TOKEN_FILE]!, { encoding: "ascii" }),
+    RoleArn: process.env[ENV_ROLE_ARN],
+    RoleSessionName: process.env[ENV_ROLE_SESSION_NAME] || `aws-sdk-js-session-${Date.now()}`,
+  });
+};
+
+const resolveCredentialsFromIni = async (
+  profileName: string,
+  profiles: ParsedIniData,
+  options: FromTokenFileInit,
+  visitedProfiles: { [profileName: string]: true } = {}
+): Promise<Credentials> => {
+  const data = profiles[profileName];
+
+  if (isAssumeRoleSourceProfile(data)) {
+    const {
+      role_arn: RoleArn,
+      role_session_name: RoleSessionName = `aws-sdk-js-session-${Date.now()}`,
+      source_profile,
+    } = data;
+
+    if (!options.roleAssumer) {
+      throw new ProviderError(
+        `Profile '${profileName}' requires a role to be assumed,` + ` but no role assumption callback was provided.`,
+        false
+      );
+    }
+
+    if (source_profile in visitedProfiles) {
+      throw new ProviderError(
+        `Detected a cycle attempting to resolve credentials for profile` +
+          ` ${getMasterProfileName(options)}. Profiles visited: ` +
+          Object.keys(visitedProfiles).join(", "),
+        false
+      );
+    }
+
+    const sourceCreds = resolveCredentialsFromIni(source_profile, profiles, options, {
+      ...visitedProfiles,
+      [source_profile]: true,
+    });
+
+    return options.roleAssumer(await sourceCreds, { RoleArn, RoleSessionName });
+  } else {
+    const {
+      web_identity_token_file,
+      role_arn: RoleArn,
+      role_session_name: RoleSessionName = `aws-sdk-js-session-${Date.now()}`,
+    } = data;
+
+    if (!options.roleAssumerWithWebIdentity) {
+      throw new ProviderError(
+        `Profile '${profileName}' requires a role to be assumed with web identity,` +
+          ` but no role assumption callback was provided.`,
+        false
+      );
+    }
+
+    const WebIdentityToken = readFileSync(web_identity_token_file!, { encoding: "ascii" });
+    return options.roleAssumerWithWebIdentity({ WebIdentityToken, RoleArn, RoleSessionName });
+  }
+};
+
+interface AssumeRoleSourceProfile extends Profile {
+  role_arn: string;
+  source_profile: string;
+}
+
+const isAssumeRoleSourceProfile = (arg: any): arg is AssumeRoleSourceProfile =>
+  Boolean(arg) &&
+  typeof arg === "object" &&
+  typeof arg.role_arn === "string" &&
+  typeof arg.source_profile === "string" &&
+  ["undefined", "string"].indexOf(typeof arg.role_session_name) > -1 &&
+  ["undefined", "string"].indexOf(typeof arg.external_id) > -1 &&
+  ["undefined", "string"].indexOf(typeof arg.mfa_serial) > -1;

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -1,7 +1,5 @@
-import { AssumeRoleCommandInput, AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
-import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/credential-provider-ini";
+import { AssumeRoleWithWebIdentityCommandInput } from "@aws-sdk/client-sts";
 import { ProviderError } from "@aws-sdk/property-provider";
-import { ParsedIniData, Profile } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { readFileSync } from "fs";
 
@@ -9,7 +7,22 @@ const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 const ENV_ROLE_ARN = "AWS_ROLE_ARN";
 const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
 
-export interface FromTokenFileInit extends SourceProfileInit {
+export interface FromTokenFileInit {
+  /**
+   * File location of where the `OIDC` token is stored.
+   */
+  webIdentityTokenFile?: string;
+
+  /**
+   * The IAM role wanting to be assumed.
+   */
+  roleArn?: string;
+
+  /**
+   * The IAM session name used to distinguish sessions.
+   */
+  roleSessionName?: string;
+
   /**
    * A function that assumes a role with web identity and returns a promise fulfilled with
    * credentials for the assumed role.
@@ -17,110 +30,26 @@ export interface FromTokenFileInit extends SourceProfileInit {
    * @param sourceCreds The credentials with which to assume a role.
    * @param params
    */
-  roleAssumerWithWebIdentity: (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
-  /**
-   * A function that assumes a role and returns a promise fulfilled with
-   * credentials for the assumed role.
-   *
-   * @param sourceCreds The credentials with which to assume a role.
-   * @param params
-   */
-  roleAssumer?: (sourceCreds: Credentials, params: AssumeRoleCommandInput) => Promise<Credentials>;
+  roleAssumerWithWebIdentity?: (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
 }
 
 /**
  * Represents OIDC credentials from a file on disk.
  */
 export const fromTokenFile = (init: FromTokenFileInit): CredentialProvider => async () => {
-  if (process.env[ENV_TOKEN_FILE] && process.env[ENV_ROLE_ARN]) {
-    return resolveCredentialsFromEnv(init);
-  }
-  const profiles = await parseKnownFiles(init);
-  return resolveCredentialsFromIni(getMasterProfileName(init), profiles, init);
-};
+  const { webIdentityTokenFile, roleArn, roleSessionName, roleAssumerWithWebIdentity } = init;
 
-const resolveCredentialsFromEnv = async (options: FromTokenFileInit) => {
-  if (!options.roleAssumerWithWebIdentity) {
+  if (!roleAssumerWithWebIdentity) {
     throw new ProviderError(
-      `Role Arn '${process.env[ENV_ROLE_ARN]}' needs to be assumed with web identity,` +
+      `Role Arn '${roleArn ?? process.env[ENV_ROLE_ARN]}' needs to be assumed with web identity,` +
         ` but no role assumption callback was provided.`,
       false
     );
   }
-  return options.roleAssumerWithWebIdentity({
-    WebIdentityToken: readFileSync(process.env[ENV_TOKEN_FILE]!, { encoding: "ascii" }),
-    RoleArn: process.env[ENV_ROLE_ARN],
-    RoleSessionName: process.env[ENV_ROLE_SESSION_NAME] || `aws-sdk-js-session-${Date.now()}`,
+
+  return roleAssumerWithWebIdentity({
+    WebIdentityToken: readFileSync(webIdentityTokenFile ?? process.env[ENV_TOKEN_FILE]!, { encoding: "ascii" }),
+    RoleArn: roleArn ?? process.env[ENV_ROLE_ARN],
+    RoleSessionName: roleSessionName ?? process.env[ENV_ROLE_SESSION_NAME] ?? `aws-sdk-js-session-${Date.now()}`,
   });
 };
-
-const resolveCredentialsFromIni = async (
-  profileName: string,
-  profiles: ParsedIniData,
-  options: FromTokenFileInit,
-  visitedProfiles: { [profileName: string]: true } = {}
-): Promise<Credentials> => {
-  const data = profiles[profileName];
-
-  if (isAssumeRoleSourceProfile(data)) {
-    const {
-      role_arn: RoleArn,
-      role_session_name: RoleSessionName = `aws-sdk-js-session-${Date.now()}`,
-      source_profile,
-    } = data;
-
-    if (!options.roleAssumer) {
-      throw new ProviderError(
-        `Profile '${profileName}' requires a role to be assumed,` + ` but no role assumption callback was provided.`,
-        false
-      );
-    }
-
-    if (source_profile in visitedProfiles) {
-      throw new ProviderError(
-        `Detected a cycle attempting to resolve credentials for profile` +
-          ` ${getMasterProfileName(options)}. Profiles visited: ` +
-          Object.keys(visitedProfiles).join(", "),
-        false
-      );
-    }
-
-    const sourceCreds = resolveCredentialsFromIni(source_profile, profiles, options, {
-      ...visitedProfiles,
-      [source_profile]: true,
-    });
-
-    return options.roleAssumer(await sourceCreds, { RoleArn, RoleSessionName });
-  } else {
-    const {
-      web_identity_token_file,
-      role_arn: RoleArn,
-      role_session_name: RoleSessionName = `aws-sdk-js-session-${Date.now()}`,
-    } = data;
-
-    if (!options.roleAssumerWithWebIdentity) {
-      throw new ProviderError(
-        `Profile '${profileName}' requires a role to be assumed with web identity,` +
-          ` but no role assumption callback was provided.`,
-        false
-      );
-    }
-
-    const WebIdentityToken = readFileSync(web_identity_token_file!, { encoding: "ascii" });
-    return options.roleAssumerWithWebIdentity({ WebIdentityToken, RoleArn, RoleSessionName });
-  }
-};
-
-interface AssumeRoleSourceProfile extends Profile {
-  role_arn: string;
-  source_profile: string;
-}
-
-const isAssumeRoleSourceProfile = (arg: any): arg is AssumeRoleSourceProfile =>
-  Boolean(arg) &&
-  typeof arg === "object" &&
-  typeof arg.role_arn === "string" &&
-  typeof arg.source_profile === "string" &&
-  ["undefined", "string"].indexOf(typeof arg.role_session_name) > -1 &&
-  ["undefined", "string"].indexOf(typeof arg.external_id) > -1 &&
-  ["undefined", "string"].indexOf(typeof arg.mfa_serial) > -1;

--- a/packages/credential-provider-web-identity/src/index.ts
+++ b/packages/credential-provider-web-identity/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./fromTokenFile";

--- a/packages/credential-provider-web-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-web-identity/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/credential-provider-web-identity/tsconfig.es.json
+++ b/packages/credential-provider-web-identity/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1808

### Description
Adds fromTokenFile credential provider to read credentials from EKS service account.

- Reads file location of where the OIDC token is stored from either provided option `webIdentityTokenFile` or environment variable `AWS_WEB_IDENTITY_TOKEN_FILE`.
- Reads IAM role wanting to be assumed from either provided option `roleArn` or environment variable `AWS_ROLE_ARN`.
- Reads optional role session name to be used to distinguish sessions from provided option `roleSessionName` or environment variable `AWS_ROLE_SESSION_NAME`.
  If session name is not defined, it comes up with a role session name.
- Reads OIDC token from file on disk.
- Calls sts:AssumeRoleWithWebIdentity via `roleAssumerWithWebIdentity` option to get credentials.

| **Configuration Key** | **Environment Variable**    | **Required** | **Description**                                   |
| --------------------- | --------------------------- | ------------ | ------------------------------------------------- |
| webIdentityTokenFile  | AWS_WEB_IDENTITY_TOKEN_FILE | true         | File location of where the `OIDC` token is stored |
| roleArn               | AWS_IAM_ROLE_ARN            | true         | The IAM role wanting to be assumed                |
| roleSessionName       | AWS_IAM_ROLE_SESSION_NAME   | false        | The IAM session name used to distinguish sessions |

### Testing
A basic example of using fromTokenFile:

```js
import { STSClient, AssumeRoleWithWebIdentityCommand } from "@aws-sdk/client-sts";
import { fromTokenFile } from "@aws-sdk/credential-provider-web-identity";

const stsClient = new STSClient({});

const roleAssumerWithWebIdentity = async (params) => {
  const { Credentials } = await stsClient.send(
    new AssumeRoleWithWebIdentityCommand(params)
  );
  if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
    throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
  }
  return {
    accessKeyId: Credentials.AccessKeyId,
    secretAccessKey: Credentials.SecretAccessKey,
    sessionToken: Credentials.SessionToken,
    expiration: Credentials.Expiration,
  };
};

const client = new FooClient({
  credentials: fromTokenFile({
    roleAssumerWithWebIdentity
  });
});
```

#### Values in environment variables

The values can be defined in environment varaibles as follows:

```console
$ node
> Object.fromEntries(Object.entries(process.env).filter(([key, value]) => key.startsWith("AWS_")));
{
  AWS_WEB_IDENTITY_TOKEN_FILE: '/temp/token',
  AWS_ROLE_ARN: 'arn:aws:iam::123456789012:role/example-role-arn'
}
```

#### Values in configuration keys

The values can be defined in configuration keys as follows:

```js
...
const client = new FooClient({
  credentials: fromTokenFile({
    webIdentityTokenFile: "/temp/token",
    roleArn: "arn:aws:iam::123456789012:role/example-role-arn",
    roleAssumerWithWebIdentity
  });
});
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
