### PR TITLE
feat: support default role assumers

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-accessanalyzer/runtimeConfig.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-acm-pca/runtimeConfig.ts
+++ b/clients/client-acm-pca/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-acm/runtimeConfig.ts
+++ b/clients/client-acm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-alexa-for-business/runtimeConfig.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-amplify/runtimeConfig.ts
+++ b/clients/client-amplify/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-amplifybackend/runtimeConfig.ts
+++ b/clients/client-amplifybackend/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-api-gateway/runtimeConfig.ts
+++ b/clients/client-api-gateway/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-apigatewayv2/runtimeConfig.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-app-mesh/runtimeConfig.ts
+++ b/clients/client-app-mesh/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-appconfig/runtimeConfig.ts
+++ b/clients/client-appconfig/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-appflow/runtimeConfig.ts
+++ b/clients/client-appflow/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-appintegrations/runtimeConfig.ts
+++ b/clients/client-appintegrations/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-application-auto-scaling/runtimeConfig.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-application-discovery-service/runtimeConfig.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-application-insights/runtimeConfig.ts
+++ b/clients/client-application-insights/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-appstream/runtimeConfig.ts
+++ b/clients/client-appstream/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-appsync/runtimeConfig.ts
+++ b/clients/client-appsync/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-athena/runtimeConfig.ts
+++ b/clients/client-athena/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-auditmanager/runtimeConfig.ts
+++ b/clients/client-auditmanager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-auto-scaling-plans/runtimeConfig.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-auto-scaling/runtimeConfig.ts
+++ b/clients/client-auto-scaling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-backup/runtimeConfig.ts
+++ b/clients/client-backup/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-batch/runtimeConfig.ts
+++ b/clients/client-batch/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-braket/runtimeConfig.ts
+++ b/clients/client-braket/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-budgets/runtimeConfig.ts
+++ b/clients/client-budgets/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-chime/runtimeConfig.ts
+++ b/clients/client-chime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloud9/runtimeConfig.ts
+++ b/clients/client-cloud9/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-clouddirectory/runtimeConfig.ts
+++ b/clients/client-clouddirectory/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudformation/runtimeConfig.ts
+++ b/clients/client-cloudformation/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudfront/runtimeConfig.ts
+++ b/clients/client-cloudfront/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudhsm-v2/runtimeConfig.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudhsm/runtimeConfig.ts
+++ b/clients/client-cloudhsm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudsearch-domain/runtimeConfig.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudsearch/runtimeConfig.ts
+++ b/clients/client-cloudsearch/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudtrail/runtimeConfig.ts
+++ b/clients/client-cloudtrail/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudwatch-events/runtimeConfig.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudwatch-logs/runtimeConfig.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cloudwatch/runtimeConfig.ts
+++ b/clients/client-cloudwatch/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codeartifact/runtimeConfig.ts
+++ b/clients/client-codeartifact/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codebuild/runtimeConfig.ts
+++ b/clients/client-codebuild/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codecommit/runtimeConfig.ts
+++ b/clients/client-codecommit/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codedeploy/runtimeConfig.ts
+++ b/clients/client-codedeploy/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codeguru-reviewer/runtimeConfig.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codeguruprofiler/runtimeConfig.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codepipeline/runtimeConfig.ts
+++ b/clients/client-codepipeline/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codestar-connections/runtimeConfig.ts
+++ b/clients/client-codestar-connections/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codestar-notifications/runtimeConfig.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-codestar/runtimeConfig.ts
+++ b/clients/client-codestar/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cognito-identity-provider/runtimeConfig.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cognito-identity/runtimeConfig.ts
+++ b/clients/client-cognito-identity/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cognito-sync/runtimeConfig.ts
+++ b/clients/client-cognito-sync/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-comprehend/runtimeConfig.ts
+++ b/clients/client-comprehend/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-comprehendmedical/runtimeConfig.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-compute-optimizer/runtimeConfig.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-config-service/runtimeConfig.ts
+++ b/clients/client-config-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-connect-contact-lens/runtimeConfig.ts
+++ b/clients/client-connect-contact-lens/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-connect/runtimeConfig.ts
+++ b/clients/client-connect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-connectparticipant/runtimeConfig.ts
+++ b/clients/client-connectparticipant/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-cost-explorer/runtimeConfig.ts
+++ b/clients/client-cost-explorer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-customer-profiles/runtimeConfig.ts
+++ b/clients/client-customer-profiles/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-data-pipeline/runtimeConfig.ts
+++ b/clients/client-data-pipeline/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-database-migration-service/runtimeConfig.ts
+++ b/clients/client-database-migration-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-databrew/runtimeConfig.ts
+++ b/clients/client-databrew/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-dataexchange/runtimeConfig.ts
+++ b/clients/client-dataexchange/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-datasync/runtimeConfig.ts
+++ b/clients/client-datasync/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-dax/runtimeConfig.ts
+++ b/clients/client-dax/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-detective/runtimeConfig.ts
+++ b/clients/client-detective/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-device-farm/runtimeConfig.ts
+++ b/clients/client-device-farm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-devops-guru/runtimeConfig.ts
+++ b/clients/client-devops-guru/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-direct-connect/runtimeConfig.ts
+++ b/clients/client-direct-connect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-directory-service/runtimeConfig.ts
+++ b/clients/client-directory-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-dlm/runtimeConfig.ts
+++ b/clients/client-dlm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-docdb/runtimeConfig.ts
+++ b/clients/client-docdb/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-dynamodb-streams/runtimeConfig.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-dynamodb/runtimeConfig.ts
+++ b/clients/client-dynamodb/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ebs/runtimeConfig.ts
+++ b/clients/client-ebs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ec2-instance-connect/runtimeConfig.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ec2/runtimeConfig.ts
+++ b/clients/client-ec2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ecr-public/runtimeConfig.ts
+++ b/clients/client-ecr-public/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ecr/runtimeConfig.ts
+++ b/clients/client-ecr/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ecs/runtimeConfig.ts
+++ b/clients/client-ecs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-efs/runtimeConfig.ts
+++ b/clients/client-efs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-eks/runtimeConfig.ts
+++ b/clients/client-eks/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-elastic-beanstalk/runtimeConfig.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-elastic-inference/runtimeConfig.ts
+++ b/clients/client-elastic-inference/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-elastic-load-balancing/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-elastic-transcoder/runtimeConfig.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-elasticache/runtimeConfig.ts
+++ b/clients/client-elasticache/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-elasticsearch-service/runtimeConfig.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-emr-containers/runtimeConfig.ts
+++ b/clients/client-emr-containers/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-emr/runtimeConfig.ts
+++ b/clients/client-emr/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-eventbridge/runtimeConfig.ts
+++ b/clients/client-eventbridge/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-firehose/runtimeConfig.ts
+++ b/clients/client-firehose/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-fms/runtimeConfig.ts
+++ b/clients/client-fms/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-forecast/runtimeConfig.ts
+++ b/clients/client-forecast/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-forecastquery/runtimeConfig.ts
+++ b/clients/client-forecastquery/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-frauddetector/runtimeConfig.ts
+++ b/clients/client-frauddetector/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-fsx/runtimeConfig.ts
+++ b/clients/client-fsx/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-gamelift/runtimeConfig.ts
+++ b/clients/client-gamelift/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -29,6 +29,7 @@
     "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/body-checksum-browser": "3.10.0",
     "@aws-sdk/body-checksum-node": "3.10.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-glacier/runtimeConfig.ts
