### PR TITLE
fix(codegen): pass settings to createSymbolProvider

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -25,9 +25,9 @@ public class AwsServiceIdIntegrationTest {
                 .unwrap();
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
-        SymbolProvider decorated = integration.decorateSymbolProvider(
-                new TypeScriptSettings(), model, provider);
+        TypeScriptSettings settings = new TypeScriptSettings();
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
+        SymbolProvider decorated = integration.decorateSymbolProvider(settings, model, provider);
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("NotSameClient"));
@@ -44,9 +44,9 @@ public class AwsServiceIdIntegrationTest {
                 .unwrap();
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
-        SymbolProvider decorated = integration.decorateSymbolProvider(
-                new TypeScriptSettings(), model, provider);
+        TypeScriptSettings settings = new TypeScriptSettings();
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
+        SymbolProvider decorated = integration.decorateSymbolProvider(settings, model, provider);
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("FirstNotCapitalizedClient"));
@@ -63,9 +63,9 @@ public class AwsServiceIdIntegrationTest {
                 .unwrap();
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
-        SymbolProvider decorated = integration.decorateSymbolProvider(
-                new TypeScriptSettings(), model, provider);
+        TypeScriptSettings settings = new TypeScriptSettings();
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
+        SymbolProvider decorated = integration.decorateSymbolProvider(settings, model, provider);
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("RestNotCapitalizedClient"));


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2195

### Description
pass settings to createSymbolProvider

### Testing
codegen-ci

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
