### PR TITLE
fix: disable idempotency autofill import when not generating a client

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -218,6 +218,10 @@ final class AwsProtocolUtils {
      * @param context The generation context.
      */
     static void addItempotencyAutofillImport(GenerationContext context) {
+        // servers do not autogenerate idempotency tokens during deserialization
+        if (!context.getSettings().generateClient()) {
+            return;
+        }
         context.getModel().shapes(MemberShape.class)
                 .filter(memberShape -> memberShape.hasTrait(IdempotencyTokenTrait.class))
                 .findFirst()


### PR DESCRIPTION
### Description
SSDKs do not automatically fill idempotency tokens.

### Testing
Local integration testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