+++ b/clients/client-glacier/runtimeConfig.ts
@@ -1,6 +1,7 @@
 import packageInfo from "./package.json";
 
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-node";
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -24,7 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyChecksumGenerator,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-global-accelerator/runtimeConfig.ts
+++ b/clients/client-global-accelerator/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-glue/runtimeConfig.ts
+++ b/clients/client-glue/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-greengrass/runtimeConfig.ts
+++ b/clients/client-greengrass/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-groundstation/runtimeConfig.ts
+++ b/clients/client-groundstation/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-guardduty/runtimeConfig.ts
+++ b/clients/client-guardduty/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-health/runtimeConfig.ts
+++ b/clients/client-health/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-healthlake/runtimeConfig.ts
+++ b/clients/client-healthlake/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-honeycode/runtimeConfig.ts
+++ b/clients/client-honeycode/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iam/runtimeConfig.ts
+++ b/clients/client-iam/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-identitystore/runtimeConfig.ts
+++ b/clients/client-identitystore/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-imagebuilder/runtimeConfig.ts
+++ b/clients/client-imagebuilder/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-inspector/runtimeConfig.ts
+++ b/clients/client-inspector/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iot-1click-devices-service/runtimeConfig.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iot-1click-projects/runtimeConfig.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iot-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iot-events-data/runtimeConfig.ts
+++ b/clients/client-iot-events-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iot-events/runtimeConfig.ts
+++ b/clients/client-iot-events/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iot/runtimeConfig.ts
+++ b/clients/client-iot/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iotanalytics/runtimeConfig.ts
+++ b/clients/client-iotanalytics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iotsecuretunneling/runtimeConfig.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iotsitewise/runtimeConfig.ts
+++ b/clients/client-iotsitewise/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-iotthingsgraph/runtimeConfig.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ivs/runtimeConfig.ts
+++ b/clients/client-ivs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kafka/runtimeConfig.ts
+++ b/clients/client-kafka/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kendra/runtimeConfig.ts
+++ b/clients/client-kendra/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kinesis-analytics/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kinesis-video-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kinesis-video-signaling/runtimeConfig.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kinesis-video/runtimeConfig.ts
+++ b/clients/client-kinesis-video/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/eventstream-serde-browser": "3.10.0",

