### PR TITLE
feat(credential-provider-ini): call fromTokenFile in assumeRole chaining

### DIFF
--- a/packages/credential-provider-ini/README.md
+++ b/packages/credential-provider-ini/README.md
@@ -5,12 +5,13 @@
 
 ## AWS Credential Provider for Node.JS - Shared Configuration Files
 
-This module provides a function, `fromSharedConfigFiles` that will create
+This module provides a function, `fromIni` that will create
 `CredentialProvider` functions that read from a shared credentials file at
 `~/.aws/credentials` and a shared configuration file at `~/.aws/config`. Both
 files are expected to be INI formatted with section names corresponding to
 profiles. Sections in the credentials file are treated as profile names, whereas
-profile sections in the config file must have the format of`[profile profile-name]`, except for the default profile. Please see the [sample
+profile sections in the config file must have the format of`[profile profile-name]`,
+except for the default profile. Please see the [sample
 files](#sample-files) below for examples of well-formed configuration and
 credentials files.
 
@@ -21,8 +22,7 @@ in the config file.
 ## Supported configuration
 
 You may customize how credentials are resolved by providing an options hash to
-the `fromSharedConfigFiles` factory function. The following options are
-supported:
+the `fromIni` factory function. The following options are supported:
 
 - `profile` - The configuration profile to use. If not specified, the provider
   will use the value in the `AWS_PROFILE` environment variable or a default of
@@ -38,7 +38,11 @@ supported:
   code and `mfaCodeProvider` is not a valid function, the credential provider
   promise will be rejected.
 - `roleAssumer` - A function that assumes a role and returns a promise
-  fulfilled with credentials for the assumed role.
+  fulfilled with credentials for the assumed role. You may call `sts:assumeRole`
+  API within this function.
+- `roleAssumerWithWebIdentity` - A function that assumes a role with web identity
+  and returns a promise fulfilled with credentials for the assumed role. You may call
+  `sts:assumeRoleWithWebIdentity` API within this function.
 
 ## Sample files
 
@@ -76,4 +80,24 @@ aws_secret_access_key=bar3
 [profile "testing host"]
 aws_access_key_id=foo4
 aws_secret_access_key=bar4
+```
+
+### source profile with static credentials
+
+```ini
+[second]
+aws_access_key_id=foo
+aws_secret_access_key=bar
+
+[first]
+source_profile=first
+role_arn=arn:aws:iam::123456789012:role/example-role-arn
+```
+
+### profile with web_identity_token_file
+
+```ini
+[default]
+web_identity_token_file=/temp/token
+role_arn=arn:aws:iam::123456789012:role/example-role-arn
 ```

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -22,6 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/credential-provider-web-identity": "3.0.0",
     "@aws-sdk/property-provider": "3.8.0",
     "@aws-sdk/shared-ini-file-loader": "3.8.0",
     "@aws-sdk/types": "3.6.1",

--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -1,3 +1,4 @@
+import { AssumeRoleWithWebIdentityParams, fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
 import { ProviderError } from "@aws-sdk/property-provider";
 import {
   loadSharedConfigFiles,
@@ -78,6 +79,15 @@ export interface FromIniInit extends SourceProfileInit {
    * @param params
    */
   roleAssumer?: (sourceCreds: Credentials, params: AssumeRoleParams) => Promise<Credentials>;
+
+  /**
+   * A function that assumes a role with web identity and returns a promise fulfilled with
+   * credentials for the assumed role.
+   *
+   * @param sourceCreds The credentials with which to assume a role.
+   * @param params
+   */
+  roleAssumerWithWebIdentity?: (params: AssumeRoleWithWebIdentityParams) => Promise<Credentials>;
 }
 
 interface StaticCredsProfile extends Profile {
@@ -93,12 +103,24 @@ const isStaticCredsProfile = (arg: any): arg is StaticCredsProfile =>
   typeof arg.aws_secret_access_key === "string" &&
   ["undefined", "string"].indexOf(typeof arg.aws_session_token) > -1;
 
+interface WebIdentityProfile extends Profile {
+  web_identity_token_file: string;
+  role_arn: string;
+  role_session_name?: string;
+}
+
+const isWebIdentityProfile = (arg: any): arg is WebIdentityProfile =>
+  Boolean(arg) &&
+  typeof arg === "object" &&
+  typeof arg.web_identity_token_file === "string" &&
+  typeof arg.role_arn === "string" &&
+  ["undefined", "string"].indexOf(typeof arg.role_session_name) > -1;
 interface AssumeRoleProfile extends Profile {
   role_arn: string;
   source_profile: string;
 }
 
-const isAssumeRoleProfile = (arg: any): arg is AssumeRoleProfile =>
+const isAssumeRoleWithSourceProfile = (arg: any): arg is AssumeRoleProfile =>
   Boolean(arg) &&
   typeof arg === "object" &&
   typeof arg.role_arn === "string" &&
@@ -155,7 +177,7 @@ const resolveProfileData = async (
 
   // If this is the first profile visited, role assumption keys should be
   // given precedence over static credentials.
-  if (isAssumeRoleProfile(data)) {
+  if (isAssumeRoleWithSourceProfile(data)) {
     const {
       external_id: ExternalId,
       mfa_serial,
@@ -205,6 +227,12 @@ const resolveProfileData = async (
     return resolveStaticCredentials(data);
   }
 
+  // If no static credentials are present, attempt to assume role with
+  // web identity if web_identity_token_file and role_arn is available
+  if (isWebIdentityProfile(data)) {
+    return resolveWebIdentityCredentials(data, options);
+  }
+
   // If the profile cannot be parsed or contains neither static credentials
   // nor role assumption metadata, throw an error. This should be considered a
   // terminal resolution error if a profile has been specified by the user
@@ -219,3 +247,11 @@ const resolveStaticCredentials = (profile: StaticCredsProfile): Promise<Credenti
     secretAccessKey: profile.aws_secret_access_key,
     sessionToken: profile.aws_session_token,
   });
+
+const resolveWebIdentityCredentials = async (profile: WebIdentityProfile, options: FromIniInit): Promise<Credentials> =>
+  fromTokenFile({
+    webIdentityTokenFile: profile.web_identity_token_file,
+    roleArn: profile.role_arn,
+    roleSessionName: profile.role_session_name,
+    roleAssumerWithWebIdentity: options.roleAssumerWithWebIdentity,
+  })();


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1808
~~The base branch for this PR would be changed to main after https://github.com/aws/aws-sdk-js-v3/pull/2177 is merged.~~ Done ✅

### Description
Call fromTokenFile in assumeRole chaining

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
