### PR TITLE
fix(util-dynamodb): unmarshall `null` to match V2 implementation

### DIFF
--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -5,8 +5,11 @@ import { NativeAttributeValue } from "./models";
 
 describe("convertToNative", () => {
   describe("null", () => {
-    it(`returns for null`, () => {
+    it(`returns for null object`, () => {
       expect(convertToNative({ NULL: true })).toEqual(null);
+    });
+    it(`returns for null value`, () => {
+      expect(convertToNative(null)).toEqual(undefined);
     });
   });
 

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -10,6 +10,9 @@ import { unmarshallOptions } from "./unmarshall";
  * @param {unmarshallOptions} options - An optional configuration object for `convertToNative`.
  */
 export const convertToNative = (data: AttributeValue, options?: unmarshallOptions): NativeAttributeValue => {
+  if (data === null) {
+    return undefined;
+  }
   for (const [key, value] of Object.entries(data)) {
     if (value !== undefined) {
       switch (key) {


### PR DESCRIPTION
### Issue
N/A

### Description
For functional pairity with V2's `DynamoDB.Converter.unmarshall()`, V3's `convertToNative()` should not throw an error on `null` values, just return `undefined`.

### Testing
Added a test.

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