--- a/clients/client-kinesis/runtimeConfig.ts
+++ b/clients/client-kinesis/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
@@ -23,7 +24,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-kms/runtimeConfig.ts
+++ b/clients/client-kms/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-lakeformation/runtimeConfig.ts
+++ b/clients/client-lakeformation/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-lambda/runtimeConfig.ts
+++ b/clients/client-lambda/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-lex-model-building-service/runtimeConfig.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-lex-runtime-service/runtimeConfig.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-license-manager/runtimeConfig.ts
+++ b/clients/client-license-manager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-lightsail/runtimeConfig.ts
+++ b/clients/client-lightsail/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-lookoutvision/runtimeConfig.ts
+++ b/clients/client-lookoutvision/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-machine-learning/runtimeConfig.ts
+++ b/clients/client-machine-learning/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-macie/runtimeConfig.ts
+++ b/clients/client-macie/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-macie2/runtimeConfig.ts
+++ b/clients/client-macie2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-managedblockchain/runtimeConfig.ts
+++ b/clients/client-managedblockchain/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-marketplace-catalog/runtimeConfig.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-marketplace-metering/runtimeConfig.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mediaconnect/runtimeConfig.ts
+++ b/clients/client-mediaconnect/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mediaconvert/runtimeConfig.ts
+++ b/clients/client-mediaconvert/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-medialive/runtimeConfig.ts
+++ b/clients/client-medialive/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mediapackage-vod/runtimeConfig.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mediapackage/runtimeConfig.ts
+++ b/clients/client-mediapackage/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mediastore-data/runtimeConfig.ts
+++ b/clients/client-mediastore-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mediastore/runtimeConfig.ts
+++ b/clients/client-mediastore/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mediatailor/runtimeConfig.ts
+++ b/clients/client-mediatailor/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-migration-hub/runtimeConfig.ts
+++ b/clients/client-migration-hub/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-migrationhub-config/runtimeConfig.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mobile/runtimeConfig.ts
+++ b/clients/client-mobile/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mq/runtimeConfig.ts
+++ b/clients/client-mq/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-mturk/runtimeConfig.ts
+++ b/clients/client-mturk/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-neptune/runtimeConfig.ts
+++ b/clients/client-neptune/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-network-firewall/runtimeConfig.ts
+++ b/clients/client-network-firewall/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-networkmanager/runtimeConfig.ts
+++ b/clients/client-networkmanager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-opsworks/runtimeConfig.ts
+++ b/clients/client-opsworks/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-opsworkscm/runtimeConfig.ts
+++ b/clients/client-opsworkscm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-organizations/runtimeConfig.ts
+++ b/clients/client-organizations/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-outposts/runtimeConfig.ts
+++ b/clients/client-outposts/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-personalize-events/runtimeConfig.ts
+++ b/clients/client-personalize-events/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-personalize-runtime/runtimeConfig.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-personalize/runtimeConfig.ts
+++ b/clients/client-personalize/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-pi/runtimeConfig.ts
+++ b/clients/client-pi/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-pinpoint-email/runtimeConfig.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-pinpoint/runtimeConfig.ts
+++ b/clients/client-pinpoint/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-polly/runtimeConfig.ts
+++ b/clients/client-polly/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-pricing/runtimeConfig.ts
+++ b/clients/client-pricing/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-qldb-session/runtimeConfig.ts
+++ b/clients/client-qldb-session/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-qldb/runtimeConfig.ts
+++ b/clients/client-qldb/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-quicksight/runtimeConfig.ts
+++ b/clients/client-quicksight/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ram/runtimeConfig.ts
+++ b/clients/client-ram/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-rds-data/runtimeConfig.ts
+++ b/clients/client-rds-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-rds/runtimeConfig.ts
+++ b/clients/client-rds/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-redshift-data/runtimeConfig.ts
+++ b/clients/client-redshift-data/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-redshift/runtimeConfig.ts
+++ b/clients/client-redshift/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-rekognition/runtimeConfig.ts
+++ b/clients/client-rekognition/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-resource-groups/runtimeConfig.ts
+++ b/clients/client-resource-groups/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-robomaker/runtimeConfig.ts
+++ b/clients/client-robomaker/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-route-53-domains/runtimeConfig.ts
+++ b/clients/client-route-53-domains/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-route-53/runtimeConfig.ts
+++ b/clients/client-route-53/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-route53resolver/runtimeConfig.ts
+++ b/clients/client-route53resolver/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-s3-control/runtimeConfig.ts
+++ b/clients/client-s3-control/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/eventstream-serde-browser": "3.10.0",

