### PR TITLE
feat: support default role assumers

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-accessanalyzer/runtimeConfig.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-acm-pca/runtimeConfig.ts
+++ b/clients/client-acm-pca/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-acm/runtimeConfig.ts
+++ b/clients/client-acm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-alexa-for-business/runtimeConfig.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-amplify/runtimeConfig.ts
+++ b/clients/client-amplify/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-amplifybackend/runtimeConfig.ts
+++ b/clients/client-amplifybackend/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-api-gateway/runtimeConfig.ts
+++ b/clients/client-api-gateway/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-apigatewayv2/runtimeConfig.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-app-mesh/runtimeConfig.ts
+++ b/clients/client-app-mesh/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-appconfig/runtimeConfig.ts
+++ b/clients/client-appconfig/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-appflow/runtimeConfig.ts
+++ b/clients/client-appflow/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-appintegrations/runtimeConfig.ts
+++ b/clients/client-appintegrations/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-application-auto-scaling/runtimeConfig.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-application-discovery-service/runtimeConfig.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-application-insights/runtimeConfig.ts
+++ b/clients/client-application-insights/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-appstream/runtimeConfig.ts
+++ b/clients/client-appstream/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-appsync/runtimeConfig.ts
+++ b/clients/client-appsync/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-athena/runtimeConfig.ts
+++ b/clients/client-athena/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-auditmanager/runtimeConfig.ts
+++ b/clients/client-auditmanager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-auto-scaling-plans/runtimeConfig.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-auto-scaling/runtimeConfig.ts
+++ b/clients/client-auto-scaling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-backup/runtimeConfig.ts
+++ b/clients/client-backup/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-batch/runtimeConfig.ts
+++ b/clients/client-batch/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-braket/runtimeConfig.ts
+++ b/clients/client-braket/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-budgets/runtimeConfig.ts
+++ b/clients/client-budgets/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-chime/runtimeConfig.ts
+++ b/clients/client-chime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloud9/runtimeConfig.ts
+++ b/clients/client-cloud9/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-clouddirectory/runtimeConfig.ts
+++ b/clients/client-clouddirectory/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudformation/runtimeConfig.ts
+++ b/clients/client-cloudformation/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudfront/runtimeConfig.ts
+++ b/clients/client-cloudfront/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudhsm-v2/runtimeConfig.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudhsm/runtimeConfig.ts
+++ b/clients/client-cloudhsm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudsearch-domain/runtimeConfig.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudsearch/runtimeConfig.ts
+++ b/clients/client-cloudsearch/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudtrail/runtimeConfig.ts
+++ b/clients/client-cloudtrail/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudwatch-events/runtimeConfig.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudwatch-logs/runtimeConfig.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cloudwatch/runtimeConfig.ts
+++ b/clients/client-cloudwatch/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codeartifact/runtimeConfig.ts
+++ b/clients/client-codeartifact/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codebuild/runtimeConfig.ts
+++ b/clients/client-codebuild/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codecommit/runtimeConfig.ts
+++ b/clients/client-codecommit/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codedeploy/runtimeConfig.ts
+++ b/clients/client-codedeploy/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codeguru-reviewer/runtimeConfig.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codeguruprofiler/runtimeConfig.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codepipeline/runtimeConfig.ts
+++ b/clients/client-codepipeline/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codestar-connections/runtimeConfig.ts
+++ b/clients/client-codestar-connections/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codestar-notifications/runtimeConfig.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-codestar/runtimeConfig.ts
+++ b/clients/client-codestar/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cognito-identity-provider/runtimeConfig.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cognito-identity/runtimeConfig.ts
+++ b/clients/client-cognito-identity/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cognito-sync/runtimeConfig.ts
+++ b/clients/client-cognito-sync/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-comprehend/runtimeConfig.ts
+++ b/clients/client-comprehend/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-comprehendmedical/runtimeConfig.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-compute-optimizer/runtimeConfig.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-config-service/runtimeConfig.ts
+++ b/clients/client-config-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-connect-contact-lens/runtimeConfig.ts
+++ b/clients/client-connect-contact-lens/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-connect/runtimeConfig.ts
+++ b/clients/client-connect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-connectparticipant/runtimeConfig.ts
+++ b/clients/client-connectparticipant/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-cost-explorer/runtimeConfig.ts
+++ b/clients/client-cost-explorer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-customer-profiles/runtimeConfig.ts
+++ b/clients/client-customer-profiles/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-data-pipeline/runtimeConfig.ts
+++ b/clients/client-data-pipeline/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-database-migration-service/runtimeConfig.ts
+++ b/clients/client-database-migration-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-databrew/runtimeConfig.ts
+++ b/clients/client-databrew/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-dataexchange/runtimeConfig.ts
+++ b/clients/client-dataexchange/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-datasync/runtimeConfig.ts
+++ b/clients/client-datasync/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-dax/runtimeConfig.ts
+++ b/clients/client-dax/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-detective/runtimeConfig.ts
+++ b/clients/client-detective/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-device-farm/runtimeConfig.ts
+++ b/clients/client-device-farm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-devops-guru/runtimeConfig.ts
+++ b/clients/client-devops-guru/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-direct-connect/runtimeConfig.ts
+++ b/clients/client-direct-connect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-directory-service/runtimeConfig.ts
+++ b/clients/client-directory-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-dlm/runtimeConfig.ts
+++ b/clients/client-dlm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-docdb/runtimeConfig.ts
+++ b/clients/client-docdb/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-dynamodb-streams/runtimeConfig.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-dynamodb/runtimeConfig.ts
+++ b/clients/client-dynamodb/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ebs/runtimeConfig.ts
+++ b/clients/client-ebs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ec2-instance-connect/runtimeConfig.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ec2/runtimeConfig.ts
+++ b/clients/client-ec2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ecr-public/runtimeConfig.ts
+++ b/clients/client-ecr-public/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ecr/runtimeConfig.ts
+++ b/clients/client-ecr/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ecs/runtimeConfig.ts
+++ b/clients/client-ecs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-efs/runtimeConfig.ts
+++ b/clients/client-efs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-eks/runtimeConfig.ts
+++ b/clients/client-eks/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-elastic-beanstalk/runtimeConfig.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-elastic-inference/runtimeConfig.ts
+++ b/clients/client-elastic-inference/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-elastic-load-balancing/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-elastic-transcoder/runtimeConfig.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-elasticache/runtimeConfig.ts
+++ b/clients/client-elasticache/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-elasticsearch-service/runtimeConfig.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-emr-containers/runtimeConfig.ts
+++ b/clients/client-emr-containers/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-emr/runtimeConfig.ts
+++ b/clients/client-emr/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-eventbridge/runtimeConfig.ts
+++ b/clients/client-eventbridge/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-firehose/runtimeConfig.ts
+++ b/clients/client-firehose/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-fms/runtimeConfig.ts
+++ b/clients/client-fms/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-forecast/runtimeConfig.ts
+++ b/clients/client-forecast/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-forecastquery/runtimeConfig.ts
+++ b/clients/client-forecastquery/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-frauddetector/runtimeConfig.ts
+++ b/clients/client-frauddetector/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-fsx/runtimeConfig.ts
+++ b/clients/client-fsx/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-gamelift/runtimeConfig.ts
+++ b/clients/client-gamelift/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -30,6 +30,7 @@
     "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/body-checksum-browser": "3.6.1",
     "@aws-sdk/body-checksum-node": "3.6.1",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-glacier/runtimeConfig.ts
