### PR TITLE
docs: add documentation for destroy method

### DIFF
--- a/clients/client-accessanalyzer/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/AccessAnalyzerClient.ts
@@ -268,6 +268,11 @@ export class AccessAnalyzerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-acm-pca/ACMPCAClient.ts
+++ b/clients/client-acm-pca/ACMPCAClient.ts
@@ -322,6 +322,11 @@ export class ACMPCAClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-acm/ACMClient.ts
+++ b/clients/client-acm/ACMClient.ts
@@ -261,6 +261,11 @@ export class ACMClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-alexa-for-business/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/AlexaForBusinessClient.ts
@@ -602,6 +602,11 @@ export class AlexaForBusinessClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-amplify/AmplifyClient.ts
+++ b/clients/client-amplify/AmplifyClient.ts
@@ -345,6 +345,11 @@ export class AmplifyClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-amplifybackend/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/AmplifyBackendClient.ts
@@ -286,6 +286,11 @@ export class AmplifyBackendClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-api-gateway/APIGatewayClient.ts
+++ b/clients/client-api-gateway/APIGatewayClient.ts
@@ -670,6 +670,11 @@ export class APIGatewayClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
@@ -205,6 +205,11 @@ export class ApiGatewayManagementApiClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-apigatewayv2/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/ApiGatewayV2Client.ts
@@ -454,6 +454,11 @@ export class ApiGatewayV2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-app-mesh/AppMeshClient.ts
+++ b/clients/client-app-mesh/AppMeshClient.ts
@@ -376,6 +376,11 @@ export class AppMeshClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-appconfig/AppConfigClient.ts
+++ b/clients/client-appconfig/AppConfigClient.ts
@@ -394,6 +394,11 @@ export class AppConfigClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-appflow/AppflowClient.ts
+++ b/clients/client-appflow/AppflowClient.ts
@@ -307,6 +307,11 @@ export class AppflowClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-appintegrations/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/AppIntegrationsClient.ts
@@ -257,6 +257,11 @@ export class AppIntegrationsClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
@@ -320,6 +320,11 @@ export class ApplicationAutoScalingClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
@@ -445,6 +445,11 @@ export class ApplicationDiscoveryServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-application-insights/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/ApplicationInsightsClient.ts
@@ -316,6 +316,11 @@ export class ApplicationInsightsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-appstream/AppStreamClient.ts
+++ b/clients/client-appstream/AppStreamClient.ts
@@ -414,6 +414,11 @@ export class AppStreamClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-appsync/AppSyncClient.ts
+++ b/clients/client-appsync/AppSyncClient.ts
@@ -338,6 +338,11 @@ export class AppSyncClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-athena/AthenaClient.ts
+++ b/clients/client-athena/AthenaClient.ts
@@ -307,6 +307,11 @@ export class AthenaClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-auditmanager/AuditManagerClient.ts
+++ b/clients/client-auditmanager/AuditManagerClient.ts
@@ -473,6 +473,11 @@ export class AuditManagerClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
@@ -233,6 +233,11 @@ export class AutoScalingPlansClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-auto-scaling/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/AutoScalingClient.ts
@@ -499,6 +499,11 @@ export class AutoScalingClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-backup/BackupClient.ts
+++ b/clients/client-backup/BackupClient.ts
@@ -436,6 +436,11 @@ export class BackupClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-batch/BatchClient.ts
+++ b/clients/client-batch/BatchClient.ts
@@ -289,6 +289,11 @@ export class BatchClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-braket/BraketClient.ts
+++ b/clients/client-braket/BraketClient.ts
@@ -217,6 +217,11 @@ export class BraketClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-budgets/BudgetsClient.ts
+++ b/clients/client-budgets/BudgetsClient.ts
@@ -331,6 +331,11 @@ export class BudgetsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-chime/ChimeClient.ts
+++ b/clients/client-chime/ChimeClient.ts
@@ -1095,6 +1095,11 @@ export class ChimeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloud9/Cloud9Client.ts
+++ b/clients/client-cloud9/Cloud9Client.ts
@@ -319,6 +319,11 @@ export class Cloud9Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-clouddirectory/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/CloudDirectoryClient.ts
@@ -480,6 +480,11 @@ export class CloudDirectoryClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudformation/CloudFormationClient.ts
+++ b/clients/client-cloudformation/CloudFormationClient.ts
@@ -447,6 +447,11 @@ export class CloudFormationClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudfront/CloudFrontClient.ts
+++ b/clients/client-cloudfront/CloudFrontClient.ts
@@ -570,6 +570,11 @@ export class CloudFrontClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
@@ -248,6 +248,11 @@ export class CloudHSMV2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudhsm/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/CloudHSMClient.ts
@@ -275,6 +275,11 @@ export class CloudHSMClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
@@ -205,6 +205,11 @@ export class CloudSearchDomainClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudsearch/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/CloudSearchClient.ts
@@ -322,6 +322,11 @@ export class CloudSearchClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudtrail/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/CloudTrailClient.ts
@@ -273,6 +273,11 @@ export class CloudTrailClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
@@ -370,6 +370,11 @@ export class CloudWatchEventsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
@@ -394,6 +394,11 @@ export class CloudWatchLogsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cloudwatch/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/CloudWatchClient.ts
@@ -336,6 +336,11 @@ export class CloudWatchClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codeartifact/CodeartifactClient.ts
+++ b/clients/client-codeartifact/CodeartifactClient.ts
@@ -642,6 +642,11 @@ export class CodeartifactClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codebuild/CodeBuildClient.ts
+++ b/clients/client-codebuild/CodeBuildClient.ts
@@ -557,6 +557,11 @@ export class CodeBuildClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codecommit/CodeCommitClient.ts
+++ b/clients/client-codecommit/CodeCommitClient.ts
@@ -970,6 +970,11 @@ export class CodeCommitClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codedeploy/CodeDeployClient.ts
+++ b/clients/client-codedeploy/CodeDeployClient.ts
@@ -541,6 +541,11 @@ export class CodeDeployClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
@@ -283,6 +283,11 @@ export class CodeGuruReviewerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
@@ -253,6 +253,11 @@ export class CodeGuruProfilerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codepipeline/CodePipelineClient.ts
+++ b/clients/client-codepipeline/CodePipelineClient.ts
@@ -564,6 +564,11 @@ export class CodePipelineClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codestar-connections/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/CodeStarConnectionsClient.ts
@@ -317,6 +317,11 @@ export class CodeStarConnectionsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codestar-notifications/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/CodestarNotificationsClient.ts
@@ -339,6 +339,11 @@ export class CodestarNotificationsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-codestar/CodeStarClient.ts
+++ b/clients/client-codestar/CodeStarClient.ts
@@ -351,6 +351,11 @@ export class CodeStarClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -666,6 +666,11 @@ export class CognitoIdentityProviderClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cognito-identity/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/CognitoIdentityClient.ts
@@ -296,6 +296,11 @@ export class CognitoIdentityClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cognito-sync/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/CognitoSyncClient.ts
@@ -277,6 +277,11 @@ export class CognitoSyncClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-comprehend/ComprehendClient.ts
+++ b/clients/client-comprehend/ComprehendClient.ts
@@ -520,6 +520,11 @@ export class ComprehendClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-comprehendmedical/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/ComprehendMedicalClient.ts
@@ -311,6 +311,11 @@ export class ComprehendMedicalClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-compute-optimizer/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/ComputeOptimizerClient.ts
@@ -268,6 +268,11 @@ export class ComputeOptimizerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-config-service/ConfigServiceClient.ts
+++ b/clients/client-config-service/ConfigServiceClient.ts
@@ -672,6 +672,11 @@ export class ConfigServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-connect-contact-lens/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/ConnectContactLensClient.ts
@@ -216,6 +216,11 @@ export class ConnectContactLensClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-connect/ConnectClient.ts
+++ b/clients/client-connect/ConnectClient.ts
@@ -623,6 +623,11 @@ export class ConnectClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-connectparticipant/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/ConnectParticipantClient.ts
@@ -232,6 +232,11 @@ export class ConnectParticipantClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
@@ -241,6 +241,11 @@ export class CostAndUsageReportServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-cost-explorer/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/CostExplorerClient.ts
@@ -365,6 +365,11 @@ export class CostExplorerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-customer-profiles/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/CustomerProfilesClient.ts
@@ -326,6 +326,11 @@ export class CustomerProfilesClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-data-pipeline/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/DataPipelineClient.ts
@@ -272,6 +272,11 @@ export class DataPipelineClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
@@ -493,6 +493,11 @@ export class DatabaseMigrationServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-databrew/DataBrewClient.ts
+++ b/clients/client-databrew/DataBrewClient.ts
@@ -331,6 +331,11 @@ export class DataBrewClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-dataexchange/DataExchangeClient.ts
+++ b/clients/client-dataexchange/DataExchangeClient.ts
@@ -271,6 +271,11 @@ export class DataExchangeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-datasync/DataSyncClient.ts
+++ b/clients/client-datasync/DataSyncClient.ts
@@ -334,6 +334,11 @@ export class DataSyncClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-dax/DAXClient.ts
+++ b/clients/client-dax/DAXClient.ts
@@ -291,6 +291,11 @@ export class DAXClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-detective/DetectiveClient.ts
+++ b/clients/client-detective/DetectiveClient.ts
@@ -281,6 +281,11 @@ export class DetectiveClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-device-farm/DeviceFarmClient.ts
+++ b/clients/client-device-farm/DeviceFarmClient.ts
@@ -540,6 +540,11 @@ export class DeviceFarmClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-devops-guru/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/DevOpsGuruClient.ts
@@ -293,6 +293,11 @@ export class DevOpsGuruClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-direct-connect/DirectConnectClient.ts
+++ b/clients/client-direct-connect/DirectConnectClient.ts
@@ -492,6 +492,11 @@ export class DirectConnectClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-directory-service/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/DirectoryServiceClient.ts
@@ -471,6 +471,11 @@ export class DirectoryServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-dlm/DLMClient.ts
+++ b/clients/client-dlm/DLMClient.ts
@@ -238,6 +238,11 @@ export class DLMClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-docdb/DocDBClient.ts
+++ b/clients/client-docdb/DocDBClient.ts
@@ -412,6 +412,11 @@ export class DocDBClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
@@ -216,6 +216,11 @@ export class DynamoDBStreamsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -418,6 +418,11 @@ export class DynamoDBClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ebs/EBSClient.ts
+++ b/clients/client-ebs/EBSClient.ts
@@ -236,6 +236,11 @@ export class EBSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
@@ -202,6 +202,11 @@ export class EC2InstanceConnectClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ec2/EC2Client.ts
+++ b/clients/client-ec2/EC2Client.ts
@@ -2540,6 +2540,11 @@ export class EC2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ecr-public/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/ECRPUBLICClient.ts
@@ -301,6 +301,11 @@ export class ECRPUBLICClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ecr/ECRClient.ts
+++ b/clients/client-ecr/ECRClient.ts
@@ -361,6 +361,11 @@ export class ECRClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ecs/ECSClient.ts
+++ b/clients/client-ecs/ECSClient.ts
@@ -441,6 +441,11 @@ export class ECSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-efs/EFSClient.ts
+++ b/clients/client-efs/EFSClient.ts
@@ -314,6 +314,11 @@ export class EFSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-eks/EKSClient.ts
+++ b/clients/client-eks/EKSClient.ts
@@ -319,6 +319,11 @@ export class EKSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
@@ -471,6 +471,11 @@ export class ElasticBeanstalkClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-elastic-inference/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/ElasticInferenceClient.ts
@@ -231,6 +231,11 @@ export class ElasticInferenceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
@@ -372,6 +372,11 @@ export class ElasticLoadBalancingV2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
@@ -378,6 +378,11 @@ export class ElasticLoadBalancingClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
@@ -257,6 +257,11 @@ export class ElasticTranscoderClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-elasticache/ElastiCacheClient.ts
+++ b/clients/client-elasticache/ElastiCacheClient.ts
@@ -535,6 +535,11 @@ export class ElastiCacheClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
@@ -403,6 +403,11 @@ export class ElasticsearchServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-emr-containers/EMRContainersClient.ts
+++ b/clients/client-emr-containers/EMRContainersClient.ts
@@ -292,6 +292,11 @@ export class EMRContainersClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-emr/EMRClient.ts
+++ b/clients/client-emr/EMRClient.ts
@@ -415,6 +415,11 @@ export class EMRClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-eventbridge/EventBridgeClient.ts
+++ b/clients/client-eventbridge/EventBridgeClient.ts
@@ -370,6 +370,11 @@ export class EventBridgeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-firehose/FirehoseClient.ts
+++ b/clients/client-firehose/FirehoseClient.ts
@@ -262,6 +262,11 @@ export class FirehoseClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-fms/FMSClient.ts
+++ b/clients/client-fms/FMSClient.ts
@@ -317,6 +317,11 @@ export class FMSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-forecast/ForecastClient.ts
+++ b/clients/client-forecast/ForecastClient.ts
@@ -340,6 +340,11 @@ export class ForecastClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-forecastquery/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/ForecastqueryClient.ts
@@ -200,6 +200,11 @@ export class ForecastqueryClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-frauddetector/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/FraudDetectorClient.ts
@@ -396,6 +396,11 @@ export class FraudDetectorClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-fsx/FSxClient.ts
+++ b/clients/client-fsx/FSxClient.ts
@@ -278,6 +278,11 @@ export class FSxClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-gamelift/GameLiftClient.ts
+++ b/clients/client-gamelift/GameLiftClient.ts
@@ -675,6 +675,11 @@ export class GameLiftClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-glacier/GlacierClient.ts
+++ b/clients/client-glacier/GlacierClient.ts
@@ -394,6 +394,11 @@ export class GlacierClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-global-accelerator/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/GlobalAcceleratorClient.ts
@@ -580,6 +580,11 @@ export class GlobalAcceleratorClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-glue/GlueClient.ts
+++ b/clients/client-glue/GlueClient.ts
@@ -812,6 +812,11 @@ export class GlueClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-greengrass/GreengrassClient.ts
+++ b/clients/client-greengrass/GreengrassClient.ts
@@ -703,6 +703,11 @@ export class GreengrassClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-groundstation/GroundStationClient.ts
+++ b/clients/client-groundstation/GroundStationClient.ts
@@ -304,6 +304,11 @@ export class GroundStationClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-guardduty/GuardDutyClient.ts
+++ b/clients/client-guardduty/GuardDutyClient.ts
@@ -461,6 +461,11 @@ export class GuardDutyClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-health/HealthClient.ts
+++ b/clients/client-health/HealthClient.ts
@@ -308,6 +308,11 @@ export class HealthClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-healthlake/HealthLakeClient.ts
+++ b/clients/client-healthlake/HealthLakeClient.ts
@@ -230,6 +230,11 @@ export class HealthLakeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-honeycode/HoneycodeClient.ts
+++ b/clients/client-honeycode/HoneycodeClient.ts
@@ -260,6 +260,11 @@ export class HoneycodeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iam/IAMClient.ts
+++ b/clients/client-iam/IAMClient.ts
@@ -821,6 +821,11 @@ export class IAMClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-identitystore/IdentitystoreClient.ts
+++ b/clients/client-identitystore/IdentitystoreClient.ts
@@ -208,6 +208,11 @@ export class IdentitystoreClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-imagebuilder/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/ImagebuilderClient.ts
@@ -388,6 +388,11 @@ export class ImagebuilderClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-inspector/InspectorClient.ts
+++ b/clients/client-inspector/InspectorClient.ts
@@ -391,6 +391,11 @@ export class InspectorClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
@@ -252,6 +252,11 @@ export class IoT1ClickDevicesServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
@@ -259,6 +259,11 @@ export class IoT1ClickProjectsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -234,6 +234,11 @@ export class IoTDataPlaneClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iot-events-data/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/IoTEventsDataClient.ts
@@ -216,6 +216,11 @@ export class IoTEventsDataClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iot-events/IoTEventsClient.ts
+++ b/clients/client-iot-events/IoTEventsClient.ts
@@ -270,6 +270,11 @@ export class IoTEventsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
@@ -230,6 +230,11 @@ export class IoTJobsDataPlaneClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iot/IoTClient.ts
+++ b/clients/client-iot/IoTClient.ts
@@ -1226,6 +1226,11 @@ export class IoTClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iotanalytics/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/IoTAnalyticsClient.ts
@@ -343,6 +343,11 @@ export class IoTAnalyticsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
@@ -227,6 +227,11 @@ export class IoTSecureTunnelingClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iotsitewise/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/IoTSiteWiseClient.ts
@@ -422,6 +422,11 @@ export class IoTSiteWiseClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
@@ -371,6 +371,11 @@ export class IoTThingsGraphClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ivs/IvsClient.ts
+++ b/clients/client-ivs/IvsClient.ts
@@ -552,6 +552,11 @@ export class IvsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kafka/KafkaClient.ts
+++ b/clients/client-kafka/KafkaClient.ts
@@ -334,6 +334,11 @@ export class KafkaClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kendra/KendraClient.ts
+++ b/clients/client-kendra/KendraClient.ts
@@ -301,6 +301,11 @@ export class KendraClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
@@ -339,6 +339,11 @@ export class KinesisAnalyticsV2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
@@ -304,6 +304,11 @@ export class KinesisAnalyticsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
@@ -223,6 +223,11 @@ export class KinesisVideoArchivedMediaClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
@@ -200,6 +200,11 @@ export class KinesisVideoMediaClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -213,6 +213,11 @@ export class KinesisVideoSignalingClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kinesis-video/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/KinesisVideoClient.ts
@@ -280,6 +280,11 @@ export class KinesisVideoClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kinesis/KinesisClient.ts
+++ b/clients/client-kinesis/KinesisClient.ts
@@ -335,6 +335,11 @@ export class KinesisClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-kms/KMSClient.ts
+++ b/clients/client-kms/KMSClient.ts
@@ -470,6 +470,11 @@ export class KMSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-lakeformation/LakeFormationClient.ts
+++ b/clients/client-lakeformation/LakeFormationClient.ts
@@ -254,6 +254,11 @@ export class LakeFormationClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-lambda/LambdaClient.ts
+++ b/clients/client-lambda/LambdaClient.ts
@@ -481,6 +481,11 @@ export class LambdaClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
@@ -349,6 +349,11 @@ export class LexModelBuildingServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
@@ -222,6 +222,11 @@ export class LexRuntimeServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-license-manager/LicenseManagerClient.ts
+++ b/clients/client-license-manager/LicenseManagerClient.ts
@@ -378,6 +378,11 @@ export class LicenseManagerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-lightsail/LightsailClient.ts
+++ b/clients/client-lightsail/LightsailClient.ts
@@ -846,6 +846,11 @@ export class LightsailClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-lookoutvision/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/LookoutVisionClient.ts
@@ -256,6 +256,11 @@ export class LookoutVisionClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-machine-learning/MachineLearningClient.ts
+++ b/clients/client-machine-learning/MachineLearningClient.ts
@@ -317,6 +317,11 @@ export class MachineLearningClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-macie/MacieClient.ts
+++ b/clients/client-macie/MacieClient.ts
@@ -242,6 +242,11 @@ export class MacieClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-macie2/Macie2Client.ts
+++ b/clients/client-macie2/Macie2Client.ts
@@ -436,6 +436,11 @@ export class Macie2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-managedblockchain/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/ManagedBlockchainClient.ts
@@ -260,6 +260,11 @@ export class ManagedBlockchainClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
@@ -223,6 +223,11 @@ export class MarketplaceCatalogClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
@@ -204,6 +204,11 @@ export class MarketplaceCommerceAnalyticsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
@@ -216,6 +216,11 @@ export class MarketplaceEntitlementServiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
@@ -267,6 +267,11 @@ export class MarketplaceMeteringClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mediaconnect/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/MediaConnectClient.ts
@@ -301,6 +301,11 @@ export class MediaConnectClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mediaconvert/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/MediaConvertClient.ts
@@ -283,6 +283,11 @@ export class MediaConvertClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-medialive/MediaLiveClient.ts
+++ b/clients/client-medialive/MediaLiveClient.ts
@@ -424,6 +424,11 @@ export class MediaLiveClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mediapackage-vod/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/MediaPackageVodClient.ts
@@ -277,6 +277,11 @@ export class MediaPackageVodClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mediapackage/MediaPackageClient.ts
+++ b/clients/client-mediapackage/MediaPackageClient.ts
@@ -280,6 +280,11 @@ export class MediaPackageClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mediastore-data/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/MediaStoreDataClient.ts
@@ -216,6 +216,11 @@ export class MediaStoreDataClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mediastore/MediaStoreClient.ts
+++ b/clients/client-mediastore/MediaStoreClient.ts
@@ -272,6 +272,11 @@ export class MediaStoreClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mediatailor/MediaTailorClient.ts
+++ b/clients/client-mediatailor/MediaTailorClient.ts
@@ -235,6 +235,11 @@ export class MediaTailorClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-migration-hub/MigrationHubClient.ts
+++ b/clients/client-migration-hub/MigrationHubClient.ts
@@ -303,6 +303,11 @@ export class MigrationHubClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-migrationhub-config/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/MigrationHubConfigClient.ts
@@ -239,6 +239,11 @@ export class MigrationHubConfigClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mobile/MobileClient.ts
+++ b/clients/client-mobile/MobileClient.ts
@@ -230,6 +230,11 @@ export class MobileClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mq/MqClient.ts
+++ b/clients/client-mq/MqClient.ts
@@ -286,6 +286,11 @@ export class MqClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-mturk/MTurkClient.ts
+++ b/clients/client-mturk/MTurkClient.ts
@@ -379,6 +379,11 @@ export class MTurkClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-neptune/NeptuneClient.ts
+++ b/clients/client-neptune/NeptuneClient.ts
@@ -552,6 +552,11 @@ export class NeptuneClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-network-firewall/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/NetworkFirewallClient.ts
@@ -413,6 +413,11 @@ export class NetworkFirewallClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-networkmanager/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/NetworkManagerClient.ts
@@ -351,6 +351,11 @@ export class NetworkManagerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-opsworks/OpsWorksClient.ts
+++ b/clients/client-opsworks/OpsWorksClient.ts
@@ -613,6 +613,11 @@ export class OpsWorksClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-opsworkscm/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/OpsWorksCMClient.ts
@@ -358,6 +358,11 @@ export class OpsWorksCMClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-organizations/OrganizationsClient.ts
+++ b/clients/client-organizations/OrganizationsClient.ts
@@ -427,6 +427,11 @@ export class OrganizationsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-outposts/OutpostsClient.ts
+++ b/clients/client-outposts/OutpostsClient.ts
@@ -228,6 +228,11 @@ export class OutpostsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-personalize-events/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/PersonalizeEventsClient.ts
@@ -203,6 +203,11 @@ export class PersonalizeEventsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
@@ -204,6 +204,11 @@ export class PersonalizeRuntimeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-personalize/PersonalizeClient.ts
+++ b/clients/client-personalize/PersonalizeClient.ts
@@ -365,6 +365,11 @@ export class PersonalizeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-pi/PIClient.ts
+++ b/clients/client-pi/PIClient.ts
@@ -217,6 +217,11 @@ export class PIClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-pinpoint-email/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/PinpointEmailClient.ts
@@ -458,6 +458,11 @@ export class PinpointEmailClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -244,6 +244,11 @@ export class PinpointSMSVoiceClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-pinpoint/PinpointClient.ts
+++ b/clients/client-pinpoint/PinpointClient.ts
@@ -643,6 +643,11 @@ export class PinpointClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-polly/PollyClient.ts
+++ b/clients/client-polly/PollyClient.ts
@@ -240,6 +240,11 @@ export class PollyClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-pricing/PricingClient.ts
+++ b/clients/client-pricing/PricingClient.ts
@@ -228,6 +228,11 @@ export class PricingClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-qldb-session/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/QLDBSessionClient.ts
@@ -220,6 +220,11 @@ export class QLDBSessionClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -280,6 +280,11 @@ export class QLDBClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-quicksight/QuickSightClient.ts
+++ b/clients/client-quicksight/QuickSightClient.ts
@@ -614,6 +614,11 @@ export class QuickSightClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ram/RAMClient.ts
+++ b/clients/client-ram/RAMClient.ts
@@ -324,6 +324,11 @@ export class RAMClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-rds-data/RDSDataClient.ts
+++ b/clients/client-rds-data/RDSDataClient.ts
@@ -232,6 +232,11 @@ export class RDSDataClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-rds/RDSClient.ts
+++ b/clients/client-rds/RDSClient.ts
@@ -942,6 +942,11 @@ export class RDSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-redshift-data/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/RedshiftDataClient.ts
@@ -227,6 +227,11 @@ export class RedshiftDataClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-redshift/RedshiftClient.ts
+++ b/clients/client-redshift/RedshiftClient.ts
@@ -709,6 +709,11 @@ export class RedshiftClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-rekognition/RekognitionClient.ts
+++ b/clients/client-rekognition/RekognitionClient.ts
@@ -406,6 +406,11 @@ export class RekognitionClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
@@ -988,6 +988,11 @@ export class ResourceGroupsTaggingAPIClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-resource-groups/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/ResourceGroupsClient.ts
@@ -282,6 +282,11 @@ export class ResourceGroupsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-robomaker/RoboMakerClient.ts
+++ b/clients/client-robomaker/RoboMakerClient.ts
@@ -484,6 +484,11 @@ export class RoboMakerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-route-53-domains/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/Route53DomainsClient.ts
@@ -340,6 +340,11 @@ export class Route53DomainsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-route-53/Route53Client.ts
+++ b/clients/client-route-53/Route53Client.ts
@@ -487,6 +487,11 @@ export class Route53Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-route53resolver/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/Route53ResolverClient.ts
@@ -399,6 +399,11 @@ export class Route53ResolverClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-s3-control/S3ControlClient.ts
+++ b/clients/client-s3-control/S3ControlClient.ts
@@ -384,6 +384,11 @@ export class S3ControlClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -672,6 +672,11 @@ export class S3Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-s3outposts/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/S3OutpostsClient.ts
@@ -202,6 +202,11 @@ export class S3OutpostsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
@@ -243,6 +243,11 @@ export class SageMakerA2IRuntimeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
@@ -204,6 +204,11 @@ export class SagemakerEdgeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
@@ -228,6 +228,11 @@ export class SageMakerFeatureStoreRuntimeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
@@ -200,6 +200,11 @@ export class SageMakerRuntimeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sagemaker/SageMakerClient.ts
+++ b/clients/client-sagemaker/SageMakerClient.ts
@@ -1246,6 +1246,11 @@ export class SageMakerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-savingsplans/SavingsplansClient.ts
+++ b/clients/client-savingsplans/SavingsplansClient.ts
@@ -247,6 +247,11 @@ export class SavingsplansClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-schemas/SchemasClient.ts
+++ b/clients/client-schemas/SchemasClient.ts
@@ -310,6 +310,11 @@ export class SchemasClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-secrets-manager/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/SecretsManagerClient.ts
@@ -330,6 +330,11 @@ export class SecretsManagerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-securityhub/SecurityHubClient.ts
+++ b/clients/client-securityhub/SecurityHubClient.ts
@@ -460,6 +460,11 @@ export class SecurityHubClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
@@ -284,6 +284,11 @@ export class ServerlessApplicationRepositoryClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
@@ -293,6 +293,11 @@ export class ServiceCatalogAppRegistryClient extends __Client<
     this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-service-catalog/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/ServiceCatalogClient.ts