--- a/clients/client-s3/runtimeConfig.ts
+++ b/clients/client-s3/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
@@ -26,7 +27,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-s3outposts/runtimeConfig.ts
+++ b/clients/client-s3outposts/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sagemaker-edge/runtimeConfig.ts
+++ b/clients/client-sagemaker-edge/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sagemaker-featurestore-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-featurestore-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sagemaker-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sagemaker/runtimeConfig.ts
+++ b/clients/client-sagemaker/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-savingsplans/runtimeConfig.ts
+++ b/clients/client-savingsplans/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-schemas/runtimeConfig.ts
+++ b/clients/client-schemas/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-secrets-manager/runtimeConfig.ts
+++ b/clients/client-secrets-manager/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-securityhub/runtimeConfig.ts
+++ b/clients/client-securityhub/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-service-catalog-appregistry/runtimeConfig.ts
+++ b/clients/client-service-catalog-appregistry/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-service-catalog/runtimeConfig.ts
+++ b/clients/client-service-catalog/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-service-quotas/runtimeConfig.ts
+++ b/clients/client-service-quotas/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-servicediscovery/runtimeConfig.ts
+++ b/clients/client-servicediscovery/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ses/runtimeConfig.ts
+++ b/clients/client-ses/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sesv2/runtimeConfig.ts
+++ b/clients/client-sesv2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sfn/runtimeConfig.ts
+++ b/clients/client-sfn/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-shield/runtimeConfig.ts
+++ b/clients/client-shield/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-signer/runtimeConfig.ts
+++ b/clients/client-signer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sms/runtimeConfig.ts
+++ b/clients/client-sms/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-snowball/runtimeConfig.ts
+++ b/clients/client-snowball/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sns/runtimeConfig.ts
+++ b/clients/client-sns/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sqs/runtimeConfig.ts
+++ b/clients/client-sqs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -23,7 +24,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-ssm/runtimeConfig.ts
+++ b/clients/client-ssm/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-sso-admin/runtimeConfig.ts
+++ b/clients/client-sso-admin/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-storage-gateway/runtimeConfig.ts
+++ b/clients/client-storage-gateway/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -30,7 +30,8 @@ import {
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
-import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
+// import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
+import { StsAuthInputConfig, StsAuthResolvedConfig, resolveStsAuthConfig } from "@aws-sdk/middleware-sdk-sts";
 import {
   UserAgentInputConfig,
   UserAgentResolvedConfig,
@@ -180,7 +181,8 @@ export type STSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
-  AwsAuthInputConfig &
+  // AwsAuthInputConfig &
+  StsAuthInputConfig &
   UserAgentInputConfig;
 
 export type STSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
@@ -189,7 +191,8 @@ export type STSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
-  AwsAuthResolvedConfig &
+  // AwsAuthResolvedConfig &
+  StsAuthResolvedConfig &
   UserAgentResolvedConfig;
 
 /**
@@ -216,7 +219,8 @@ export class STSClient extends __Client<
     let _config_2 = resolveEndpointsConfig(_config_1);
     let _config_3 = resolveRetryConfig(_config_2);
     let _config_4 = resolveHostHeaderConfig(_config_3);
-    let _config_5 = resolveAwsAuthConfig(_config_4);
+    // let _config_5 = resolveAwsAuthConfig(_config_4);
+    let _config_5 = resolveStsAuthConfig(_config_4, STSClient);
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);
     this.config = _config_6;

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -30,7 +30,6 @@ import {
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
-// import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
 import { StsAuthInputConfig, StsAuthResolvedConfig, resolveStsAuthConfig } from "@aws-sdk/middleware-sdk-sts";
 import {
   UserAgentInputConfig,
@@ -181,7 +180,6 @@ export type STSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
-  // AwsAuthInputConfig &
   StsAuthInputConfig &
   UserAgentInputConfig;
 
@@ -191,7 +189,6 @@ export type STSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
-  // AwsAuthResolvedConfig &
   StsAuthResolvedConfig &
   UserAgentResolvedConfig;
 
@@ -219,7 +216,6 @@ export class STSClient extends __Client<
     let _config_2 = resolveEndpointsConfig(_config_1);
     let _config_3 = resolveRetryConfig(_config_2);
     let _config_4 = resolveHostHeaderConfig(_config_3);
-    // let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_5 = resolveStsAuthConfig(_config_4, STSClient);
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);

--- a/clients/client-sts/defaultRoleAssumers.ts
+++ b/clients/client-sts/defaultRoleAssumers.ts
@@ -7,13 +7,27 @@ import {
 } from "./defaultStsRoleAssumers";
 import { STSClient, STSClientConfig } from "./STSClient";
 
-export const getDefaultRoleAssumer = (stsOptions: Pick<STSClientConfig, "logger" | "region">): RoleAssumer =>
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRole API is needed.
+ */
+export const getDefaultRoleAssumer = (stsOptions: Pick<STSClientConfig, "logger" | "region"> = {}): RoleAssumer =>
   StsGetDefaultRoleAssumer(stsOptions, STSClient);
 
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRoleWithWebIdentity API is needed.
+ */
 export const getDefaultRoleAssumerWithWebIdentity = (
-  stsOptions: Pick<STSClientConfig, "logger" | "region">
+  stsOptions: Pick<STSClientConfig, "logger" | "region"> = {}
 ): RoleAssumerWithWebIdentity => StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, STSClient);
 
+/**
+ * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
+ * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
+ * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
+ * dependencies.
+ *
+ * @internal
+ */
 export const decorateDefaultCredentialProvider = (provider: DefaultCredentialProvider): DefaultCredentialProvider => (
   input: any
 ) =>

--- a/clients/client-sts/defaultRoleAssumers.ts
+++ b/clients/client-sts/defaultRoleAssumers.ts
@@ -1,0 +1,24 @@
+import {
+  DefaultCredentialProvider,
+  getDefaultRoleAssumer as StsGetDefaultRoleAssumer,
+  getDefaultRoleAssumerWithWebIdentity as StsGetDefaultRoleAssumerWithWebIdentity,
+  RoleAssumer,
+  RoleAssumerWithWebIdentity,
+} from "./defaultStsRoleAssumers";
+import { STSClient, STSClientConfig } from "./STSClient";
+
+export const getDefaultRoleAssumer = (stsOptions: Pick<STSClientConfig, "logger" | "region">): RoleAssumer =>
+  StsGetDefaultRoleAssumer(stsOptions, STSClient);
+
+export const getDefaultRoleAssumerWithWebIdentity = (
+  stsOptions: Pick<STSClientConfig, "logger" | "region">
+): RoleAssumerWithWebIdentity => StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, STSClient);
+
+export const decorateDefaultCredentialProvider = (provider: DefaultCredentialProvider): DefaultCredentialProvider => (
+  input: any
+) =>
+  provider({
+    roleAssumer: getDefaultRoleAssumer(input),
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input),
+    ...input,
+  });

