### PR TITLE
chore(codegen): pass ServiceShape service to ShapeId.getName()

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -125,7 +125,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
         if (testServiceId(service, "STS")) {
             Boolean isUnsignedCommand = SetUtils
                     .of("AssumeRoleWithWebIdentity", "AssumeRoleWithSAML")
-                    .contains(operation.getId().getName());
+                    .contains(operation.getId().getName(service));
             return !isUnsignedCommand;
         }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -68,19 +68,19 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.EC2_MIDDLEWARE.dependency,
                                          "CopySnapshotPresignedUrl", HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("CopySnapshot")
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CopySnapshot")
                                             && testServiceId(s, "EC2"))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MACHINELEARNING_MIDDLEWARE.dependency, "PredictEndpoint",
                                 HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("Predict")
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("Predict")
                                             && testServiceId(s, "Machine Learning"))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.ROUTE53_MIDDLEWARE.dependency,
                                          "ChangeResourceRecordSets", HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("ChangeResourceRecordSets")
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("ChangeResourceRecordSets")
                                             && testServiceId(s, "Route 53"))
                         .build(),
                 RuntimeClientPlugin.builder()
@@ -92,19 +92,19 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessage",
                                          HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("SendMessage")
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("SendMessage")
                                             && testServiceId(s, "SQS"))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessageBatch",
                                          HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("SendMessageBatch")
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("SendMessageBatch")
                                             && testServiceId(s, "SQS"))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "ReceiveMessage",
                                          HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("ReceiveMessage")
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("ReceiveMessage")
                                             && testServiceId(s, "SQS"))
                         .build(),
                 RuntimeClientPlugin.builder()

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
@@ -43,13 +43,13 @@ public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
             RuntimeClientPlugin.builder()
                 .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
                         HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> RDS_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
+                .operationPredicate((m, s, o) -> RDS_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName(s))
                         && testServiceId(s, "RDS"))
                 .build(),
             RuntimeClientPlugin.builder()
                 .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl",
                         HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> SHARED_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName())
+                .operationPredicate((m, s, o) -> SHARED_PRESIGNED_URL_OPERATIONS.contains(o.getId().getName(s))
                         && (testServiceId(s, "RDS") || testServiceId(s, "DocDB")  || testServiceId(s, "Neptune")))
                 .build()
         );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -127,7 +127,7 @@ public final class AddS3Config implements TypeScriptIntegration {
                                 .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "throw200Exceptions",
                                         HAS_MIDDLEWARE)
                                 .operationPredicate(
-                                        (m, s, o) -> EXCEPTIONS_OF_200_OPERATIONS.contains(o.getId().getName())
+                                        (m, s, o) -> EXCEPTIONS_OF_200_OPERATIONS.contains(o.getId().getName(s))
                                                 && testServiceId(s))
                                 .build(),
                 RuntimeClientPlugin.builder()
