### PR TITLE
fix(util-user-agent-browser): react native useragent metadata

### DIFF
--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -17,9 +17,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "react-native": {
-    "./index": "./index.native"
-  },
+  "react-native": "dist/es/index.native.js",
   "dependencies": {
     "@aws-sdk/types": "3.10.0",
     "bowser": "^2.11.0",


### PR DESCRIPTION
Fix the react native entry point. Need to use the entry point
pattern in `react-native` field of package.json, instead of replace
pattern in clients. Because the later one isn't applicable to
entry point file like index.js

### Testing
`x-amz-user-agent` is now `aws-sdk-js/3.11.0 os/other lang/js md/rn api/3.11.0`
<details>
  <summary>Screen Shot</summary>
  
![Simulator Screen Shot - iPhone 11 - 2021-04-04 at 11 45 33](https://user-images.githubusercontent.com/7614947/113597606-ced9c500-95f0-11eb-95a4-1776bf4082ad.png)
</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