--- a/clients/client-sts/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/defaultStsRoleAssumers.ts
@@ -1,0 +1,119 @@
+import { Credentials, Provider } from "@aws-sdk/types";
+
+import { AssumeRoleCommand, AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
+import {
+  AssumeRoleWithWebIdentityCommand,
+  AssumeRoleWithWebIdentityCommandInput,
+} from "./commands/AssumeRoleWithWebIdentityCommand";
+import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+
+/**
+ * @internal
+ */
+export type RoleAssumer = (sourceCreds: Credentials, params: AssumeRoleCommandInput) => Promise<Credentials>;
+
+const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
+
+/**
+ * Inject the fallback STS region of us-east-1.
+ */
+const decorateDefaultRegion = (region: string | Provider<string> | undefined): string | Provider<string> => {
+  if (typeof region !== "function") {
+    return region === undefined ? ASSUME_ROLE_DEFAULT_REGION : region;
+  }
+  return async () => {
+    try {
+      return await region();
+    } catch (e) {
+      return ASSUME_ROLE_DEFAULT_REGION;
+    }
+  };
+};
+
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRole API is needed.
+ * @internal
+ */
+export const getDefaultRoleAssumer = (
+  stsOptions: Pick<STSClientConfig, "logger" | "region">,
+  stsClientCtor: new (options: STSClientConfig) => STSClient
+): RoleAssumer => {
+  let stsClient: STSClient;
+  return async (sourceCreds, params) => {
+    if (!stsClient) {
+      const { logger, region } = stsOptions;
+      stsClient = new stsClientCtor({
+        logger,
+        credentials: sourceCreds,
+        region: decorateDefaultRegion(region),
+      });
+    }
+    const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
+    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+      throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
+    }
+    return {
+      accessKeyId: Credentials.AccessKeyId,
+      secretAccessKey: Credentials.SecretAccessKey,
+      sessionToken: Credentials.SessionToken,
+      expiration: Credentials.Expiration,
+    };
+  };
+};
+
+/**
+ * @internal
+ */
+export type RoleAssumerWithWebIdentity = (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
+
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRoleWithWebIdentity API is needed.
+ * @internal
+ */
+export const getDefaultRoleAssumerWithWebIdentity = (
+  stsOptions: Pick<STSClientConfig, "logger" | "region">,
+  stsClientCtor: new (options: STSClientConfig) => STSClient
+): RoleAssumerWithWebIdentity => {
+  let stsClient: STSClient;
+  return async (params) => {
+    if (!stsClient) {
+      const { logger, region } = stsOptions;
+      stsClient = new stsClientCtor({
+        logger,
+        region: decorateDefaultRegion(region),
+      });
+    }
+    const { Credentials } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
+    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+      throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
+    }
+    return {
+      accessKeyId: Credentials.AccessKeyId,
+      secretAccessKey: Credentials.SecretAccessKey,
+      sessionToken: Credentials.SessionToken,
+      expiration: Credentials.Expiration,
+    };
+  };
+};
+
+/**
+ * @internal
+ */
+export type DefaultCredentialProvider = (input: any) => Provider<Credentials>;
+
+/**
+ * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
+ * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
+ * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
+ * dependencies.
+ *
+ * @internal
+ */
+export const decorateDefaultCredentialProvider = (provider: DefaultCredentialProvider): DefaultCredentialProvider => (
+  input: STSClientResolvedConfig
+) =>
+  provider({
+    roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor),
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input, input.stsClientCtor),
+    ...input,
+  });

--- a/clients/client-sts/index.ts
+++ b/clients/client-sts/index.ts
@@ -9,3 +9,4 @@ export * from "./commands/GetCallerIdentityCommand";
 export * from "./commands/GetFederationTokenCommand";
 export * from "./commands/GetSessionTokenCommand";
 export * from "./models/index";
+export * from "./defaultRoleAssumers";

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/middleware-host-header": "3.10.0",
     "@aws-sdk/middleware-logger": "3.10.0",
     "@aws-sdk/middleware-retry": "3.10.0",
+    "@aws-sdk/middleware-sdk-sts": "3.0.0",
     "@aws-sdk/middleware-serde": "3.10.0",
     "@aws-sdk/middleware-signing": "3.10.0",
     "@aws-sdk/middleware-stack": "3.10.0",
@@ -88,5 +89,11 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "clients/client-sts"
+  },
+  "exports": {
+    "./defaultRoleAssumers": {
+      "import": "./dist/es/defaultRoleAssumers.js",
+      "require": "./dist/cjs/defaultRoleAssumers.js"
+    }
   }
 }

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -89,11 +89,5 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "clients/client-sts"
-  },
-  "exports": {
-    "./defaultRoleAssumers": {
-      "import": "./dist/es/defaultRoleAssumers.js",
-      "require": "./dist/cjs/defaultRoleAssumers.js"
-    }
   }
 }

--- a/clients/client-sts/runtimeConfig.ts
+++ b/clients/client-sts/runtimeConfig.ts
@@ -1,6 +1,7 @@
 import packageInfo from "./package.json";
 
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
+import { decorateDefaultCredentialProvider } from "./defaultStsRoleAssumers";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-sts/runtimeConfig.ts
+++ b/clients/client-sts/runtimeConfig.ts
@@ -1,7 +1,7 @@
 import packageInfo from "./package.json";
 