+++ b/clients/client-glacier/runtimeConfig.ts
@@ -1,6 +1,7 @@
 import packageInfo from "./package.json";
 
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-node";
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -24,7 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyChecksumGenerator,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-global-accelerator/runtimeConfig.ts
+++ b/clients/client-global-accelerator/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-glue/runtimeConfig.ts
+++ b/clients/client-glue/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-greengrass/runtimeConfig.ts
+++ b/clients/client-greengrass/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-groundstation/runtimeConfig.ts
+++ b/clients/client-groundstation/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-guardduty/runtimeConfig.ts
+++ b/clients/client-guardduty/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-health/runtimeConfig.ts
+++ b/clients/client-health/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-healthlake/runtimeConfig.ts
+++ b/clients/client-healthlake/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-honeycode/runtimeConfig.ts
+++ b/clients/client-honeycode/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iam/runtimeConfig.ts
+++ b/clients/client-iam/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-identitystore/runtimeConfig.ts
+++ b/clients/client-identitystore/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-imagebuilder/runtimeConfig.ts
+++ b/clients/client-imagebuilder/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-inspector/runtimeConfig.ts
+++ b/clients/client-inspector/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iot-1click-devices-service/runtimeConfig.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iot-1click-projects/runtimeConfig.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iot-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iot-events-data/runtimeConfig.ts
+++ b/clients/client-iot-events-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iot-events/runtimeConfig.ts
+++ b/clients/client-iot-events/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iot/runtimeConfig.ts
+++ b/clients/client-iot/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iotanalytics/runtimeConfig.ts
+++ b/clients/client-iotanalytics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iotsecuretunneling/runtimeConfig.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iotsitewise/runtimeConfig.ts
+++ b/clients/client-iotsitewise/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-iotthingsgraph/runtimeConfig.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ivs/runtimeConfig.ts
+++ b/clients/client-ivs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kafka/runtimeConfig.ts
+++ b/clients/client-kafka/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kendra/runtimeConfig.ts
+++ b/clients/client-kendra/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kinesis-analytics/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kinesis-video-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kinesis-video-signaling/runtimeConfig.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kinesis-video/runtimeConfig.ts
+++ b/clients/client-kinesis-video/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/eventstream-serde-browser": "3.6.1",