@@ -640,6 +640,11 @@ export class ServiceCatalogClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-service-quotas/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/ServiceQuotasClient.ts
@@ -297,6 +297,11 @@ export class ServiceQuotasClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-servicediscovery/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/ServiceDiscoveryClient.ts
@@ -290,6 +290,11 @@ export class ServiceDiscoveryClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ses/SESClient.ts
+++ b/clients/client-ses/SESClient.ts
@@ -570,6 +570,11 @@ export class SESClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sesv2/SESv2Client.ts
+++ b/clients/client-sesv2/SESv2Client.ts
@@ -626,6 +626,11 @@ export class SESv2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sfn/SFNClient.ts
+++ b/clients/client-sfn/SFNClient.ts
@@ -295,6 +295,11 @@ export class SFNClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-shield/ShieldClient.ts
+++ b/clients/client-shield/ShieldClient.ts
@@ -349,6 +349,11 @@ export class ShieldClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-signer/SignerClient.ts
+++ b/clients/client-signer/SignerClient.ts
@@ -290,6 +290,11 @@ export class SignerClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sms/SMSClient.ts
+++ b/clients/client-sms/SMSClient.ts
@@ -380,6 +380,11 @@ export class SMSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-snowball/SnowballClient.ts
+++ b/clients/client-snowball/SnowballClient.ts
@@ -283,6 +283,11 @@ export class SnowballClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sns/SNSClient.ts
+++ b/clients/client-sns/SNSClient.ts
@@ -359,6 +359,11 @@ export class SNSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -342,6 +342,11 @@ export class SQSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-ssm/SSMClient.ts
+++ b/clients/client-ssm/SSMClient.ts
@@ -842,6 +842,11 @@ export class SSMClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sso-admin/SSOAdminClient.ts
+++ b/clients/client-sso-admin/SSOAdminClient.ts
@@ -370,6 +370,11 @@ export class SSOAdminClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -212,6 +212,11 @@ export class SSOOIDCClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -210,6 +210,11 @@ export class SSOClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-storage-gateway/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/StorageGatewayClient.ts
@@ -657,6 +657,11 @@ export class StorageGatewayClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -227,6 +227,11 @@ export class STSClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-support/SupportClient.ts
+++ b/clients/client-support/SupportClient.ts
@@ -344,6 +344,11 @@ export class SupportClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-swf/SWFClient.ts
+++ b/clients/client-swf/SWFClient.ts
@@ -409,6 +409,11 @@ export class SWFClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-synthetics/SyntheticsClient.ts
+++ b/clients/client-synthetics/SyntheticsClient.ts
@@ -262,6 +262,11 @@ export class SyntheticsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-textract/TextractClient.ts
+++ b/clients/client-textract/TextractClient.ts
@@ -231,6 +231,11 @@ export class TextractClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -204,6 +204,11 @@ export class TimestreamQueryClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -247,6 +247,11 @@ export class TimestreamWriteClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
@@ -245,6 +245,11 @@ export class TranscribeStreamingClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-transcribe/TranscribeClient.ts
+++ b/clients/client-transcribe/TranscribeClient.ts
@@ -343,6 +343,11 @@ export class TranscribeClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-transfer/TransferClient.ts
+++ b/clients/client-transfer/TransferClient.ts
@@ -279,6 +279,11 @@ export class TransferClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-translate/TranslateClient.ts
+++ b/clients/client-translate/TranslateClient.ts
@@ -254,6 +254,11 @@ export class TranslateClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-waf-regional/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/WAFRegionalClient.ts
@@ -557,6 +557,11 @@ export class WAFRegionalClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-waf/WAFClient.ts
+++ b/clients/client-waf/WAFClient.ts
@@ -539,6 +539,11 @@ export class WAFClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-wafv2/WAFV2Client.ts
+++ b/clients/client-wafv2/WAFV2Client.ts
@@ -429,6 +429,11 @@ export class WAFV2Client extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-workdocs/WorkDocsClient.ts
+++ b/clients/client-workdocs/WorkDocsClient.ts
@@ -402,6 +402,11 @@ export class WorkDocsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-worklink/WorkLinkClient.ts
+++ b/clients/client-worklink/WorkLinkClient.ts
@@ -364,6 +364,11 @@ export class WorkLinkClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-workmail/WorkMailClient.ts
+++ b/clients/client-workmail/WorkMailClient.ts
@@ -365,6 +365,11 @@ export class WorkMailClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
@@ -207,6 +207,11 @@ export class WorkMailMessageFlowClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-workspaces/WorkSpacesClient.ts
+++ b/clients/client-workspaces/WorkSpacesClient.ts
@@ -441,6 +441,11 @@ export class WorkSpacesClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/clients/client-xray/XRayClient.ts
+++ b/clients/client-xray/XRayClient.ts
@@ -305,6 +305,11 @@ export class XRayClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/protocol_tests/aws-ec2/EC2ProtocolClient.ts
+++ b/protocol_tests/aws-ec2/EC2ProtocolClient.ts
@@ -274,6 +274,11 @@ export class EC2ProtocolClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/protocol_tests/aws-json/JsonProtocolClient.ts
+++ b/protocol_tests/aws-json/JsonProtocolClient.ts
@@ -238,6 +238,11 @@ export class JsonProtocolClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/protocol_tests/aws-query/QueryProtocolClient.ts
+++ b/protocol_tests/aws-query/QueryProtocolClient.ts
@@ -304,6 +304,11 @@ export class QueryProtocolClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
+++ b/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
@@ -382,6 +382,11 @@ export class RestJsonProtocolClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }

--- a/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
@@ -415,6 +415,11 @@ export class RestXmlProtocolClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 
+  /**
+   * Destroy underlying resources, like sockets. It's usually not necessary to do this.
+   * However in Node.js, it's best to explicitly shut down the client's agent when it is no longer needed.
+   * Otherwise, sockets might stay open for quite a long time before the server terminates them.
+   */
   destroy(): void {
     super.destroy();
   }


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-js-v3/issues/2105
Related to: https://github.com/awslabs/smithy-typescript/pull/301

### Description
Since the `destroy` is inherited from the underlying Node.js API [agent.destroy()](https://nodejs.org/api/http.html#http_agent_destroy), and it doesn't actually destroy and disable the agent for the future use, we will keep the `destroy()` method name in V3 SDK. This change adds documentation to clarify the confusion.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