-import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { decorateDefaultCredentialProvider } from "./defaultStsRoleAssumers";
+import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-support/runtimeConfig.ts
+++ b/clients/client-support/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-swf/runtimeConfig.ts
+++ b/clients/client-swf/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-synthetics/runtimeConfig.ts
+++ b/clients/client-synthetics/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-textract/runtimeConfig.ts
+++ b/clients/client-textract/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-timestream-query/runtimeConfig.ts
+++ b/clients/client-timestream-query/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-timestream-write/runtimeConfig.ts
+++ b/clients/client-timestream-write/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/eventstream-handler-node": "3.10.0",

--- a/clients/client-transcribe-streaming/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
@@ -24,7 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-transcribe/runtimeConfig.ts
+++ b/clients/client-transcribe/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-transfer/runtimeConfig.ts
+++ b/clients/client-transfer/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-translate/runtimeConfig.ts
+++ b/clients/client-translate/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-waf-regional/runtimeConfig.ts
+++ b/clients/client-waf-regional/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-waf/runtimeConfig.ts
+++ b/clients/client-waf/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-wafv2/runtimeConfig.ts
+++ b/clients/client-wafv2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-workdocs/runtimeConfig.ts
+++ b/clients/client-workdocs/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-worklink/runtimeConfig.ts
+++ b/clients/client-worklink/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-workmail/runtimeConfig.ts
+++ b/clients/client-workmail/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-workmailmessageflow/runtimeConfig.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-workspaces/runtimeConfig.ts
+++ b/clients/client-workspaces/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/clients/client-xray/runtimeConfig.ts
+++ b/clients/client-xray/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -59,6 +59,8 @@ public enum AwsDependency implements SymbolDependencyContainer {
     AWS_SDK_EVENTSTREAM_HANDLER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/eventstream-handler-node", "^1.0.0-rc.1"),
     TRANSCRIBE_STREAMING_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-transcribe-streaming",
             "^1.0.0-rc.1"),
+    STS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-sts", "3.11.0"),
+    STS_CLIENT(NORMAL_DEPENDENCY, "@aws-sdk/client-sts", "3.11.0"),
     RETRY_CONFIG_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/retry-config-provider", "^1.0.0-rc.1"),
     NODE_CONFIG_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/node-config-provider", "^1.0.0-rc.1"),
     MIDDLEWARE_LOGGER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-logger", "^1.0.0-rc.1"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
@@ -1,0 +1,38 @@
+import {
+  DefaultCredentialProvider,
+  getDefaultRoleAssumer as StsGetDefaultRoleAssumer,
+  getDefaultRoleAssumerWithWebIdentity as StsGetDefaultRoleAssumerWithWebIdentity,
+  RoleAssumer,
+  RoleAssumerWithWebIdentity,
+} from "./defaultStsRoleAssumers";
+import { STSClient, STSClientConfig } from "./STSClient";
+
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRole API is needed.
+ */
+export const getDefaultRoleAssumer = (stsOptions: Pick<STSClientConfig, "logger" | "region"> = {}): RoleAssumer =>
+  StsGetDefaultRoleAssumer(stsOptions, STSClient);
+
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRoleWithWebIdentity API is needed.
+ */
+export const getDefaultRoleAssumerWithWebIdentity = (
+  stsOptions: Pick<STSClientConfig, "logger" | "region"> = {}
+): RoleAssumerWithWebIdentity => StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, STSClient);
+
+/**
+ * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
+ * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
+ * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
+ * dependencies.
+ *
+ * @internal
+ */
+export const decorateDefaultCredentialProvider = (provider: DefaultCredentialProvider): DefaultCredentialProvider => (
+  input: any
+) =>
+  provider({
+    roleAssumer: getDefaultRoleAssumer(input),
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input),
+    ...input,
+  });

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -1,0 +1,119 @@
+import { Credentials, Provider } from "@aws-sdk/types";
+
+import { AssumeRoleCommand, AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
+import {
+  AssumeRoleWithWebIdentityCommand,
+  AssumeRoleWithWebIdentityCommandInput,
+} from "./commands/AssumeRoleWithWebIdentityCommand";
+import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+
+/**
+ * @internal
+ */
+export type RoleAssumer = (sourceCreds: Credentials, params: AssumeRoleCommandInput) => Promise<Credentials>;
+
+const ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
+
+/**
+ * Inject the fallback STS region of us-east-1.
+ */
+const decorateDefaultRegion = (region: string | Provider<string> | undefined): string | Provider<string> => {
+  if (typeof region !== "function") {
+    return region === undefined ? ASSUME_ROLE_DEFAULT_REGION : region;
+  }
+  return async () => {
+    try {
+      return await region();
+    } catch (e) {
+      return ASSUME_ROLE_DEFAULT_REGION;
+    }
+  };
+};
+
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRole API is needed.
+ * @internal
+ */
+export const getDefaultRoleAssumer = (
+  stsOptions: Pick<STSClientConfig, "logger" | "region">,
+  stsClientCtor: new (options: STSClientConfig) => STSClient
+): RoleAssumer => {
+  let stsClient: STSClient;
+  return async (sourceCreds, params) => {
+    if (!stsClient) {
+      const { logger, region } = stsOptions;
+      stsClient = new stsClientCtor({
+        logger,
+        credentials: sourceCreds,
+        region: decorateDefaultRegion(region),
+      });
+    }
+    const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
+    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+      throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
+    }
+    return {
+      accessKeyId: Credentials.AccessKeyId,
+      secretAccessKey: Credentials.SecretAccessKey,
+      sessionToken: Credentials.SessionToken,
+      expiration: Credentials.Expiration,
+    };
+  };
+};
+
+/**
+ * @internal
+ */
+export type RoleAssumerWithWebIdentity = (params: AssumeRoleWithWebIdentityCommandInput) => Promise<Credentials>;
+
+/**
+ * The default role assumer that used by credential providers when sts:AssumeRoleWithWebIdentity API is needed.
+ * @internal
+ */
+export const getDefaultRoleAssumerWithWebIdentity = (
+  stsOptions: Pick<STSClientConfig, "logger" | "region">,
+  stsClientCtor: new (options: STSClientConfig) => STSClient
+): RoleAssumerWithWebIdentity => {
+  let stsClient: STSClient;
+  return async (params) => {
+    if (!stsClient) {
+      const { logger, region } = stsOptions;
+      stsClient = new stsClientCtor({
+        logger,
+        region: decorateDefaultRegion(region),
+      });
+    }
+    const { Credentials } = await stsClient.send(new AssumeRoleWithWebIdentityCommand(params));
+    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+      throw new Error(`Invalid response from STS.assumeRoleWithWebIdentity call with role ${params.RoleArn}`);
+    }
+    return {
+      accessKeyId: Credentials.AccessKeyId,
+      secretAccessKey: Credentials.SecretAccessKey,
+      sessionToken: Credentials.SessionToken,
+      expiration: Credentials.Expiration,
+    };
+  };
+};
+
+/**
+ * @internal
+ */
+export type DefaultCredentialProvider = (input: any) => Provider<Credentials>;
+
+/**
+ * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
+ * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
+ * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
+ * dependencies.
+ *
+ * @internal
+ */
+export const decorateDefaultCredentialProvider = (provider: DefaultCredentialProvider): DefaultCredentialProvider => (
+  input: STSClientResolvedConfig
+) =>
+  provider({
+    roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor),
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input, input.stsClientCtor),
+    ...input,
+  });