--- a/clients/client-kinesis/runtimeConfig.ts
+++ b/clients/client-kinesis/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
@@ -23,7 +24,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-kms/runtimeConfig.ts
+++ b/clients/client-kms/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-lakeformation/runtimeConfig.ts
+++ b/clients/client-lakeformation/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-lambda/runtimeConfig.ts
+++ b/clients/client-lambda/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-lex-model-building-service/runtimeConfig.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-lex-runtime-service/runtimeConfig.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-license-manager/runtimeConfig.ts
+++ b/clients/client-license-manager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-lightsail/runtimeConfig.ts
+++ b/clients/client-lightsail/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-lookoutvision/runtimeConfig.ts
+++ b/clients/client-lookoutvision/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-machine-learning/runtimeConfig.ts
+++ b/clients/client-machine-learning/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-macie/runtimeConfig.ts
+++ b/clients/client-macie/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-macie2/runtimeConfig.ts
+++ b/clients/client-macie2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-managedblockchain/runtimeConfig.ts
+++ b/clients/client-managedblockchain/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-marketplace-catalog/runtimeConfig.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-marketplace-metering/runtimeConfig.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mediaconnect/runtimeConfig.ts
+++ b/clients/client-mediaconnect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mediaconvert/runtimeConfig.ts
+++ b/clients/client-mediaconvert/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-medialive/runtimeConfig.ts
+++ b/clients/client-medialive/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mediapackage-vod/runtimeConfig.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mediapackage/runtimeConfig.ts
+++ b/clients/client-mediapackage/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mediastore-data/runtimeConfig.ts
+++ b/clients/client-mediastore-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mediastore/runtimeConfig.ts
+++ b/clients/client-mediastore/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mediatailor/runtimeConfig.ts
+++ b/clients/client-mediatailor/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-migration-hub/runtimeConfig.ts
+++ b/clients/client-migration-hub/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-migrationhub-config/runtimeConfig.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mobile/runtimeConfig.ts
+++ b/clients/client-mobile/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mq/runtimeConfig.ts
+++ b/clients/client-mq/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-mturk/runtimeConfig.ts
+++ b/clients/client-mturk/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-neptune/runtimeConfig.ts
+++ b/clients/client-neptune/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-network-firewall/runtimeConfig.ts
+++ b/clients/client-network-firewall/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-networkmanager/runtimeConfig.ts
+++ b/clients/client-networkmanager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-opsworks/runtimeConfig.ts
+++ b/clients/client-opsworks/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-opsworkscm/runtimeConfig.ts
+++ b/clients/client-opsworkscm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-organizations/runtimeConfig.ts
+++ b/clients/client-organizations/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-outposts/runtimeConfig.ts
+++ b/clients/client-outposts/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-personalize-events/runtimeConfig.ts
+++ b/clients/client-personalize-events/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-personalize-runtime/runtimeConfig.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-personalize/runtimeConfig.ts
+++ b/clients/client-personalize/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-pi/runtimeConfig.ts
+++ b/clients/client-pi/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-pinpoint-email/runtimeConfig.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-pinpoint/runtimeConfig.ts
+++ b/clients/client-pinpoint/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-polly/runtimeConfig.ts
+++ b/clients/client-polly/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-pricing/runtimeConfig.ts
+++ b/clients/client-pricing/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-qldb-session/runtimeConfig.ts
+++ b/clients/client-qldb-session/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-qldb/runtimeConfig.ts
+++ b/clients/client-qldb/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-quicksight/runtimeConfig.ts
+++ b/clients/client-quicksight/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ram/runtimeConfig.ts
+++ b/clients/client-ram/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-rds-data/runtimeConfig.ts
+++ b/clients/client-rds-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-rds/runtimeConfig.ts
+++ b/clients/client-rds/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-redshift-data/runtimeConfig.ts
+++ b/clients/client-redshift-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-redshift/runtimeConfig.ts
+++ b/clients/client-redshift/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-rekognition/runtimeConfig.ts
+++ b/clients/client-rekognition/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-resource-groups/runtimeConfig.ts
+++ b/clients/client-resource-groups/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-robomaker/runtimeConfig.ts
+++ b/clients/client-robomaker/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-route-53-domains/runtimeConfig.ts
+++ b/clients/client-route-53-domains/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-route-53/runtimeConfig.ts
+++ b/clients/client-route-53/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-route53resolver/runtimeConfig.ts
+++ b/clients/client-route53resolver/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-s3-control/runtimeConfig.ts
+++ b/clients/client-s3-control/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/eventstream-serde-browser": "3.6.1",

