### PR TITLE
Support generating non-AWS client

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -123,7 +123,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
     }
 
     private static boolean isAwsService(Shape serviceShape) {
-        return serviceShape.getTrait(ServiceTrait.class).isPresent();
+        return serviceShape.hasTrait(ServiceTrait.class);
     }
 
     private static boolean operationUsesAwsAuth(Model model, ServiceShape service, OperationShape operation) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -175,9 +177,5 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
             default:
                 return Collections.emptyMap();
         }
-    }
-
-    private static boolean isAwsService(TypeScriptSettings settings, Model model) {
-        return settings.getService(model).hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -116,12 +116,14 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         + "trait was found on " + service.getId());
             }
         }
-        runtimeConfigs.putAll(getDefaultConfig(target, isAwsService(settings, model)));
+        runtimeConfigs.putAll(getDefaultConfig(target, settings, model));
         return runtimeConfigs;
     }
 
-    private Map<String, Consumer<TypeScriptWriter>> getDefaultConfig(LanguageTarget target, boolean isAwsService) {
+    private Map<String, Consumer<TypeScriptWriter>> getDefaultConfig(LanguageTarget target, TypeScriptSettings settings,
+                                                                     Model model) {
         Map<String, Consumer<TypeScriptWriter>> defaultConfigs = new HashMap();
+        boolean isAwsService = isAwsService(settings, model);
         switch (target) {
             case SHARED:
                 return MapUtils.of(
@@ -176,6 +178,6 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
     }
 
     private static boolean isAwsService(TypeScriptSettings settings, Model model) {
-        return settings.getService(model).getTrait(ServiceTrait.class).isPresent();
+        return settings.getService(model).hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -122,8 +122,11 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         return runtimeConfigs;
     }
 
-    private Map<String, Consumer<TypeScriptWriter>> getDefaultConfig(LanguageTarget target, TypeScriptSettings settings,
-                                                                     Model model) {
+    private Map<String, Consumer<TypeScriptWriter>> getDefaultConfig(
+            LanguageTarget target,
+            TypeScriptSettings settings,
+            Model model
+    ) {
         Map<String, Consumer<TypeScriptWriter>> defaultConfigs = new HashMap();
         boolean isAwsService = isAwsService(settings, model);
         switch (target) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -44,6 +44,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
+                        .servicePredicate((m, s) -> testAwsService(s))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Endpoints", HAS_CONFIG)
@@ -129,5 +130,9 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
 
     private static boolean testServiceId(Shape serviceShape, String expectedId) {
         return serviceShape.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("").equals(expectedId);
+    }
+
+    private static boolean testAwsService(Shape serviceShape) {
+        return serviceShape.getTrait(ServiceTrait.class).isPresent();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_CONFIG;
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
@@ -44,7 +45,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
-                        .servicePredicate((m, s) -> testAwsService(s))
+                        .servicePredicate((m, s) -> isAwsService(s))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Endpoints", HAS_CONFIG)
@@ -130,9 +131,5 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
 
     private static boolean testServiceId(Shape serviceShape, String expectedId) {
         return serviceShape.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("").equals(expectedId);
-    }
-
-    private static boolean testAwsService(Shape serviceShape) {
-        return serviceShape.hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -133,6 +133,6 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
     }
 
     private static boolean testAwsService(Shape serviceShape) {
-        return serviceShape.getTrait(ServiceTrait.class).isPresent();
+        return serviceShape.hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
@@ -15,14 +15,14 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -99,13 +99,5 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
             default:
                 return Collections.emptyMap();
         }
-    }
-
-    private static boolean isAwsService(TypeScriptSettings settings, Model model) {
-        return isAwsService(settings.getService(model));
-    }
-
-    private static boolean isAwsService(ServiceShape serviceShape) {
-        return serviceShape.hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
@@ -53,13 +53,14 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
             SymbolProvider symbolProvider,
             TypeScriptWriter writer
     ) {
-        if (isAwsService(settings, model)) {
-            writer.addImport("Provider", "Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-            writer.addImport("UserAgent", "__UserAgent", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-            writer.writeDocs("The provider populating default tracking information to be sent with `user-agent`, "
-                    + "`x-amz-user-agent` header\n@internal");
-            writer.write("defaultUserAgentProvider?: Provider<__UserAgent>;\n");
+        if (!isAwsService(settings, model)) {
+            return;
         }
+        writer.addImport("Provider", "Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("UserAgent", "__UserAgent", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.writeDocs("The provider populating default tracking information to be sent with `user-agent`, "
+                + "`x-amz-user-agent` header\n@internal");
+        writer.write("defaultUserAgentProvider?: Provider<__UserAgent>;\n");
     }
 
     @Override
@@ -105,6 +106,6 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
     }
 
     private static boolean isAwsService(ServiceShape serviceShape) {
-        return serviceShape.getTrait(ServiceTrait.class).isPresent();
+        return serviceShape.hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -15,11 +15,12 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
@@ -85,9 +86,5 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             default:
                 return Collections.emptyMap();
         }
-    }
-
-    private static boolean isAwsService(TypeScriptSettings settings, Model model) {
-        return settings.getService(model).hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
@@ -39,7 +40,7 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             SymbolProvider symbolProvider,
             BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory
     ) {
-        if (!settings.generateClient()) {
+        if (!settings.generateClient() || !isAwsService(settings, model)) {
             return;
         }
 
@@ -55,7 +56,7 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             SymbolProvider symbolProvider,
             TypeScriptWriter writer
     ) {
-        if (!settings.generateClient()) {
+        if (!settings.generateClient() || !isAwsService(settings, model)) {
             return;
         }
 
@@ -71,7 +72,7 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             SymbolProvider symbolProvider,
             LanguageTarget target
     ) {
-        if (!settings.generateClient()) {
+        if (!settings.generateClient() || !isAwsService(settings, model)) {
             return Collections.emptyMap();
         }
 
@@ -84,5 +85,9 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             default:
                 return Collections.emptyMap();
         }
+    }
+
+    private static boolean isAwsService(TypeScriptSettings settings, Model model) {
+        return settings.getService(model).getTrait(ServiceTrait.class).isPresent();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -88,6 +88,6 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
     }
 
     private static boolean isAwsService(TypeScriptSettings settings, Model model) {
-        return settings.getService(model).getTrait(ServiceTrait.class).isPresent();
+        return settings.getService(model).hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -92,6 +92,6 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
     }
 
     private static boolean isAwsService(TypeScriptSettings settings, Model model) {
-        return settings.getService(model).getTrait(ServiceTrait.class).isPresent();
+        return settings.getService(model).hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
+
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.function.BiConsumer;
@@ -89,9 +91,5 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
 
             writer.write(resource);
         });
-    }
-
-    private static boolean isAwsService(TypeScriptSettings settings, Model model) {
-        return settings.getService(model).hasTrait(ServiceTrait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -56,7 +56,8 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
             writer.write(resource);
         });
 
-        if (!settings.generateClient()) {
+        // TODO: May need to generate a different/modified README.md for these cases
+        if (!settings.generateClient() || !isAwsService(settings, model)) {
             return;
         }
 
@@ -88,5 +89,9 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
 
             writer.write(resource);
         });
+    }
+
+    private static boolean isAwsService(TypeScriptSettings settings, Model model) {
+        return settings.getService(model).getTrait(ServiceTrait.class).isPresent();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
@@ -44,6 +44,7 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
                 return symbol;
             }
 
+            // TODO: Should this WARNING be avoided somehow if client is not for an AWS service?
             // If the SDK service ID trait is present, use that, otherwise fall back to
             // the default naming strategy for the service.
             return shape.getTrait(ServiceTrait.class)

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -33,5 +34,13 @@ final class AwsTraitsUtils {
 
     static boolean isAwsService(ServiceShape serviceShape) {
         return serviceShape.hasTrait(ServiceTrait.class);
+    }
+
+    static boolean isSigV4Service(TypeScriptSettings settings, Model model) {
+        return isSigV4Service(settings.getService(model));
+    }
+
+    static boolean isSigV4Service(ServiceShape serviceShape) {
+        return serviceShape.hasTrait(SigV4Trait.class);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+
+/**
+ * Utility methods related to AWS traits.
+ */
+final class AwsTraitsUtils {
+
+    private AwsTraitsUtils() {}
+
+    static boolean isAwsService(TypeScriptSettings settings, Model model) {
+        return isAwsService(settings.getService(model));
+    }
+
+    static boolean isAwsService(ServiceShape serviceShape) {
+        return serviceShape.hasTrait(ServiceTrait.class);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/NotSame.smithy
+++ b/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/NotSame.smithy
@@ -4,6 +4,7 @@ use aws.protocols#restJson1
 
 @aws.api#service(sdkId: "Not Same")
 @restJson1
+@aws.auth#sigv4(name: "notsame")
 service OriginalName {
     version: "2019-10-15",
     operations: [GetFoo]

--- a/packages/config-resolver/src/EndpointsConfig.ts
+++ b/packages/config-resolver/src/EndpointsConfig.ts
@@ -13,9 +13,9 @@ export interface EndpointsInputConfig {
 }
 
 interface PreviouslyResolved {
-  regionInfoProvider: RegionInfoProvider;
+  regionInfoProvider?: RegionInfoProvider;
   urlParser: UrlParser;
-  region: Provider<string>;
+  region?: Provider<string>;
 }
 
 export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> {
@@ -45,6 +45,10 @@ const normalizeEndpoint = (input: EndpointsInputConfig & PreviouslyResolved): Pr
 };
 
 const getEndPointFromRegion = async (input: EndpointsInputConfig & PreviouslyResolved) => {
+  if (input.region === undefined || input.regionInfoProvider === undefined) {
+    throw new Error("No endpoint specified and region is not defined");
+  }
+
   const { tls = true } = input;
   const region = await input.region();
 


### PR DESCRIPTION
### Description
These changes are to support generating a non-AWS typescript client. There are changes in the code generation logic to skip pieces that apply only to AWS services. Some typescript dependencies (aws-sdk/config-resolver) also needed updates.

This is initial prototype work for smithy-typescript-ssdk-demo.

### Testing
Using these changes I successfully generated a working non-AWS typescript client for the bootleg-service in smithy-typescript-ssdk-demo.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