--- a/packages/credential-provider-web-identity/README.md
+++ b/packages/credential-provider-web-identity/README.md
@@ -51,25 +51,8 @@ providers, you can set up the SDK to get credentials for the IAM role using help
 
 ```javascript
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { STSClient, AssumeRoleWithWebIdentityCommand } from "@aws-sdk/client-sts";
+import { getDefaultRoleAssumerWithWebIdentity } from "@aws-sdk/client-sts";
 import { fromWebToken } from "@aws-sdk/credential-provider-web-identity";
-
-const stsClient = new STSClient({});
-
-const roleAssumerWithWebIdentity = async (params) => {
-  const { Credentials } = await stsClient.send(
-    new AssumeRoleWithWebIdentityCommand(params)
-  );
-  if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
-    throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
-  }
-  return {
-    accessKeyId: Credentials.AccessKeyId,
-    secretAccessKey: Credentials.SecretAccessKey,
-    sessionToken: Credentials.SessionToken,
-    expiration: Credentials.Expiration,
-  };
-};
 
 const dynamodb = new DynamoDBClient({
   region,
@@ -77,7 +60,7 @@ const dynamodb = new DynamoDBClient({
     roleArn: 'arn:aws:iam::<AWS_ACCOUNT_ID>/:role/<WEB_IDENTITY_ROLE_NAME>',
     providerId: 'graph.facebook.com|www.amazon.com', // this is null for Google
     webIdentityToken: ACCESS_TOKEN // from OpenID token identity provider
-    roleAssumerWithWebIdentity,
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(),
   })
 });
 
@@ -117,29 +100,12 @@ The following options are supported:
 A basic example of using fromTokenFile:
 
 ```js
