### PR TITLE
docs(upgrading): add generate-clients doc dependencies

### DIFF
--- a/scripts/generate-clients/README.md
+++ b/scripts/generate-clients/README.md
@@ -2,9 +2,8 @@
 
 ## Prerequisite
 
-This script requires Node.js >= 12
-
-It requires https://github.com/awslabs/smithy-typescript#steps-to-build
+* Node.js version >= 12.
+* [Build and publish Smithy-TypeScript locally](https://github.com/awslabs/smithy-typescript#steps-to-build).
 
 ## Options:
 

--- a/scripts/generate-clients/README.md
+++ b/scripts/generate-clients/README.md
@@ -4,6 +4,8 @@
 
 This script requires Node.js >= 12
 
+It requires https://github.com/awslabs/smithy-typescript#steps-to-build
+
 ## Options:
 
 ```


### PR DESCRIPTION
Documentation to mention dependency on smithy-typescript.

### Issue #1291 

### Description
Add link in documentation text for the dependency smithy-typescript

### Testing
The link to external dependency install steps works, as has been noted by myself and @ajredniwja

### Additional context
The dependency on smithy-typescript crosses over from the usual node/javascript package ecosystem into java/maven/gradle used by smithy.  It's also for an internal/developer step in the codebase.  As such it is not an automated install of the dependency.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
