### PR TITLE
Differentiate server serde

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -139,16 +139,19 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    protected void writeDefaultHeaders(GenerationContext context, OperationShape operation) {
-        super.writeDefaultHeaders(context, operation);
-        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
+    protected void writeDefaultHeaders(GenerationContext context, Shape operationOrError, boolean isInput) {
+        super.writeDefaultHeaders(context, operationOrError, isInput);
+        if (isInput && operationOrError.isOperationShape()) {
+            AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operationOrError.asOperationShape().get());
+        }
     }
 
     @Override
-    protected void serializeInputDocument(
+    protected void serializeDocumentBody(
             GenerationContext context,
             OperationShape operation,
-            List<HttpBinding> documentBindings
+            List<HttpBinding> documentBindings,
+            boolean isInput
     ) {
         // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
@@ -201,10 +204,11 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    protected void serializeInputPayload(
+    protected void serializePayload(
             GenerationContext context,
             OperationShape operation,
-            HttpBinding payloadBinding
+            HttpBinding payloadBinding,
+            boolean isInput
     ) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         TypeScriptWriter writer = context.getWriter();
@@ -252,10 +256,11 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    protected void deserializeOutputDocument(
+    protected void deserializeDocumentBody(
             GenerationContext context,
             Shape operationOrError,
-            List<HttpBinding> documentBindings
+            List<HttpBinding> documentBindings,
+            boolean isInput
     ) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         XmlShapeDeserVisitor shapeVisitor = new XmlShapeDeserVisitor(context);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -144,7 +144,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void serializeInputDocumentBody(
+    protected void serializeInputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -153,7 +153,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void serializeOutputDocumentBody(
+    protected void serializeOutputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -162,7 +162,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void serializeErrorDocumentBody(
+    protected void serializeErrorDocumentBody(
             GenerationContext context,
             StructureShape error,
             List<HttpBinding> documentBindings
@@ -304,7 +304,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void deserializeInputDocumentBody(
+    protected void deserializeInputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -313,7 +313,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void deserializeOutputDocumentBody(
+    protected void deserializeOutputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -322,7 +322,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void deserializeErrorDocumentBody(
+    protected void deserializeErrorDocumentBody(
             GenerationContext context,
             StructureShape error,
             List<HttpBinding> documentBindings
@@ -330,7 +330,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         deserializeDocumentBody(context, documentBindings);
     }
 
-    protected void deserializeDocumentBody(
+    private void deserializeDocumentBody(
             GenerationContext context,
             List<HttpBinding> documentBindings
     ) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -139,19 +139,40 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    protected void writeDefaultHeaders(GenerationContext context, Shape operationOrError, boolean isInput) {
-        super.writeDefaultHeaders(context, operationOrError, isInput);
-        if (isInput && operationOrError.isOperationShape()) {
-            AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operationOrError.asOperationShape().get());
-        }
+    protected void writeDefaultInputHeaders(GenerationContext context, OperationShape operation) {
+        AwsProtocolUtils.generateUnsignedPayloadSigV4Header(context, operation);
     }
 
     @Override
-    protected void serializeDocumentBody(
+    public void serializeInputDocumentBody(
             GenerationContext context,
             OperationShape operation,
-            List<HttpBinding> documentBindings,
-            boolean isInput
+            List<HttpBinding> documentBindings
+    ) {
+        serializeDocumentBody(context, documentBindings);
+    }
+
+    @Override
+    public void serializeOutputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+    ) {
+        serializeDocumentBody(context, documentBindings);
+    }
+
+    @Override
+    public void serializeErrorDocumentBody(
+            GenerationContext context,
+            StructureShape error,
+            List<HttpBinding> documentBindings
+    ) {
+        serializeDocumentBody(context, documentBindings);
+    }
+
+    private void serializeDocumentBody(
+            GenerationContext context,
+            List<HttpBinding> documentBindings
     ) {
         // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
@@ -204,11 +225,38 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    protected void serializePayload(
+    protected void serializeInputPayload(
             GenerationContext context,
             OperationShape operation,
-            HttpBinding payloadBinding,
-            boolean isInput
+            HttpBinding payloadBinding
+    ) {
+        super.serializeInputPayload(context, operation, payloadBinding);
+        serializePayload(context, payloadBinding);
+    }
+
+    @Override
+    protected void serializeOutputPayload(
+            GenerationContext context,
+            OperationShape operation,
+            HttpBinding payloadBinding
+    ) {
+        super.serializeOutputPayload(context, operation, payloadBinding);
+        serializePayload(context, payloadBinding);
+    }
+
+    @Override
+    protected void serializeErrorPayload(
+            GenerationContext context,
+            StructureShape error,
+            HttpBinding payloadBinding
+    ) {
+        super.serializeErrorPayload(context, error, payloadBinding);
+        serializePayload(context, payloadBinding);
+    }
+
+    private void serializePayload(
+            GenerationContext context,
+            HttpBinding payloadBinding
     ) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         TypeScriptWriter writer = context.getWriter();
@@ -256,11 +304,35 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     }
 
     @Override
+    public void deserializeInputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+    ) {
+        deserializeDocumentBody(context, documentBindings);
+    }
+
+    @Override
+    public void deserializeOutputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+    ) {
+        deserializeDocumentBody(context, documentBindings);
+    }
+
+    @Override
+    public void deserializeErrorDocumentBody(
+            GenerationContext context,
+            StructureShape error,
+            List<HttpBinding> documentBindings
+    ) {
+        deserializeDocumentBody(context, documentBindings);
+    }
+
     protected void deserializeDocumentBody(
             GenerationContext context,
-            Shape operationOrError,
-            List<HttpBinding> documentBindings,
-            boolean isInput
+            List<HttpBinding> documentBindings
     ) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         XmlShapeDeserVisitor shapeVisitor = new XmlShapeDeserVisitor(context);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -97,7 +97,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void serializeInputDocumentBody(
+    protected void serializeInputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -112,7 +112,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void serializeOutputDocumentBody(
+    protected void serializeOutputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -127,7 +127,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void serializeErrorDocumentBody(
+    protected void serializeErrorDocumentBody(
             GenerationContext context,
             StructureShape error,
             List<HttpBinding> documentBindings
@@ -243,7 +243,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void deserializeInputDocumentBody(
+    protected void deserializeInputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -252,7 +252,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void deserializeOutputDocumentBody(
+    protected void deserializeOutputDocumentBody(
             GenerationContext context,
             OperationShape operation,
             List<HttpBinding> documentBindings
@@ -261,7 +261,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public void deserializeErrorDocumentBody(
+    protected void deserializeErrorDocumentBody(
             GenerationContext context,
             StructureShape error,
             List<HttpBinding> documentBindings


### PR DESCRIPTION
This adds differentation for empty body behavior in restJson1. For
responses this protocol requires always sending an empty json object
if there is some shape defined as output but nothing bound to the
body or payload.

### Additional context

depends on: https://github.com/awslabs/smithy-typescript/pull/305

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
