### PR TITLE
docs(client-ses): use await in async/await sample

### DIFF
--- a/clients/client-ses/README.md
+++ b/clients/client-ses/README.md
@@ -140,7 +140,7 @@ const client = new AWS.SES({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cloneReceiptRuleSet(params);
+  const data = await client.cloneReceiptRuleSet(params);
   // process data.
 } catch (error) {
   // error handling.


### PR DESCRIPTION
### Issue
Fix https://github.com/aws/aws-sdk-js-v3/issues/2231
### Description
What does this implement/fix? Explain your changes.
Async await example in client-ses README does not use async/await

### Testing
async/await command would need await to get the expected result based on the sample

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
