### PR TITLE
fix(util-user-agent-browser): `window` can be undefined

### DIFF
--- a/packages/util-user-agent-browser/src/index.ts
+++ b/packages/util-user-agent-browser/src/index.ts
@@ -11,7 +11,7 @@ export const defaultUserAgent = ({
   serviceId,
   clientVersion,
 }: DefaultUserAgentOptions): Provider<UserAgent> => async () => {
-  const parsedUA = window?.navigator?.userAgent ? bowser.parse(window.navigator.userAgent) : undefined;
+  const parsedUA = (typeof window !== 'undefined' && window?.navigator?.userAgent) ? bowser.parse(window.navigator.userAgent) : undefined;
   const sections: UserAgent = [
     // sdk-metadata
     ["aws-sdk-js", clientVersion],


### PR DESCRIPTION
### Description
In sandboxed environments (pure v8) `window` can be undefined. Should not fail.
Actually should always check for `globalThis` instead, but IE 11 is still alive....

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