--- a/clients/client-s3/runtimeConfig.ts
+++ b/clients/client-s3/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
@@ -26,7 +27,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-s3outposts/runtimeConfig.ts
+++ b/clients/client-s3outposts/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sagemaker-edge/runtimeConfig.ts
+++ b/clients/client-sagemaker-edge/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sagemaker-featurestore-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-featurestore-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sagemaker-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sagemaker/runtimeConfig.ts
+++ b/clients/client-sagemaker/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-savingsplans/runtimeConfig.ts
+++ b/clients/client-savingsplans/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-schemas/runtimeConfig.ts
+++ b/clients/client-schemas/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-secrets-manager/runtimeConfig.ts
+++ b/clients/client-secrets-manager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-securityhub/runtimeConfig.ts
+++ b/clients/client-securityhub/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-service-catalog-appregistry/runtimeConfig.ts
+++ b/clients/client-service-catalog-appregistry/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-service-catalog/runtimeConfig.ts
+++ b/clients/client-service-catalog/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-service-quotas/runtimeConfig.ts
+++ b/clients/client-service-quotas/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-servicediscovery/runtimeConfig.ts
+++ b/clients/client-servicediscovery/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ses/runtimeConfig.ts
+++ b/clients/client-ses/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sesv2/runtimeConfig.ts
+++ b/clients/client-sesv2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sfn/runtimeConfig.ts
+++ b/clients/client-sfn/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-shield/runtimeConfig.ts
+++ b/clients/client-shield/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-signer/runtimeConfig.ts
+++ b/clients/client-signer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sms/runtimeConfig.ts
+++ b/clients/client-sms/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-snowball/runtimeConfig.ts
+++ b/clients/client-snowball/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sns/runtimeConfig.ts
+++ b/clients/client-sns/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sqs/runtimeConfig.ts
+++ b/clients/client-sqs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -23,7 +24,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-ssm/runtimeConfig.ts
+++ b/clients/client-ssm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-sso-admin/runtimeConfig.ts
+++ b/clients/client-sso-admin/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-storage-gateway/runtimeConfig.ts
+++ b/clients/client-storage-gateway/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sts/defaultRoleAssumers.ts
+++ b/clients/client-sts/defaultRoleAssumers.ts
@@ -28,17 +28,17 @@ const decorateDefaultRegion = (region: STSClientConfig["region"]): STSClientConf
 };
 
 /**
- * The default role assumer that used by credential providers when STS.AssumeRole API is needed.
+ * The default role assumer that used by credential providers when sts:AssumeRole API is needed.
  */