-import { STSClient, AssumeRoleWithWebIdentityCommand } from "@aws-sdk/client-sts";
+import { getDefaultRoleAssumerWithWebIdentity } from "@aws-sdk/client-sts";
 import { fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
-
-const stsClient = new STSClient({});
-
-const roleAssumerWithWebIdentity = async (params) => {
-  const { Credentials } = await stsClient.send(
-    new AssumeRoleWithWebIdentityCommand(params)
-  );
-  if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
-    throw new Error(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`);
-  }
-  return {
-    accessKeyId: Credentials.AccessKeyId,
-    secretAccessKey: Credentials.SecretAccessKey,
-    sessionToken: Credentials.SessionToken,
-    expiration: Credentials.Expiration,
-  };
-};
 
 const client = new FooClient({
   credentials: fromTokenFile({
-    roleAssumerWithWebIdentity
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity()
   });
 });
 ```
@@ -167,7 +133,7 @@ const client = new FooClient({
   credentials: fromTokenFile({
     webIdentityTokenFile: "/temp/token",
     roleArn: "arn:aws:iam::123456789012:role/example-role-arn",
-    roleAssumerWithWebIdentity
+    roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity()
   });
 });
 ```

--- a/packages/middleware-sdk-sts/LICENSE
+++ b/packages/middleware-sdk-sts/LICENSE
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-sdk-sts/README.md
+++ b/packages/middleware-sdk-sts/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/middleware-sdk-sts
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-sdk-sts/latest.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-sts)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-sdk-sts.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-sts)

--- a/packages/middleware-sdk-sts/jest.config.js
+++ b/packages/middleware-sdk-sts/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@aws-sdk/middleware-sdk-sts",
+  "version": "3.0.0",
+  "scripts": {
+    "prepublishOnly": "yarn build:cjs && yarn build:es",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build": "yarn build:es && yarn build:cjs",
+    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
+    "test": "jest"
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "types": "./dist/types/index.d.ts",
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/jest": "^26.0.4",
+    "jest": "^26.1.0",
+    "typescript": "~4.1.2"
+  },
+  "dependencies": {
+    "@aws-sdk/middleware-signing": "3.10.0",
+    "@aws-sdk/property-provider": "3.10.0",
+    "@aws-sdk/protocol-http": "3.10.0",
+    "@aws-sdk/signature-v4": "3.10.0",
+    "@aws-sdk/types": "3.10.0",
+    "tslib": "^1.8.0"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "types/*": [
+        "types/ts3.4/*"
+      ]
+    }
+  },
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/middleware-sdk-sts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/middleware-sdk-sts"
+  }
+}

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -2,11 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-sts",
   "version": "3.0.0",
   "scripts": {
-    "prepublishOnly": "yarn build:cjs && yarn build:es",
+    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-sts/src/index.ts
+++ b/packages/middleware-sdk-sts/src/index.ts
@@ -1,0 +1,30 @@
+import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
+import { Client, Credentials, HashConstructor, Pluggable, Provider, RegionInfoProvider } from "@aws-sdk/types";
+
+export interface StsAuthInputConfig extends AwsAuthInputConfig {}
+interface PreviouslyResolved {
+  credentialDefaultProvider: (input: any) => Provider<Credentials>;
+  region: string | Provider<string>;
+  regionInfoProvider: RegionInfoProvider;
+  signingName?: string;
+  serviceId: string;
+  sha256: HashConstructor;
+}
+export interface StsAuthResolvedConfig extends AwsAuthResolvedConfig {
+  stsClientCtor: new (clientConfig: any) => Client<any, any, any>;
+}
+
+/**
+ * Set STS client constructor to `stsClientCtor` config parameter. It is used
+ * for role assumers for STS client internally. See `clients/client-sts/defaultStsRoleAssumers.ts`
+ * and `clients/client-sts/STSClient.ts`.
+ */
+export const resolveStsAuthConfig = <T>(
+  input: T & PreviouslyResolved & StsAuthInputConfig,
+  stsClientCtor: new (clientConfig: any) => Client<any, any, any>
+): T & StsAuthResolvedConfig => {
+  return resolveAwsAuthConfig({
+    ...input,
+    stsClientCtor,
+  });
+};

--- a/packages/middleware-sdk-sts/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sts/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-sdk-sts/tsconfig.es.json
+++ b/packages/middleware-sdk-sts/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/protocol_tests/aws-ec2/runtimeConfig.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/protocol_tests/aws-json/runtimeConfig.ts
+++ b/protocol_tests/aws-json/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/protocol_tests/aws-query/runtimeConfig.ts
+++ b/protocol_tests/aws-query/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/protocol_tests/aws-restjson/runtimeConfig.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "^1.0.0",
     "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-sdk/client-sts": "3.11.0",
     "@aws-sdk/config-resolver": "3.10.0",
     "@aws-sdk/credential-provider-node": "3.11.0",
     "@aws-sdk/fetch-http-handler": "3.10.0",

--- a/protocol_tests/aws-restxml/runtimeConfig.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.ts
@@ -1,5 +1,6 @@
 import packageInfo from "./package.json";
 
+import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -22,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider,
+  credentialDefaultProvider: decorateDefaultCredentialProvider(credentialDefaultProvider),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -20,12 +20,17 @@ const getOverwritablePredicate = (packageName) => (pathName) => {
     "endpoints.ts",
     "README.md",
   ];
+  const additionalGeneratedFiles = {
+    "@aws-sdk/client-sts": ["defaultRoleAssumers.ts", "defaultStsRoleAssumers.ts"],
+  };
   return (
     pathName
       .toLowerCase()
       .startsWith(
         packageName.toLowerCase().replace("@aws-sdk/client-", "").replace("@aws-sdk/aws-", "").replace(/-/g, "")
-      ) || overwritablePathnames.indexOf(pathName) >= 0
+      ) ||
+    overwritablePathnames.indexOf(pathName) >= 0 ||
+    additionalGeneratedFiles[packageName.toLowerCase()]?.indexOf(pathName) >= 0
   );
 };
 


### PR DESCRIPTION
### Issue
Resolves #2087
Resolves #1998
Resolves #2011
Resolves #1193

Replaces #2179 

### Description
This change provides default role assumer for the default credentials provider that calls `sts:assumeRole` or `sts:assumeRoleWithWebIdentity` under the hood. As a result, users don't need to import STS client and supply their own role assumer(like mentioned in #1193).

These assumer is exported from STS client not the `packages/` folder because it can avoid circular dependency. The `credential-provider-*` packages having any dependency over STS client will cause the same issue. As a result this change makes the source code comply the contract that `clients/` depends on `packages/`; `lib/` depends on `packages/` and `clients/`. 

### Testing
✅ It has been manually tested with credential files containing assume role chaining
✅ It has been validate with bundler(Webpack) that tree shaking work well

### Additional context
This PR is based #2179 but it doen't use dynamic import, and doen't introduce separate STS clients.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
