### PR TITLE
fix(deps): request consumers to install react-native polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ If you use tree shaking to reduce bundle size, using non-modular interface will 
 <!-- Uncomment when numbers are available for gamma clients
 In our workshop code, a lambda with DynamoDBClient and a command takes ~18kB while DynamoDB takes ~26 kB ([details](https://github.com/aws-samples/aws-sdk-js-v3-workshop/blob/dc3ad778b04dfe3f8f277dca67162da79c937eca/Exercise1/backend/README.md#reduce-bundle-size-by-just-importing-dynamodb)) -->
 
+If you are consuming modular AWS SDK for JavaScript on react-native environments, you will need
+to add and import following polyfills in your react-antive application:
+
+- [react-native-get-random-values](https://www.npmjs.com/package/react-native-get-random-values)
+- [react-native-url-polyfill](https://www.npmjs.com/package/react-native-url-polyfill) <!-- Future support in #2138 --->
+
 ## New features
 
 ### Modularized packages

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you use tree shaking to reduce bundle size, using non-modular interface will 
 In our workshop code, a lambda with DynamoDBClient and a command takes ~18kB while DynamoDB takes ~26 kB ([details](https://github.com/aws-samples/aws-sdk-js-v3-workshop/blob/dc3ad778b04dfe3f8f277dca67162da79c937eca/Exercise1/backend/README.md#reduce-bundle-size-by-just-importing-dynamodb)) -->
 
 If you are consuming modular AWS SDK for JavaScript on react-native environments, you will need
-to add and import following polyfills in your react-antive application:
+to add and import following polyfills in your react-native application:
 
 - [react-native-get-random-values](https://www.npmjs.com/package/react-native-get-random-values)
 - [react-native-url-polyfill](https://www.npmjs.com/package/react-native-url-polyfill) <!-- Future support in #2138 --->

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ to add and import following polyfills in your react-native application:
 - [react-native-get-random-values](https://www.npmjs.com/package/react-native-get-random-values)
 - [react-native-url-polyfill](https://www.npmjs.com/package/react-native-url-polyfill) <!-- Future support in #2138 --->
 
+```js
+import "react-native-get-random-values";
+import "react-native-url-polyfill/auto";
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+```
+
 ## New features
 
 ### Modularized packages

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -30,6 +30,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
+  "peerDependencies": {
+    "react-native-get-random-values": "^1.6.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-get-random-values": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -20,7 +20,6 @@
     "@aws-sdk/protocol-http": "3.10.0",
     "@aws-sdk/service-error-classification": "3.10.0",
     "@aws-sdk/types": "3.10.0",
-    "react-native-get-random-values": "^1.4.0",
     "tslib": "^1.8.0",
     "uuid": "^3.0.0"
   },
@@ -30,6 +29,14 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
+  },
+  "peerDependencies": {
+    "react-native-get-random-values": "^1.6.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-get-random-values": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -30,14 +30,6 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "peerDependencies": {
-    "react-native-get-random-values": "^1.6.0"
-  },
-  "peerDependenciesMeta": {
-    "react-native-get-random-values": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/middleware-retry/src/index.native.ts
+++ b/packages/middleware-retry/src/index.native.ts
@@ -1,7 +1,0 @@
-//reference: https://github.com/uuidjs/uuid#getrandomvalues-not-supported
-import "react-native-get-random-values";
-export * from "./retryMiddleware";
-export * from "./defaultStrategy";
-export * from "./configurations";
-export * from "./delayDecider";
-export * from "./retryDecider";

--- a/packages/middleware-retry/src/index.ts
+++ b/packages/middleware-retry/src/index.ts
@@ -1,11 +1,3 @@
-//reference: https://github.com/uuidjs/uuid#getrandomvalues-not-supported
-try {
-  //@ts-ignore
-  require("react-native-get-random-values");
-} catch {
-  // do nothing
-}
-
 export * from "./retryMiddleware";
 export * from "./omitRetryHeadersMiddleware";
 export * from "./defaultStrategy";

--- a/packages/middleware-retry/src/index.ts
+++ b/packages/middleware-retry/src/index.ts
@@ -1,3 +1,11 @@
+//reference: https://github.com/uuidjs/uuid#getrandomvalues-not-supported
+try {
+  //@ts-ignore
+  require("react-native-get-random-values");
+} catch {
+  // do nothing
+}
+
 export * from "./retryMiddleware";
 export * from "./omitRetryHeadersMiddleware";
 export * from "./defaultStrategy";

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -24,7 +24,6 @@
     "@aws-sdk/signature-v4": "3.10.0",
     "@aws-sdk/types": "3.10.0",
     "@aws-sdk/util-format-url": "3.10.0",
-    "react-native-get-random-values": "^1.4.0",
     "tslib": "^1.8.0",
     "uuid": "^3.0.0"
   },
@@ -34,6 +33,14 @@
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.0.3",
     "typescript": "~4.1.2"
+  },
+  "peerDependencies": {
+    "react-native-get-random-values": "^1.6.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-get-random-values": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -34,14 +34,6 @@
     "mock-socket": "^9.0.3",
     "typescript": "~4.1.2"
   },
-  "peerDependencies": {
-    "react-native-get-random-values": "^1.6.0"
-  },
-  "peerDependenciesMeta": {
-    "react-native-get-random-values": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -34,6 +34,14 @@
     "mock-socket": "^9.0.3",
     "typescript": "~4.1.2"
   },
+  "peerDependencies": {
+    "react-native-get-random-values": "^1.6.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-get-random-values": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/middleware-sdk-transcribe-streaming/src/index.native.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/index.native.ts
@@ -1,9 +1,0 @@
-//reference: https://github.com/uuidjs/uuid#getrandomvalues-not-supported
-import "react-native-get-random-values";
-export * from "./websocket-handler";
-export * from "./eventstream-handler";
-export * from "./signer";
-export * from "./configuration";
-export * from "./middleware-endpoint";
-export * from "./middleware-session-id";
-export * from "./plugin";

--- a/tests/react-native/End2End/App.tsx
+++ b/tests/react-native/End2End/App.tsx
@@ -8,6 +8,7 @@
  * @format
  */
 
+import "react-native-get-random-values";
 import React, { Fragment, useState } from "react";
 import { SafeAreaView, StyleSheet, ScrollView, StatusBar, Button, Text } from "react-native";
 import { S3 } from "@aws-sdk/client-s3";

--- a/tests/react-native/End2End/package.json
+++ b/tests/react-native/End2End/package.json
@@ -13,7 +13,8 @@
     "detox": "^17.0.2",
     "jest-junit": "^11.0.1",
     "react": "16.8.6",
-    "react-native": "0.60.3"
+    "react-native": "0.60.3",
+    "react-native-get-random-values": "^1.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,11 +4918,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-base64-decode@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
-  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
-
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -9490,13 +9485,6 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
-
-react-native-get-random-values@^1.4.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.6.0.tgz#9035636b2dc2a6d574f2803205381fe1a7b5c864"
-  integrity sha512-sPTRTJk4bpuZeTBf6d7DldQGAOCi0GZh5NxzNI3eHXzxwHbNkV13Q22TehiSb3bsaVqwLC4UAa6QvYIucyyc+A==
-  dependencies:
-    fast-base64-decode "^1.0.0"
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"


### PR DESCRIPTION
Co-authored-by: Nicolas Perraut <n.perraut@gmail.com>

### Issue
Related to #1536
Replaces https://github.com/aws/aws-sdk-js-v3/pull/2108

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1797
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2051
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2192
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2199
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2219

### Description
This PR marks react-native-get-random-values as optional peer dependency to prevent install on non React Native environments.

### Testing
Verified that ReactNative E2E tests are successful.

<details>
<summary>Command line output</summary>

```console
$ pwd
/Users/trivikr/workspace/aws-sdk-js-v3/tests/react-native/End2End

$ node launch-app.js --local-publish
...
 PASS  e2e/End2EndTest.spec.js (14.5s)
  S3
    ✓ should upload an object after tapping putObject button (2276ms)
    ✓ after tapping getObject, App should get the same object that uploaded (2224ms)
    ✓ should list Objects after tapping listObjects button (1496ms)
    ✓ should conduct multipart upload after tapping createMultipartUpload, uploadPart, completeMultipartUpload buttons (3096ms)
```

</details>

<details>
<summary>Details</summary>

https://user-images.githubusercontent.com/16024985/112871068-bb1fe300-9073-11eb-9d25-13d0a2f67ab0.mov

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