-const getDefaultAssumer = (stsOptions: STSClientConfig): RoleAssumer => {
+export const getDefaultRoleAssumer = (stsOptions: Pick<STSClientConfig, "logger" | "region">): RoleAssumer => {
   let stsClient: STSClient;
   return async (sourceCreds, params) => {
     if (!stsClient) {
-      const { logger } = stsOptions;
+      const { logger, region } = stsOptions;
       stsClient = new STSClient({
         logger,
         credentials: sourceCreds,
-        region: decorateDefaultRegion(stsOptions.region),
+        region: decorateDefaultRegion(region),
       });
     }
     const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
@@ -57,16 +57,18 @@ const getDefaultAssumer = (stsOptions: STSClientConfig): RoleAssumer => {
 type RoleAssumerWithWebIdentity = (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
 
 /**
- * The default role assumer that used by credential providers when STS.AssumeRole API is needed.
+ * The default role assumer that used by credential providers when sts:AssumeRoleWithWebIdentity API is needed.
  */
-const getDefaultAssumerWithWebIdentity = (stsOptions: STSClientConfig): RoleAssumerWithWebIdentity => {
+export const getDefaultRoleAssumerWithWebIdentity = (
+  stsOptions: Pick<STSClientConfig, "logger" | "region">
+): RoleAssumerWithWebIdentity => {
   let stsClient: STSClient;
   return async (params) => {
     if (!stsClient) {
-      const { logger } = stsOptions;
+      const { logger, region } = stsOptions;
       stsClient = new STSClient({
         logger,
-        region: decorateDefaultRegion(stsOptions.region),
+        region: decorateDefaultRegion(region),
       });
     }
     const { Credentials } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
@@ -96,7 +98,7 @@ export const decorateDefaultCredentialProvider = (provider: DefaultCredentialPro
   input: any
 ) =>
   provider({
-    roleAssumer: getDefaultAssumer(input),
-    roleAssumerWithWebIdentity: getDefaultAssumerWithWebIdentity(input),
+    roleAssumer: getDefaultRoleAssumer(input),
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input),
     ...input,
   });

--- a/clients/client-sts/defaultRoleAssumers.ts
+++ b/clients/client-sts/defaultRoleAssumers.ts
@@ -1,0 +1,102 @@
+import { Credentials, Provider } from "@aws-sdk/types";
+
+import { AssumeRoleCommand, AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
+import {
+  AssumeRoleWithWebIdentityCommand,
+  AssumeRoleWithWebIdentityCommandInput,
+} from "./commands/AssumeRoleWithWebIdentityCommand";
+import { STSClient, STSClientConfig } from "./STSClient";
+
+type RoleAssumer = (sourceCreds: Credentials, params: AssumeRoleCommandInput) => Promise<Credentials>;
+
+const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
+
+/**
+ * Inject the fallback STS region of us-east-1.
+ */
+const decorateDefaultRegion = (region: STSClientConfig["region"]): STSClientConfig["region"] => {
+  if (typeof region !== "function") {
+    return region === undefined ? ASSUME_ROLE_DEFAULT_REGION : region;
+  }
+  return async () => {
+    try {
+      return await region();
+    } catch (e) {
+      return ASSUME_ROLE_DEFAULT_REGION;
+    }
+  };
+};
+
+/**
+ * The default role assumer that used by credential providers when STS.AssumeRole API is needed.
+ */
+const getDefaultAssumer = (stsOptions: STSClientConfig): RoleAssumer => {
+  let stsClient: STSClient;
+  return async (sourceCreds, params) => {
+    if (!stsClient) {
+      const { logger } = stsOptions;
+      stsClient = new STSClient({
+        logger,
+        credentials: sourceCreds,
+        region: decorateDefaultRegion(stsOptions.region),
+      });
+    }
+    const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
+    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+      throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
+    }
+    return {
+      accessKeyId: Credentials.AccessKeyId,
+      secretAccessKey: Credentials.SecretAccessKey,
+      sessionToken: Credentials.SessionToken,
+      expiration: Credentials.Expiration,
+    };
+  };
+};
+
+type RoleAssumerWithWebIdentity = (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
+
+/**
+ * The default role assumer that used by credential providers when STS.AssumeRole API is needed.
+ */
+const getDefaultAssumerWithWebIdentity = (stsOptions: STSClientConfig): RoleAssumerWithWebIdentity => {
+  let stsClient: STSClient;
+  return async (params) => {
+    if (!stsClient) {
+      const { logger } = stsOptions;
+      stsClient = new STSClient({
+        logger,
+        region: decorateDefaultRegion(stsOptions.region),
+      });
+    }
+    const { Credentials } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
+    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+      throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
+    }
+    return {
+      accessKeyId: Credentials.AccessKeyId,
+      secretAccessKey: Credentials.SecretAccessKey,
+      sessionToken: Credentials.SessionToken,
+      expiration: Credentials.Expiration,
+    };
+  };
+};
+
+type DefaultCredentialProvider = (input: any) => Provider<Credentials>;
+
+/**
+ * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
+ * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
+ * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
+ * dependencies.
+ *
+ * @internal
+ */
+export const decorateDefaultCredentialProvider = (provider: DefaultCredentialProvider): DefaultCredentialProvider => (
+  input: any
+) =>
+  provider({
+    roleAssumer: getDefaultAssumer(input),
+    roleAssumerWithWebIdentity: getDefaultAssumerWithWebIdentity(input),
+    ...input,
+  });

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -89,5 +89,11 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "clients/client-sts"
+  },
+  "exports": {
+    "./defaultRoleAssumers": {
+      "require": "./dist/cjs/defaultRoleAssumers.js",
+      "import": "./dist/es/defaultRoleAssumers.js"
+    }
   }
 }

--- a/clients/client-sts/runtimeConfig.ts
+++ b/clients/client-sts/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "./defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sts/runtimeConfig.ts
+++ b/clients/client-sts/runtimeConfig.ts
@@ -22,7 +22,12 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: (input) => {
+    /**
+     * Inline require to avoid circular dependencies
+     */
+    return require("./defaultRoleAssumers").decorateDefaultCredentialProvider(credentialDefaultProvider)(input);
+  },
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-support/runtimeConfig.ts
+++ b/clients/client-support/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-swf/runtimeConfig.ts
+++ b/clients/client-swf/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-synthetics/runtimeConfig.ts
+++ b/clients/client-synthetics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-textract/runtimeConfig.ts
+++ b/clients/client-textract/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-timestream-query/runtimeConfig.ts
+++ b/clients/client-timestream-query/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-timestream-write/runtimeConfig.ts
+++ b/clients/client-timestream-write/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/eventstream-handler-node": "3.6.1",

--- a/clients/client-transcribe-streaming/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
@@ -24,7 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-transcribe/runtimeConfig.ts
+++ b/clients/client-transcribe/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-transfer/runtimeConfig.ts
+++ b/clients/client-transfer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-translate/runtimeConfig.ts
+++ b/clients/client-translate/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-waf-regional/runtimeConfig.ts
+++ b/clients/client-waf-regional/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-waf/runtimeConfig.ts
+++ b/clients/client-waf/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-wafv2/runtimeConfig.ts
+++ b/clients/client-wafv2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-workdocs/runtimeConfig.ts
+++ b/clients/client-workdocs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-worklink/runtimeConfig.ts
+++ b/clients/client-worklink/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-workmail/runtimeConfig.ts
+++ b/clients/client-workmail/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-workmailmessageflow/runtimeConfig.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-workspaces/runtimeConfig.ts
+++ b/clients/client-workspaces/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.9.0",
     "@aws-sdk/config-resolver": "3.8.0",
     "@aws-sdk/credential-provider-node": "3.9.0",
     "@aws-sdk/fetch-http-handler": "3.6.1",

--- a/clients/client-xray/runtimeConfig.ts
+++ b/clients/client-xray/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts/defaultRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 public enum AwsDependency implements SymbolDependencyContainer {
 
     MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing", "^1.0.0-rc.1"),
+    STS_CLIENT(NORMAL_DEPENDENCY, "@aws-sdk/client-sts", "^3.9.0"),
     CREDENTIAL_PROVIDER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/credential-provider-node", "^1.0.0-rc.1"),
     ACCEPT_HEADER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-api-gateway", "^1.0.0-rc.1"),
     S3_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-s3", "^1.0.0-rc.1"),

--- a/packages/credential-provider-ini/README.md
+++ b/packages/credential-provider-ini/README.md
@@ -82,7 +82,7 @@ aws_access_key_id=foo4
 aws_secret_access_key=bar4
 ```
 
-### source profile with static credentials
+### source profile with assume role credentials
 
 ```ini
 [second]
@@ -94,10 +94,37 @@ source_profile=first
 role_arn=arn:aws:iam::123456789012:role/example-role-arn
 ```
 
+If your credentials or config file contains assume role credentials, you are required to supply `roleAssumer`, which
+will call sts:AssumeRole API. SDK provide a default `roleAssumer`, you can import and supply it like below:
+
+```javascript
+const { getDefaultRoleAssumer } = require("@aws-sdk/client-sts/defaultRoleAssumers"); //CJS
+// import { getDefaultRoleAssumer } from "@aws-sdk/client-sts/defaultRoleAssumers"; //ESM
+
+const provider = fromIni({
+  //...other parameters
+  roleAssumer: getDefaultRoleAssumer();
+})
+```
+
 ### profile with web_identity_token_file
 
 ```ini
 [default]
 web_identity_token_file=/temp/token
 role_arn=arn:aws:iam::123456789012:role/example-role-arn
+```
+
+If your credentials or config file indicates web identity token file credentials, you are required to supply
+`roleAssumerWithWebIdentity` parameter, which will call sts:AssumeRoleWithWebIdentity API. SDK provide a default
+`roleAssumerWithWebIdentity`, you can import and supply it like below:
+
+```javascript
+const { getDefaultRoleAssumerWithWebIdentity } = require("@aws-sdk/client-sts/defaultRoleAssumers"); //CJS
+// import { getDefaultRoleAssumerWithWebIdentity } from "@aws-sdk/client-sts/defaultRoleAssumers"; //ESM
+
+const provider = fromIni({
+  //...other parameters
+  roleAssumerFromWebIdentity: getDefaultRoleAssumerWithWebIdentity();
+})
 ```

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -135,6 +135,9 @@ const copyToClients = async (sourceDir, destinationDir) => {
             directory: `clients/${clientName}`,
           },
         };
+        if (clientName === "client-sts" && destManifest.exports) {
+          mergedManifest["exports"] = destManifest.exports;
+        }
         writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2).concat(`\n`));
       } else if (overwritablePredicate(packageSub) || !existsSync(destSubPath)) {
         if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);


### PR DESCRIPTION
### Issue
Resolves #2087
Resolves #1998
Resolves #2011
Resolves #1193

### Description
This change provides default role assumer for the default credentials provider that calls `sts:assumeRole` or `sts:assumeRoleWithWebIdentity` under the hood. As a result, users don't need to import STS client and supply their own role assumer(like mentioned in #1193).

These assumer is exported from STS client not the `packages/` folder because it can avoid circular dependency. The `credential-provider-*` packages having any dependency over STS client will cause the same issue. As a result this change makes the source code comply the contract that `clients/` depends on `packages/`; `lib/` depends on `packages/` and `clients/`. 

### Testing
✅ It has been manually tested with credential files containing assume role chaining
✅ It has been validate with bundler(Webpack) that tree shaking work well

### Additional context
The example Lambda function size after tree shaking using default configure shows an increase from 115KB to 190KB because the base client now has dependencies over STS client

This change will add some overhead to lambda cold start performance whereas warm start performance is not changed. Here's a typical load test result(10K request, 500 concurrency). The lattency increases about 1~5%

*Lambda invoke with 1 DyanmoDB call. Webpack; v3.9.0*
```console
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0   14  61.6      0     351
Processing:    36  177 244.3    103    1452
Waiting:       35  177 244.3    102
    1452
Total:         36  190 293.9    103    1788

Percentage of the requests served within a certain time (ms)
  50%    103
  66%    116
  75%    128
  80%    140
  90%    212
  95%   1126
  98%   1322
  99%   1372
 100%   1788 (longest request)
```

*Lambda invoke with 1 DyanmoDB call. Webpack; local-released*
```console
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0   14  62.7      0     357
Processing:    33  204 289.8    104    1360
Waiting:       33  204 289.8    104    
1360
Total:         33  218 334.3    104    1700

Percentage of the requests served within a certain time (ms)
  50%    104
  66%    122
  75%    138
  80%    152
  90%    382
  95%   1197
  98%   1395
  99%   1433
 100%   1700 (longest request)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
