### PR TITLE
fix(client-s3): return GetBucketPolicyOutput without parsing

### DIFF
--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -6479,10 +6479,8 @@ export const deserializeAws_restXmlGetBucketPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
-  if (data["Policy"] !== undefined) {
-    contents.Policy = data["Policy"];
-  }
+  const data: any = await collectBodyString(output.body, context);
+  contents.Policy = data;
   return Promise.resolve(contents);
 };
 

--- a/codegen/sdk-codegen/aws-models/s3.2006-03-01.json
+++ b/codegen/sdk-codegen/aws-models/s3.2006-03-01.json
@@ -4233,7 +4233,8 @@
         "Policy": {
           "target": "com.amazonaws.s3#Policy",
           "traits": {
-            "smithy.api#documentation": "<p>The bucket policy as a JSON document.</p>"
+            "smithy.api#documentation": "<p>The bucket policy as a JSON document.</p>",
+            "smithy.api#httpPayload": {}
           }
         }
       }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2040

### Description
Add smithy.api#httpPayload to GetBucketPolicyOutput.

### Testing
Verified that the issue in https://github.com/aws/aws-sdk-js-v3/issues/2040 is not reproducible with this fix.
Verified that this issue is fixed in smithy models, and will not be reverted in the next models update.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