@@ -143,7 +143,7 @@ public final class AddS3Config implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.LOCATION_CONSTRAINT.dependency, "LocationConstraint",
                                          HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName().equals("CreateBucket")
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CreateBucket")
                                             && testServiceId(s))
                         .build(),
                  /**
@@ -158,13 +158,13 @@ public final class AddS3Config implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint",
                                          HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> !NON_BUCKET_ENDPOINT_OPERATIONS.contains(o.getId().getName())
+                        .operationPredicate((m, s, o) -> !NON_BUCKET_ENDPOINT_OPERATIONS.contains(o.getId().getName(s))
                                             && testServiceId(s))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.BODY_CHECKSUM.dependency, "ApplyMd5BodyChecksum",
                                          HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> S3_MD5_OPERATIONS.contains(o.getId().getName())
+                        .operationPredicate((m, s, o) -> S3_MD5_OPERATIONS.contains(o.getId().getName(s))
                                             && testServiceId(s))
                         .build()
         );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import software.amazon.smithy.aws.traits.protocols.Ec2QueryTrait;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -134,8 +135,9 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
             writer.write("...$L,",
                     inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
             // Set the protocol required values.
-            writer.write("Action: $S,", operation.getId().getName());
-            writer.write("Version: $S,", context.getService().getVersion());
+            ServiceShape serviceShape = context.getService();
+            writer.write("Action: $S,", operation.getId().getName(serviceShape));
+            writer.write("Version: $S,", serviceShape.getVersion());
         });
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -76,7 +76,7 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
 
             TopDownIndex topDownIndex = TopDownIndex.of(model);
             OperationShape firstOperation = topDownIndex.getContainedOperations(service).iterator().next();
-            String operationName = firstOperation.getId().getName();
+            String operationName = firstOperation.getId().getName(service);
             resource = resource.replaceAll(Pattern.quote("${commandName}"), operationName);
             resource = resource.replaceAll(Pattern.quote("${operationName}"),
                     operationName.substring(0, 1).toLowerCase() + operationName.substring(1));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
@@ -178,8 +179,9 @@ final class AwsProtocolUtils {
         // Set the form encoded string.
         writer.openBlock("const body = buildFormUrlencodedString({", "});", () -> {
             // Set the protocol required values.
-            writer.write("Action: $S,", operation.getId().getName());
-            writer.write("Version: $S,", context.getService().getVersion());
+            ServiceShape serviceShape = context.getService();
+            writer.write("Action: $S,", operation.getId().getName(serviceShape));
+            writer.write("Version: $S,", serviceShape.getVersion());
         });
 
         return true;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -134,8 +135,9 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
             writer.write("...$L,",
                     inputStructure.accept(new QueryMemberSerVisitor(context, "input", Format.DATE_TIME)));
             // Set the protocol required values.
-            writer.write("Action: $S,", operation.getId().getName());
-            writer.write("Version: $S,", context.getService().getVersion());
+            ServiceShape serviceShape = context.getService();
+            writer.write("Action: $S,", operation.getId().getName(serviceShape));
+            writer.write("Version: $S,", serviceShape.getVersion());
         });
     }
 
@@ -160,7 +162,7 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     ) {
         TypeScriptWriter writer = context.getWriter();
 
-        String dataSource = "data." + operation.getId().getName() + "Result";
+        String dataSource = "data." + operation.getId().getName(context.getService()) + "Result";
         writer.write("contents = $L;",
                 outputStructure.accept(new XmlMemberDeserVisitor(context, dataSource, Format.DATE_TIME)));
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -153,6 +154,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             return;
         }
 
+        ServiceShape serviceShape = context.getService();
         SymbolProvider symbolProvider = context.getSymbolProvider();
         ShapeId inputShapeId = documentBindings.get(0).getMember().getContainer();
 
@@ -160,11 +162,11 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         writer.write("body = \"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\";");
 
         writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
-        writer.write("const bodyNode = new __XmlNode($S);", inputShapeId.getName());
+        writer.write("const bodyNode = new __XmlNode($S);", inputShapeId.getName(serviceShape));
 
         // Add @xmlNamespace value of the service to the root node,
         // fall back to one from the input shape.
-        boolean serviceXmlns = AwsProtocolUtils.writeXmlNamespace(context, context.getService(), "bodyNode");
+        boolean serviceXmlns = AwsProtocolUtils.writeXmlNamespace(context, serviceShape, "bodyNode");
         if (!serviceXmlns) {
             StructureShape inputShape = context.getModel().expectShape(inputShapeId, StructureShape.class);
             AwsProtocolUtils.writeXmlNamespace(context, inputShape, "bodyNode");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Set;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
@@ -88,7 +89,8 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
         // AWS JSON RPC protocols use a combination of the service and operation shape names,
         // separated by a '.' character, for the target header.
         TypeScriptWriter writer = context.getWriter();
-        String target = context.getService().getId().getName() + "." + operation.getId().getName();
+        ServiceShape serviceShape = context.getService();
+        String target = serviceShape.getId().getName(serviceShape) + "." + operation.getId().getName(serviceShape);
         writer.write("'x-amz-target': $S,", target);
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.DocumentShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
@@ -152,9 +153,10 @@ final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
     public void serializeUnion(GenerationContext context, UnionShape shape) {
         TypeScriptWriter writer = context.getWriter();
         Model model = context.getModel();
+        ServiceShape serviceShape = context.getService();
 
         // Visit over the union type, then get the right serialization for the member.
-        writer.openBlock("return $L.visit(input, {", "});", shape.getId().getName(), () -> {
+        writer.openBlock("return $L.visit(input, {", "});", shape.getId().getName(serviceShape), () -> {
             // Use a TreeMap to sort the members.
             Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
             members.forEach((memberName, memberShape) -> {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.DocumentShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
@@ -272,12 +273,13 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
     @Override
     protected void serializeUnion(GenerationContext context, UnionShape shape) {
         TypeScriptWriter writer = context.getWriter();
+        ServiceShape serviceShape = context.getService();
 
         // Set up a location to store the entry pair.
         writer.write("const entries: any = {};");
 
         // Visit over the union type, then get the right serialization for the member.
-        writer.openBlock("$L.visit(input, {", "});", shape.getId().getName(), () -> {
+        writer.openBlock("$L.visit(input, {", "});", shape.getId().getName(serviceShape), () -> {
             shape.getAllMembers().forEach((memberName, memberShape) -> {
                 writer.openBlock("$L: value => {", "},", memberName, () -> {
                     serializeNamedMember(context, memberName, memberShape, "value");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
@@ -49,9 +49,11 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * @see <a href="https://awslabs.github.io/smithy/spec/xml.html">Smithy XML traits.</a>
  */
 final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
+    private final GenerationContext context;
 
     XmlMemberSerVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
+        this.context = context;
     }
 
     @Override
@@ -112,7 +114,7 @@ final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
         // Handle the @xmlName trait for the shape itself.
         String nodeName = shape.getTrait(XmlNameTrait.class)
                 .map(XmlNameTrait::getValue)
-                .orElse(shape.getId().getName());
+                .orElse(shape.getId().getName(context.getService()));
 
         TypeScriptWriter writer = getContext().getWriter();
         writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/awslabs/smithy-typescript/pull/292

### Description
Pass ServiceShape service to ShapeId.getName()

### Testing
CI

### Additional context
This is a required update while moving to smithy deps 1.7.x

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
