### PR TITLE
docs(clients): add missing await for client.operationName call

### DIFF
--- a/clients/client-accessanalyzer/README.md
+++ b/clients/client-accessanalyzer/README.md
@@ -137,7 +137,7 @@ const client = new AWS.AccessAnalyzer({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createAnalyzer(params);
+  const data = await client.createAnalyzer(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-acm-pca/README.md
+++ b/clients/client-acm-pca/README.md
@@ -146,7 +146,7 @@ const client = new AWS.ACMPCA({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createCertificateAuthority(params);
+  const data = await client.createCertificateAuthority(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-acm/README.md
+++ b/clients/client-acm/README.md
@@ -137,7 +137,7 @@ const client = new AWS.ACM({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToCertificate(params);
+  const data = await client.addTagsToCertificate(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-alexa-for-business/README.md
+++ b/clients/client-alexa-for-business/README.md
@@ -138,7 +138,7 @@ const client = new AWS.AlexaForBusiness({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.approveSkill(params);
+  const data = await client.approveSkill(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-amplify/README.md
+++ b/clients/client-amplify/README.md
@@ -136,7 +136,7 @@ const client = new AWS.Amplify({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApp(params);
+  const data = await client.createApp(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-amplifybackend/README.md
+++ b/clients/client-amplifybackend/README.md
@@ -131,7 +131,7 @@ const client = new AWS.AmplifyBackend({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cloneBackend(params);
+  const data = await client.cloneBackend(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-api-gateway/README.md
+++ b/clients/client-api-gateway/README.md
@@ -133,7 +133,7 @@ const client = new AWS.APIGateway({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApiKey(params);
+  const data = await client.createApiKey(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-apigatewaymanagementapi/README.md
+++ b/clients/client-apigatewaymanagementapi/README.md
@@ -131,7 +131,7 @@ const client = new AWS.ApiGatewayManagementApi({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteConnection(params);
+  const data = await client.deleteConnection(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-apigatewayv2/README.md
+++ b/clients/client-apigatewayv2/README.md
@@ -131,7 +131,7 @@ const client = new AWS.ApiGatewayV2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApi(params);
+  const data = await client.createApi(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-app-mesh/README.md
+++ b/clients/client-app-mesh/README.md
@@ -143,7 +143,7 @@ const client = new AWS.AppMesh({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createGatewayRoute(params);
+  const data = await client.createGatewayRoute(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-appconfig/README.md
+++ b/clients/client-appconfig/README.md
@@ -180,7 +180,7 @@ const client = new AWS.AppConfig({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApplication(params);
+  const data = await client.createApplication(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-appflow/README.md
+++ b/clients/client-appflow/README.md
@@ -159,7 +159,7 @@ const client = new AWS.Appflow({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createConnectorProfile(params);
+  const data = await client.createConnectorProfile(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-appintegrations/README.md
+++ b/clients/client-appintegrations/README.md
@@ -134,7 +134,7 @@ const client = new AWS.AppIntegrations({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createEventIntegration(params);
+  const data = await client.createEventIntegration(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-application-auto-scaling/README.md
+++ b/clients/client-application-auto-scaling/README.md
@@ -200,7 +200,7 @@ const client = new AWS.ApplicationAutoScaling({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteScalingPolicy(params);
+  const data = await client.deleteScalingPolicy(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-application-discovery-service/README.md
+++ b/clients/client-application-discovery-service/README.md
@@ -262,7 +262,7 @@ const client = new AWS.ApplicationDiscoveryService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateConfigurationItemsToApplication(params);
+  const data = await client.associateConfigurationItemsToApplication(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-application-insights/README.md
+++ b/clients/client-application-insights/README.md
@@ -144,7 +144,7 @@ const client = new AWS.ApplicationInsights({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApplication(params);
+  const data = await client.createApplication(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-appstream/README.md
+++ b/clients/client-appstream/README.md
@@ -152,7 +152,7 @@ const client = new AWS.AppStream({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateFleet(params);
+  const data = await client.associateFleet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-appsync/README.md
+++ b/clients/client-appsync/README.md
@@ -132,7 +132,7 @@ const client = new AWS.AppSync({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApiCache(params);
+  const data = await client.createApiCache(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-athena/README.md
+++ b/clients/client-athena/README.md
@@ -143,7 +143,7 @@ const client = new AWS.Athena({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchGetNamedQuery(params);
+  const data = await client.batchGetNamedQuery(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-auditmanager/README.md
+++ b/clients/client-auditmanager/README.md
@@ -161,7 +161,7 @@ const client = new AWS.AuditManager({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateAssessmentReportEvidenceFolder(params);
+  const data = await client.associateAssessmentReportEvidenceFolder(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-auto-scaling-plans/README.md
+++ b/clients/client-auto-scaling-plans/README.md
@@ -139,7 +139,7 @@ const client = new AWS.AutoScalingPlans({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createScalingPlan(params);
+  const data = await client.createScalingPlan(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-auto-scaling/README.md
+++ b/clients/client-auto-scaling/README.md
@@ -137,7 +137,7 @@ const client = new AWS.AutoScaling({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.attachInstances(params);
+  const data = await client.attachInstances(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-backup/README.md
+++ b/clients/client-backup/README.md
@@ -135,7 +135,7 @@ const client = new AWS.Backup({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createBackupPlan(params);
+  const data = await client.createBackupPlan(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-batch/README.md
+++ b/clients/client-batch/README.md
@@ -140,7 +140,7 @@ const client = new AWS.Batch({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelJob(params);
+  const data = await client.cancelJob(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-braket/README.md
+++ b/clients/client-braket/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Braket({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelQuantumTask(params);
+  const data = await client.cancelQuantumTask(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-budgets/README.md
+++ b/clients/client-budgets/README.md
@@ -173,7 +173,7 @@ const client = new AWS.Budgets({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createBudget(params);
+  const data = await client.createBudget(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-chime/README.md
+++ b/clients/client-chime/README.md
@@ -168,7 +168,7 @@ const client = new AWS.Chime({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associatePhoneNumbersWithVoiceConnector(params);
+  const data = await client.associatePhoneNumbersWithVoiceConnector(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloud9/README.md
+++ b/clients/client-cloud9/README.md
@@ -189,7 +189,7 @@ const client = new AWS.Cloud9({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createEnvironmentEC2(params);
+  const data = await client.createEnvironmentEC2(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-clouddirectory/README.md
+++ b/clients/client-clouddirectory/README.md
@@ -137,7 +137,7 @@ const client = new AWS.CloudDirectory({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addFacetToObject(params);
+  const data = await client.addFacetToObject(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudformation/README.md
+++ b/clients/client-cloudformation/README.md
@@ -146,7 +146,7 @@ const client = new AWS.CloudFormation({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelUpdateStack(params);
+  const data = await client.cancelUpdateStack(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudfront/README.md
+++ b/clients/client-cloudfront/README.md
@@ -134,7 +134,7 @@ const client = new AWS.CloudFront({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createCachePolicy(params);
+  const data = await client.createCachePolicy(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudhsm-v2/README.md
+++ b/clients/client-cloudhsm-v2/README.md
@@ -132,7 +132,7 @@ const client = new AWS.CloudHSMV2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.copyBackupToRegion(params);
+  const data = await client.copyBackupToRegion(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudhsm/README.md
+++ b/clients/client-cloudhsm/README.md
@@ -142,7 +142,7 @@ const client = new AWS.CloudHSM({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToResource(params);
+  const data = await client.addTagsToResource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudsearch-domain/README.md
+++ b/clients/client-cloudsearch-domain/README.md
@@ -134,7 +134,7 @@ const client = new AWS.CloudSearchDomain({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.search(params);
+  const data = await client.search(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudsearch/README.md
+++ b/clients/client-cloudsearch/README.md
@@ -138,7 +138,7 @@ const client = new AWS.CloudSearch({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.buildSuggesters(params);
+  const data = await client.buildSuggesters(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudtrail/README.md
+++ b/clients/client-cloudtrail/README.md
@@ -146,7 +146,7 @@ const client = new AWS.CloudTrail({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTags(params);
+  const data = await client.addTags(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudwatch-events/README.md
+++ b/clients/client-cloudwatch-events/README.md
@@ -152,7 +152,7 @@ const client = new AWS.CloudWatchEvents({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.activateEventSource(params);
+  const data = await client.activateEventSource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudwatch-logs/README.md
+++ b/clients/client-cloudwatch-logs/README.md
@@ -164,7 +164,7 @@ const client = new AWS.CloudWatchLogs({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateKmsKey(params);
+  const data = await client.associateKmsKey(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cloudwatch/README.md
+++ b/clients/client-cloudwatch/README.md
@@ -145,7 +145,7 @@ const client = new AWS.CloudWatch({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteAlarms(params);
+  const data = await client.deleteAlarms(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codeartifact/README.md
+++ b/clients/client-codeartifact/README.md
@@ -406,7 +406,7 @@ const client = new AWS.Codeartifact({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateExternalConnection(params);
+  const data = await client.associateExternalConnection(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codebuild/README.md
+++ b/clients/client-codebuild/README.md
@@ -316,7 +316,7 @@ const client = new AWS.CodeBuild({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchDeleteBuilds(params);
+  const data = await client.batchDeleteBuilds(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codecommit/README.md
+++ b/clients/client-codecommit/README.md
@@ -522,7 +522,7 @@ const client = new AWS.CodeCommit({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateApprovalRuleTemplateWithRepository(params);
+  const data = await client.associateApprovalRuleTemplateWithRepository(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codedeploy/README.md
+++ b/clients/client-codedeploy/README.md
@@ -231,7 +231,7 @@ const client = new AWS.CodeDeploy({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToOnPremisesInstances(params);
+  const data = await client.addTagsToOnPremisesInstances(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codeguru-reviewer/README.md
+++ b/clients/client-codeguru-reviewer/README.md
@@ -146,7 +146,7 @@ const client = new AWS.CodeGuruReviewer({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateRepository(params);
+  const data = await client.associateRepository(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codeguruprofiler/README.md
+++ b/clients/client-codeguruprofiler/README.md
@@ -131,7 +131,7 @@ const client = new AWS.CodeGuruProfiler({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.configureAgent(params);
+  const data = await client.configureAgent(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codepipeline/README.md
+++ b/clients/client-codepipeline/README.md
@@ -326,7 +326,7 @@ const client = new AWS.CodePipeline({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acknowledgeJob(params);
+  const data = await client.acknowledgeJob(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codestar-connections/README.md
+++ b/clients/client-codestar-connections/README.md
@@ -211,7 +211,7 @@ const client = new AWS.CodeStarConnections({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createConnection(params);
+  const data = await client.createConnection(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codestar-notifications/README.md
+++ b/clients/client-codestar-notifications/README.md
@@ -215,7 +215,7 @@ const client = new AWS.CodestarNotifications({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createNotificationRule(params);
+  const data = await client.createNotificationRule(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-codestar/README.md
+++ b/clients/client-codestar/README.md
@@ -221,7 +221,7 @@ const client = new AWS.CodeStar({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateTeamMember(params);
+  const data = await client.associateTeamMember(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cognito-identity-provider/README.md
+++ b/clients/client-cognito-identity-provider/README.md
@@ -139,7 +139,7 @@ const client = new AWS.CognitoIdentityProvider({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addCustomAttributes(params);
+  const data = await client.addCustomAttributes(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cognito-identity/README.md
+++ b/clients/client-cognito-identity/README.md
@@ -145,7 +145,7 @@ const client = new AWS.CognitoIdentity({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createIdentityPool(params);
+  const data = await client.createIdentityPool(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cognito-sync/README.md
+++ b/clients/client-cognito-sync/README.md
@@ -138,7 +138,7 @@ const client = new AWS.CognitoSync({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.bulkPublish(params);
+  const data = await client.bulkPublish(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-comprehend/README.md
+++ b/clients/client-comprehend/README.md
@@ -134,7 +134,7 @@ const client = new AWS.Comprehend({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchDetectDominantLanguage(params);
+  const data = await client.batchDetectDominantLanguage(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-comprehendmedical/README.md
+++ b/clients/client-comprehendmedical/README.md
@@ -132,7 +132,7 @@ const client = new AWS.ComprehendMedical({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeEntitiesDetectionV2Job(params);
+  const data = await client.describeEntitiesDetectionV2Job(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-compute-optimizer/README.md
+++ b/clients/client-compute-optimizer/README.md
@@ -143,7 +143,7 @@ const client = new AWS.ComputeOptimizer({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeRecommendationExportJobs(params);
+  const data = await client.describeRecommendationExportJobs(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-config-service/README.md
+++ b/clients/client-config-service/README.md
@@ -154,7 +154,7 @@ const client = new AWS.ConfigService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchGetAggregateResourceConfig(params);
+  const data = await client.batchGetAggregateResourceConfig(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-connect-contact-lens/README.md
+++ b/clients/client-connect-contact-lens/README.md
@@ -143,7 +143,7 @@ const client = new AWS.ConnectContactLens({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.listRealtimeContactAnalysisSegments(params);
+  const data = await client.listRealtimeContactAnalysisSegments(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-connect/README.md
+++ b/clients/client-connect/README.md
@@ -144,7 +144,7 @@ const client = new AWS.Connect({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateApprovedOrigin(params);
+  const data = await client.associateApprovedOrigin(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-connectparticipant/README.md
+++ b/clients/client-connectparticipant/README.md
@@ -136,7 +136,7 @@ const client = new AWS.ConnectParticipant({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createParticipantConnection(params);
+  const data = await client.createParticipantConnection(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cost-and-usage-report-service/README.md
+++ b/clients/client-cost-and-usage-report-service/README.md
@@ -154,7 +154,7 @@ const client = new AWS.CostAndUsageReportService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteReportDefinition(params);
+  const data = await client.deleteReportDefinition(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-cost-explorer/README.md
+++ b/clients/client-cost-explorer/README.md
@@ -144,7 +144,7 @@ const client = new AWS.CostExplorer({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createAnomalyMonitor(params);
+  const data = await client.createAnomalyMonitor(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-customer-profiles/README.md
+++ b/clients/client-customer-profiles/README.md
@@ -141,7 +141,7 @@ const client = new AWS.CustomerProfiles({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addProfileKey(params);
+  const data = await client.addProfileKey(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-data-pipeline/README.md
+++ b/clients/client-data-pipeline/README.md
@@ -135,7 +135,7 @@ const client = new AWS.DataPipeline({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.activatePipeline(params);
+  const data = await client.activatePipeline(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-database-migration-service/README.md
+++ b/clients/client-database-migration-service/README.md
@@ -144,7 +144,7 @@ const client = new AWS.DatabaseMigrationService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToResource(params);
+  const data = await client.addTagsToResource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-databrew/README.md
+++ b/clients/client-databrew/README.md
@@ -134,7 +134,7 @@ const client = new AWS.DataBrew({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchDeleteRecipeVersion(params);
+  const data = await client.batchDeleteRecipeVersion(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-dataexchange/README.md
+++ b/clients/client-dataexchange/README.md
@@ -131,7 +131,7 @@ const client = new AWS.DataExchange({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelJob(params);
+  const data = await client.cancelJob(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-datasync/README.md
+++ b/clients/client-datasync/README.md
@@ -137,7 +137,7 @@ const client = new AWS.DataSync({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelTaskExecution(params);
+  const data = await client.cancelTaskExecution(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-dax/README.md
+++ b/clients/client-dax/README.md
@@ -136,7 +136,7 @@ const client = new AWS.DAX({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createCluster(params);
+  const data = await client.createCluster(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-detective/README.md
+++ b/clients/client-detective/README.md
@@ -171,7 +171,7 @@ const client = new AWS.Detective({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptInvitation(params);
+  const data = await client.acceptInvitation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-device-farm/README.md
+++ b/clients/client-device-farm/README.md
@@ -145,7 +145,7 @@ const client = new AWS.DeviceFarm({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createDevicePool(params);
+  const data = await client.createDevicePool(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-devops-guru/README.md
+++ b/clients/client-devops-guru/README.md
@@ -129,7 +129,7 @@ const client = new AWS.DevOpsGuru({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addNotificationChannel(params);
+  const data = await client.addNotificationChannel(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-direct-connect/README.md
+++ b/clients/client-direct-connect/README.md
@@ -142,7 +142,7 @@ const client = new AWS.DirectConnect({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptDirectConnectGatewayAssociationProposal(params);
+  const data = await client.acceptDirectConnectGatewayAssociationProposal(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-directory-service/README.md
+++ b/clients/client-directory-service/README.md
@@ -137,7 +137,7 @@ const client = new AWS.DirectoryService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptSharedDirectory(params);
+  const data = await client.acceptSharedDirectory(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-dlm/README.md
+++ b/clients/client-dlm/README.md
@@ -131,7 +131,7 @@ const client = new AWS.DLM({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createLifecyclePolicy(params);
+  const data = await client.createLifecyclePolicy(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-docdb/README.md
+++ b/clients/client-docdb/README.md
@@ -131,7 +131,7 @@ const client = new AWS.DocDB({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToResource(params);
+  const data = await client.addTagsToResource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-dynamodb-streams/README.md
+++ b/clients/client-dynamodb-streams/README.md
@@ -136,7 +136,7 @@ const client = new AWS.DynamoDBStreams({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeStream(params);
+  const data = await client.describeStream(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-dynamodb/README.md
+++ b/clients/client-dynamodb/README.md
@@ -148,7 +148,7 @@ const client = new AWS.DynamoDB({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchExecuteStatement(params);
+  const data = await client.batchExecuteStatement(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ebs/README.md
+++ b/clients/client-ebs/README.md
@@ -149,7 +149,7 @@ const client = new AWS.EBS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.completeSnapshot(params);
+  const data = await client.completeSnapshot(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ec2-instance-connect/README.md
+++ b/clients/client-ec2-instance-connect/README.md
@@ -133,7 +133,7 @@ const client = new AWS.EC2InstanceConnect({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.sendSSHPublicKey(params);
+  const data = await client.sendSSHPublicKey(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ec2/README.md
+++ b/clients/client-ec2/README.md
@@ -154,7 +154,7 @@ const client = new AWS.EC2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptReservedInstancesExchangeQuote(params);
+  const data = await client.acceptReservedInstancesExchangeQuote(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ecr-public/README.md
+++ b/clients/client-ecr-public/README.md
@@ -138,7 +138,7 @@ const client = new AWS.ECRPUBLIC({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchCheckLayerAvailability(params);
+  const data = await client.batchCheckLayerAvailability(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ecr/README.md
+++ b/clients/client-ecr/README.md
@@ -138,7 +138,7 @@ const client = new AWS.ECR({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchCheckLayerAvailability(params);
+  const data = await client.batchCheckLayerAvailability(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ecs/README.md
+++ b/clients/client-ecs/README.md
@@ -146,7 +146,7 @@ const client = new AWS.ECS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createCapacityProvider(params);
+  const data = await client.createCapacityProvider(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-efs/README.md
+++ b/clients/client-efs/README.md
@@ -136,7 +136,7 @@ const client = new AWS.EFS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createAccessPoint(params);
+  const data = await client.createAccessPoint(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-eks/README.md
+++ b/clients/client-eks/README.md
@@ -140,7 +140,7 @@ const client = new AWS.EKS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createAddon(params);
+  const data = await client.createAddon(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-elastic-beanstalk/README.md
+++ b/clients/client-elastic-beanstalk/README.md
@@ -144,7 +144,7 @@ const client = new AWS.ElasticBeanstalk({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.abortEnvironmentUpdate(params);
+  const data = await client.abortEnvironmentUpdate(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-elastic-inference/README.md
+++ b/clients/client-elastic-inference/README.md
@@ -133,7 +133,7 @@ const client = new AWS.ElasticInference({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeAcceleratorOfferings(params);
+  const data = await client.describeAcceleratorOfferings(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-elastic-load-balancing-v2/README.md
+++ b/clients/client-elastic-load-balancing-v2/README.md
@@ -166,7 +166,7 @@ const client = new AWS.ElasticLoadBalancingV2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addListenerCertificates(params);
+  const data = await client.addListenerCertificates(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-elastic-load-balancing/README.md
+++ b/clients/client-elastic-load-balancing/README.md
@@ -151,7 +151,7 @@ const client = new AWS.ElasticLoadBalancing({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTags(params);
+  const data = await client.addTags(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-elastic-transcoder/README.md
+++ b/clients/client-elastic-transcoder/README.md
@@ -133,7 +133,7 @@ const client = new AWS.ElasticTranscoder({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelJob(params);
+  const data = await client.cancelJob(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-elasticache/README.md
+++ b/clients/client-elasticache/README.md
@@ -141,7 +141,7 @@ const client = new AWS.ElastiCache({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToResource(params);
+  const data = await client.addTagsToResource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-elasticsearch-service/README.md
+++ b/clients/client-elasticsearch-service/README.md
@@ -144,7 +144,7 @@ const client = new AWS.ElasticsearchService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptInboundCrossClusterSearchConnection(params);
+  const data = await client.acceptInboundCrossClusterSearchConnection(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-emr-containers/README.md
+++ b/clients/client-emr-containers/README.md
@@ -152,7 +152,7 @@ const client = new AWS.EMRContainers({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelJobRun(params);
+  const data = await client.cancelJobRun(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-emr/README.md
+++ b/clients/client-emr/README.md
@@ -134,7 +134,7 @@ const client = new AWS.EMR({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addInstanceFleet(params);
+  const data = await client.addInstanceFleet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-eventbridge/README.md
+++ b/clients/client-eventbridge/README.md
@@ -152,7 +152,7 @@ const client = new AWS.EventBridge({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.activateEventSource(params);
+  const data = await client.activateEventSource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-firehose/README.md
+++ b/clients/client-firehose/README.md
@@ -135,7 +135,7 @@ const client = new AWS.Firehose({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createDeliveryStream(params);
+  const data = await client.createDeliveryStream(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-fms/README.md
+++ b/clients/client-fms/README.md
@@ -139,7 +139,7 @@ const client = new AWS.FMS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateAdminAccount(params);
+  const data = await client.associateAdminAccount(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-forecast/README.md
+++ b/clients/client-forecast/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Forecast({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createDataset(params);
+  const data = await client.createDataset(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-forecastquery/README.md
+++ b/clients/client-forecastquery/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Forecastquery({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.queryForecast(params);
+  const data = await client.queryForecast(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-frauddetector/README.md
+++ b/clients/client-frauddetector/README.md
@@ -133,7 +133,7 @@ const client = new AWS.FraudDetector({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchCreateVariable(params);
+  const data = await client.batchCreateVariable(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-fsx/README.md
+++ b/clients/client-fsx/README.md
@@ -132,7 +132,7 @@ const client = new AWS.FSx({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateFileSystemAliases(params);
+  const data = await client.associateFileSystemAliases(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-gamelift/README.md
+++ b/clients/client-gamelift/README.md
@@ -182,7 +182,7 @@ const client = new AWS.GameLift({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptMatch(params);
+  const data = await client.acceptMatch(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-glacier/README.md
+++ b/clients/client-glacier/README.md
@@ -168,7 +168,7 @@ const client = new AWS.Glacier({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.abortMultipartUpload(params);
+  const data = await client.abortMultipartUpload(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-global-accelerator/README.md
+++ b/clients/client-global-accelerator/README.md
@@ -279,7 +279,7 @@ const client = new AWS.GlobalAccelerator({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addCustomRoutingEndpoints(params);
+  const data = await client.addCustomRoutingEndpoints(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-glue/README.md
+++ b/clients/client-glue/README.md
@@ -133,7 +133,7 @@ const client = new AWS.Glue({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchCreatePartition(params);
+  const data = await client.batchCreatePartition(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-greengrass/README.md
+++ b/clients/client-greengrass/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Greengrass({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateRoleToGroup(params);
+  const data = await client.associateRoleToGroup(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-groundstation/README.md
+++ b/clients/client-groundstation/README.md
@@ -134,7 +134,7 @@ const client = new AWS.GroundStation({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelContact(params);
+  const data = await client.cancelContact(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-guardduty/README.md
+++ b/clients/client-guardduty/README.md
@@ -147,7 +147,7 @@ const client = new AWS.GuardDuty({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptInvitation(params);
+  const data = await client.acceptInvitation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-health/README.md
+++ b/clients/client-health/README.md
@@ -168,7 +168,7 @@ const client = new AWS.Health({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeAffectedAccountsForOrganization(params);
+  const data = await client.describeAffectedAccountsForOrganization(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-healthlake/README.md
+++ b/clients/client-healthlake/README.md
@@ -132,7 +132,7 @@ const client = new AWS.HealthLake({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createFHIRDatastore(params);
+  const data = await client.createFHIRDatastore(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-honeycode/README.md
+++ b/clients/client-honeycode/README.md
@@ -135,7 +135,7 @@ const client = new AWS.Honeycode({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchCreateTableRows(params);
+  const data = await client.batchCreateTableRows(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iam/README.md
+++ b/clients/client-iam/README.md
@@ -136,7 +136,7 @@ const client = new AWS.IAM({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addClientIDToOpenIDConnectProvider(params);
+  const data = await client.addClientIDToOpenIDConnectProvider(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-identitystore/README.md
+++ b/clients/client-identitystore/README.md
@@ -129,7 +129,7 @@ const client = new AWS.Identitystore({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeGroup(params);
+  const data = await client.describeGroup(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-imagebuilder/README.md
+++ b/clients/client-imagebuilder/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Imagebuilder({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelImageCreation(params);
+  const data = await client.cancelImageCreation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-inspector/README.md
+++ b/clients/client-inspector/README.md
@@ -135,7 +135,7 @@ const client = new AWS.Inspector({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addAttributesToFindings(params);
+  const data = await client.addAttributesToFindings(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iot-1click-devices-service/README.md
+++ b/clients/client-iot-1click-devices-service/README.md
@@ -139,7 +139,7 @@ const client = new AWS.IoT1ClickDevicesService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.claimDevicesByClaimCode(params);
+  const data = await client.claimDevicesByClaimCode(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iot-1click-projects/README.md
+++ b/clients/client-iot-1click-projects/README.md
@@ -131,7 +131,7 @@ const client = new AWS.IoT1ClickProjects({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateDeviceWithPlacement(params);
+  const data = await client.associateDeviceWithPlacement(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iot-data-plane/README.md
+++ b/clients/client-iot-data-plane/README.md
@@ -142,7 +142,7 @@ const client = new AWS.IoTDataPlane({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteThingShadow(params);
+  const data = await client.deleteThingShadow(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iot-events-data/README.md
+++ b/clients/client-iot-events-data/README.md
@@ -133,7 +133,7 @@ const client = new AWS.IoTEventsData({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchPutMessage(params);
+  const data = await client.batchPutMessage(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iot-events/README.md
+++ b/clients/client-iot-events/README.md
@@ -133,7 +133,7 @@ const client = new AWS.IoTEvents({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createDetectorModel(params);
+  const data = await client.createDetectorModel(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iot-jobs-data-plane/README.md
+++ b/clients/client-iot-jobs-data-plane/README.md
@@ -141,7 +141,7 @@ const client = new AWS.IoTJobsDataPlane({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeJobExecution(params);
+  const data = await client.describeJobExecution(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iot/README.md
+++ b/clients/client-iot/README.md
@@ -147,7 +147,7 @@ const client = new AWS.IoT({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptCertificateTransfer(params);
+  const data = await client.acceptCertificateTransfer(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iotanalytics/README.md
+++ b/clients/client-iotanalytics/README.md
@@ -149,7 +149,7 @@ const client = new AWS.IoTAnalytics({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchPutMessage(params);
+  const data = await client.batchPutMessage(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iotsecuretunneling/README.md
+++ b/clients/client-iotsecuretunneling/README.md
@@ -136,7 +136,7 @@ const client = new AWS.IoTSecureTunneling({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.closeTunnel(params);
+  const data = await client.closeTunnel(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iotsitewise/README.md
+++ b/clients/client-iotsitewise/README.md
@@ -132,7 +132,7 @@ const client = new AWS.IoTSiteWise({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateAssets(params);
+  const data = await client.associateAssets(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-iotthingsgraph/README.md
+++ b/clients/client-iotthingsgraph/README.md
@@ -136,7 +136,7 @@ const client = new AWS.IoTThingsGraph({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateEntityToThing(params);
+  const data = await client.associateEntityToThing(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ivs/README.md
+++ b/clients/client-ivs/README.md
@@ -403,7 +403,7 @@ const client = new AWS.Ivs({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchGetChannel(params);
+  const data = await client.batchGetChannel(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kafka/README.md
+++ b/clients/client-kafka/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Kafka({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchAssociateScramSecret(params);
+  const data = await client.batchAssociateScramSecret(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kendra/README.md
+++ b/clients/client-kendra/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Kendra({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchDeleteDocument(params);
+  const data = await client.batchDeleteDocument(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kinesis-analytics-v2/README.md
+++ b/clients/client-kinesis-analytics-v2/README.md
@@ -139,7 +139,7 @@ const client = new AWS.KinesisAnalyticsV2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addApplicationCloudWatchLoggingOption(params);
+  const data = await client.addApplicationCloudWatchLoggingOption(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kinesis-analytics/README.md
+++ b/clients/client-kinesis-analytics/README.md
@@ -147,7 +147,7 @@ const client = new AWS.KinesisAnalytics({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addApplicationCloudWatchLoggingOption(params);
+  const data = await client.addApplicationCloudWatchLoggingOption(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kinesis-video-archived-media/README.md
+++ b/clients/client-kinesis-video-archived-media/README.md
@@ -131,7 +131,7 @@ const client = new AWS.KinesisVideoArchivedMedia({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getClip(params);
+  const data = await client.getClip(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kinesis-video-media/README.md
+++ b/clients/client-kinesis-video-media/README.md
@@ -131,7 +131,7 @@ const client = new AWS.KinesisVideoMedia({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getMedia(params);
+  const data = await client.getMedia(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kinesis-video-signaling/README.md
+++ b/clients/client-kinesis-video-signaling/README.md
@@ -133,7 +133,7 @@ const client = new AWS.KinesisVideoSignaling({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getIceServerConfig(params);
+  const data = await client.getIceServerConfig(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kinesis-video/README.md
+++ b/clients/client-kinesis-video/README.md
@@ -131,7 +131,7 @@ const client = new AWS.KinesisVideo({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createSignalingChannel(params);
+  const data = await client.createSignalingChannel(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kinesis/README.md
+++ b/clients/client-kinesis/README.md
@@ -134,7 +134,7 @@ const client = new AWS.Kinesis({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToStream(params);
+  const data = await client.addTagsToStream(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-kms/README.md
+++ b/clients/client-kms/README.md
@@ -220,7 +220,7 @@ const client = new AWS.KMS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelKeyDeletion(params);
+  const data = await client.cancelKeyDeletion(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-lakeformation/README.md
+++ b/clients/client-lakeformation/README.md
@@ -133,7 +133,7 @@ const client = new AWS.LakeFormation({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchGrantPermissions(params);
+  const data = await client.batchGrantPermissions(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-lambda/README.md
+++ b/clients/client-lambda/README.md
@@ -138,7 +138,7 @@ const client = new AWS.Lambda({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addLayerVersionPermission(params);
+  const data = await client.addLayerVersionPermission(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-lex-model-building-service/README.md
+++ b/clients/client-lex-model-building-service/README.md
@@ -138,7 +138,7 @@ const client = new AWS.LexModelBuildingService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createBotVersion(params);
+  const data = await client.createBotVersion(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-lex-runtime-service/README.md
+++ b/clients/client-lex-runtime-service/README.md
@@ -139,7 +139,7 @@ const client = new AWS.LexRuntimeService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteSession(params);
+  const data = await client.deleteSession(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-license-manager/README.md
+++ b/clients/client-license-manager/README.md
@@ -134,7 +134,7 @@ const client = new AWS.LicenseManager({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptGrant(params);
+  const data = await client.acceptGrant(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-lightsail/README.md
+++ b/clients/client-lightsail/README.md
@@ -145,7 +145,7 @@ const client = new AWS.Lightsail({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.allocateStaticIp(params);
+  const data = await client.allocateStaticIp(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-lookoutvision/README.md
+++ b/clients/client-lookoutvision/README.md
@@ -137,7 +137,7 @@ const client = new AWS.LookoutVision({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createDataset(params);
+  const data = await client.createDataset(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-machine-learning/README.md
+++ b/clients/client-machine-learning/README.md
@@ -132,7 +132,7 @@ const client = new AWS.MachineLearning({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTags(params);
+  const data = await client.addTags(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-macie/README.md
+++ b/clients/client-macie/README.md
@@ -142,7 +142,7 @@ const client = new AWS.Macie({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateMemberAccount(params);
+  const data = await client.associateMemberAccount(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-macie2/README.md
+++ b/clients/client-macie2/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Macie2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptInvitation(params);
+  const data = await client.acceptInvitation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-managedblockchain/README.md
+++ b/clients/client-managedblockchain/README.md
@@ -132,7 +132,7 @@ const client = new AWS.ManagedBlockchain({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createMember(params);
+  const data = await client.createMember(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-marketplace-catalog/README.md
+++ b/clients/client-marketplace-catalog/README.md
@@ -137,7 +137,7 @@ const client = new AWS.MarketplaceCatalog({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelChangeSet(params);
+  const data = await client.cancelChangeSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-marketplace-commerce-analytics/README.md
+++ b/clients/client-marketplace-commerce-analytics/README.md
@@ -137,7 +137,7 @@ const client = new AWS.MarketplaceCommerceAnalytics({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.generateDataSet(params);
+  const data = await client.generateDataSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-marketplace-entitlement-service/README.md
+++ b/clients/client-marketplace-entitlement-service/README.md
@@ -154,7 +154,7 @@ const client = new AWS.MarketplaceEntitlementService({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getEntitlements(params);
+  const data = await client.getEntitlements(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-marketplace-metering/README.md
+++ b/clients/client-marketplace-metering/README.md
@@ -188,7 +188,7 @@ const client = new AWS.MarketplaceMetering({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchMeterUsage(params);
+  const data = await client.batchMeterUsage(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mediaconnect/README.md
+++ b/clients/client-mediaconnect/README.md
@@ -131,7 +131,7 @@ const client = new AWS.MediaConnect({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addFlowOutputs(params);
+  const data = await client.addFlowOutputs(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mediaconvert/README.md
+++ b/clients/client-mediaconvert/README.md
@@ -131,7 +131,7 @@ const client = new AWS.MediaConvert({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateCertificate(params);
+  const data = await client.associateCertificate(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-medialive/README.md
+++ b/clients/client-medialive/README.md
@@ -131,7 +131,7 @@ const client = new AWS.MediaLive({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptInputDeviceTransfer(params);
+  const data = await client.acceptInputDeviceTransfer(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mediapackage-vod/README.md
+++ b/clients/client-mediapackage-vod/README.md
@@ -131,7 +131,7 @@ const client = new AWS.MediaPackageVod({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createAsset(params);
+  const data = await client.createAsset(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mediapackage/README.md
+++ b/clients/client-mediapackage/README.md
@@ -131,7 +131,7 @@ const client = new AWS.MediaPackage({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.configureLogs(params);
+  const data = await client.configureLogs(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mediastore-data/README.md
+++ b/clients/client-mediastore-data/README.md
@@ -133,7 +133,7 @@ const client = new AWS.MediaStoreData({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteObject(params);
+  const data = await client.deleteObject(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mediastore/README.md
+++ b/clients/client-mediastore/README.md
@@ -132,7 +132,7 @@ const client = new AWS.MediaStore({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createContainer(params);
+  const data = await client.createContainer(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mediatailor/README.md
+++ b/clients/client-mediatailor/README.md
@@ -131,7 +131,7 @@ const client = new AWS.MediaTailor({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deletePlaybackConfiguration(params);
+  const data = await client.deletePlaybackConfiguration(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-migration-hub/README.md
+++ b/clients/client-migration-hub/README.md
@@ -136,7 +136,7 @@ const client = new AWS.MigrationHub({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateCreatedArtifact(params);
+  const data = await client.associateCreatedArtifact(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-migrationhub-config/README.md
+++ b/clients/client-migrationhub-config/README.md
@@ -156,7 +156,7 @@ const client = new AWS.MigrationHubConfig({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createHomeRegionControl(params);
+  const data = await client.createHomeRegionControl(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mobile/README.md
+++ b/clients/client-mobile/README.md
@@ -135,7 +135,7 @@ const client = new AWS.Mobile({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createProject(params);
+  const data = await client.createProject(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mq/README.md
+++ b/clients/client-mq/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Mq({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createBroker(params);
+  const data = await client.createBroker(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-mturk/README.md
+++ b/clients/client-mturk/README.md
@@ -131,7 +131,7 @@ const client = new AWS.MTurk({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptQualificationRequest(params);
+  const data = await client.acceptQualificationRequest(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-neptune/README.md
+++ b/clients/client-neptune/README.md
@@ -149,7 +149,7 @@ const client = new AWS.Neptune({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addRoleToDBCluster(params);
+  const data = await client.addRoleToDBCluster(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-network-firewall/README.md
+++ b/clients/client-network-firewall/README.md
@@ -210,7 +210,7 @@ const client = new AWS.NetworkFirewall({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateFirewallPolicy(params);
+  const data = await client.associateFirewallPolicy(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-networkmanager/README.md
+++ b/clients/client-networkmanager/README.md
@@ -133,7 +133,7 @@ const client = new AWS.NetworkManager({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateCustomerGateway(params);
+  const data = await client.associateCustomerGateway(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-opsworks/README.md
+++ b/clients/client-opsworks/README.md
@@ -246,7 +246,7 @@ const client = new AWS.OpsWorks({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.assignInstance(params);
+  const data = await client.assignInstance(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-opsworkscm/README.md
+++ b/clients/client-opsworkscm/README.md
@@ -219,7 +219,7 @@ const client = new AWS.OpsWorksCM({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateNode(params);
+  const data = await client.associateNode(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-organizations/README.md
+++ b/clients/client-organizations/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Organizations({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptHandshake(params);
+  const data = await client.acceptHandshake(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-outposts/README.md
+++ b/clients/client-outposts/README.md
@@ -136,7 +136,7 @@ const client = new AWS.Outposts({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createOutpost(params);
+  const data = await client.createOutpost(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-personalize-events/README.md
+++ b/clients/client-personalize-events/README.md
@@ -132,7 +132,7 @@ const client = new AWS.PersonalizeEvents({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.putEvents(params);
+  const data = await client.putEvents(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-personalize-runtime/README.md
+++ b/clients/client-personalize-runtime/README.md
@@ -131,7 +131,7 @@ const client = new AWS.PersonalizeRuntime({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getPersonalizedRanking(params);
+  const data = await client.getPersonalizedRanking(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-personalize/README.md
+++ b/clients/client-personalize/README.md
@@ -132,7 +132,7 @@ const client = new AWS.Personalize({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createBatchInferenceJob(params);
+  const data = await client.createBatchInferenceJob(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-pi/README.md
+++ b/clients/client-pi/README.md
@@ -144,7 +144,7 @@ const client = new AWS.PI({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeDimensionKeys(params);
+  const data = await client.describeDimensionKeys(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-pinpoint-email/README.md
+++ b/clients/client-pinpoint-email/README.md
@@ -160,7 +160,7 @@ const client = new AWS.PinpointEmail({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createConfigurationSet(params);
+  const data = await client.createConfigurationSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-pinpoint-sms-voice/README.md
+++ b/clients/client-pinpoint-sms-voice/README.md
@@ -131,7 +131,7 @@ const client = new AWS.PinpointSMSVoice({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createConfigurationSet(params);
+  const data = await client.createConfigurationSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-pinpoint/README.md
+++ b/clients/client-pinpoint/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Pinpoint({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApp(params);
+  const data = await client.createApp(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-polly/README.md
+++ b/clients/client-polly/README.md
@@ -136,7 +136,7 @@ const client = new AWS.Polly({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteLexicon(params);
+  const data = await client.deleteLexicon(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-pricing/README.md
+++ b/clients/client-pricing/README.md
@@ -154,7 +154,7 @@ const client = new AWS.Pricing({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeServices(params);
+  const data = await client.describeServices(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-qldb-session/README.md
+++ b/clients/client-qldb-session/README.md
@@ -151,7 +151,7 @@ const client = new AWS.QLDBSession({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.sendCommand(params);
+  const data = await client.sendCommand(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-qldb/README.md
+++ b/clients/client-qldb/README.md
@@ -131,7 +131,7 @@ const client = new AWS.QLDB({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelJournalKinesisStream(params);
+  const data = await client.cancelJournalKinesisStream(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-quicksight/README.md
+++ b/clients/client-quicksight/README.md
@@ -136,7 +136,7 @@ const client = new AWS.QuickSight({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelIngestion(params);
+  const data = await client.cancelIngestion(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ram/README.md
+++ b/clients/client-ram/README.md
@@ -136,7 +136,7 @@ const client = new AWS.RAM({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptResourceShareInvitation(params);
+  const data = await client.acceptResourceShareInvitation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-rds-data/README.md
+++ b/clients/client-rds-data/README.md
@@ -141,7 +141,7 @@ const client = new AWS.RDSData({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchExecuteStatement(params);
+  const data = await client.batchExecuteStatement(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-rds/README.md
+++ b/clients/client-rds/README.md
@@ -188,7 +188,7 @@ const client = new AWS.RDS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addRoleToDBCluster(params);
+  const data = await client.addRoleToDBCluster(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-redshift-data/README.md
+++ b/clients/client-redshift-data/README.md
@@ -132,7 +132,7 @@ const client = new AWS.RedshiftData({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelStatement(params);
+  const data = await client.cancelStatement(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-redshift/README.md
+++ b/clients/client-redshift/README.md
@@ -153,7 +153,7 @@ const client = new AWS.Redshift({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptReservedNodeExchange(params);
+  const data = await client.acceptReservedNodeExchange(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-rekognition/README.md
+++ b/clients/client-rekognition/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Rekognition({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.compareFaces(params);
+  const data = await client.compareFaces(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-resource-groups-tagging-api/README.md
+++ b/clients/client-resource-groups-tagging-api/README.md
@@ -894,7 +894,7 @@ const client = new AWS.ResourceGroupsTaggingAPI({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.describeReportCreation(params);
+  const data = await client.describeReportCreation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-resource-groups/README.md
+++ b/clients/client-resource-groups/README.md
@@ -166,7 +166,7 @@ const client = new AWS.ResourceGroups({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createGroup(params);
+  const data = await client.createGroup(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-robomaker/README.md
+++ b/clients/client-robomaker/README.md
@@ -131,7 +131,7 @@ const client = new AWS.RoboMaker({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchDeleteWorlds(params);
+  const data = await client.batchDeleteWorlds(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-route-53-domains/README.md
+++ b/clients/client-route-53-domains/README.md
@@ -137,7 +137,7 @@ const client = new AWS.Route53Domains({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptDomainTransferFromAnotherAwsAccount(params);
+  const data = await client.acceptDomainTransferFromAnotherAwsAccount(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-route-53/README.md
+++ b/clients/client-route-53/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Route53({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateVPCWithHostedZone(params);
+  const data = await client.associateVPCWithHostedZone(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-route53resolver/README.md
+++ b/clients/client-route53resolver/README.md
@@ -160,7 +160,7 @@ const client = new AWS.Route53Resolver({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateResolverEndpointIpAddress(params);
+  const data = await client.associateResolverEndpointIpAddress(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-s3-control/README.md
+++ b/clients/client-s3-control/README.md
@@ -134,7 +134,7 @@ const client = new AWS.S3Control({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createAccessPoint(params);
+  const data = await client.createAccessPoint(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-s3/README.md
+++ b/clients/client-s3/README.md
@@ -131,7 +131,7 @@ const client = new AWS.S3({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.abortMultipartUpload(params);
+  const data = await client.abortMultipartUpload(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-s3outposts/README.md
+++ b/clients/client-s3outposts/README.md
@@ -131,7 +131,7 @@ const client = new AWS.S3Outposts({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createEndpoint(params);
+  const data = await client.createEndpoint(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sagemaker-a2i-runtime/README.md
+++ b/clients/client-sagemaker-a2i-runtime/README.md
@@ -160,7 +160,7 @@ const client = new AWS.SageMakerA2IRuntime({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteHumanLoop(params);
+  const data = await client.deleteHumanLoop(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sagemaker-edge/README.md
+++ b/clients/client-sagemaker-edge/README.md
@@ -131,7 +131,7 @@ const client = new AWS.SagemakerEdge({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getDeviceRegistration(params);
+  const data = await client.getDeviceRegistration(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sagemaker-featurestore-runtime/README.md
+++ b/clients/client-sagemaker-featurestore-runtime/README.md
@@ -163,7 +163,7 @@ const client = new AWS.SageMakerFeatureStoreRuntime({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.deleteRecord(params);
+  const data = await client.deleteRecord(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sagemaker-runtime/README.md
+++ b/clients/client-sagemaker-runtime/README.md
@@ -131,7 +131,7 @@ const client = new AWS.SageMakerRuntime({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.invokeEndpoint(params);
+  const data = await client.invokeEndpoint(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sagemaker/README.md
+++ b/clients/client-sagemaker/README.md
@@ -146,7 +146,7 @@ const client = new AWS.SageMaker({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addAssociation(params);
+  const data = await client.addAssociation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-savingsplans/README.md
+++ b/clients/client-savingsplans/README.md
@@ -134,7 +134,7 @@ const client = new AWS.Savingsplans({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createSavingsPlan(params);
+  const data = await client.createSavingsPlan(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-schemas/README.md
+++ b/clients/client-schemas/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Schemas({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createDiscoverer(params);
+  const data = await client.createDiscoverer(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-secrets-manager/README.md
+++ b/clients/client-secrets-manager/README.md
@@ -187,7 +187,7 @@ const client = new AWS.SecretsManager({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelRotateSecret(params);
+  const data = await client.cancelRotateSecret(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-securityhub/README.md
+++ b/clients/client-securityhub/README.md
@@ -185,7 +185,7 @@ const client = new AWS.SecurityHub({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptInvitation(params);
+  const data = await client.acceptInvitation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-serverlessapplicationrepository/README.md
+++ b/clients/client-serverlessapplicationrepository/README.md
@@ -156,7 +156,7 @@ const client = new AWS.ServerlessApplicationRepository({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApplication(params);
+  const data = await client.createApplication(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-service-catalog-appregistry/README.md
+++ b/clients/client-service-catalog-appregistry/README.md
@@ -137,7 +137,7 @@ const client = new AWS.ServiceCatalogAppRegistry({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateAttributeGroup(params);
+  const data = await client.associateAttributeGroup(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-service-catalog/README.md
+++ b/clients/client-service-catalog/README.md
@@ -138,7 +138,7 @@ const client = new AWS.ServiceCatalog({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.acceptPortfolioShare(params);
+  const data = await client.acceptPortfolioShare(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-service-quotas/README.md
+++ b/clients/client-service-quotas/README.md
@@ -142,7 +142,7 @@ const client = new AWS.ServiceQuotas({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateServiceQuotaTemplate(params);
+  const data = await client.associateServiceQuotaTemplate(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-servicediscovery/README.md
+++ b/clients/client-servicediscovery/README.md
@@ -135,7 +135,7 @@ const client = new AWS.ServiceDiscovery({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createHttpNamespace(params);
+  const data = await client.createHttpNamespace(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ses/README.md
+++ b/clients/client-ses/README.md
@@ -140,7 +140,7 @@ const client = new AWS.SES({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cloneReceiptRuleSet(params);
+  const data = await client.cloneReceiptRuleSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sesv2/README.md
+++ b/clients/client-sesv2/README.md
@@ -151,7 +151,7 @@ const client = new AWS.SESv2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createConfigurationSet(params);
+  const data = await client.createConfigurationSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sfn/README.md
+++ b/clients/client-sfn/README.md
@@ -147,7 +147,7 @@ const client = new AWS.SFN({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createActivity(params);
+  const data = await client.createActivity(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-shield/README.md
+++ b/clients/client-shield/README.md
@@ -135,7 +135,7 @@ const client = new AWS.Shield({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateDRTLogBucket(params);
+  const data = await client.associateDRTLogBucket(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-signer/README.md
+++ b/clients/client-signer/README.md
@@ -147,7 +147,7 @@ const client = new AWS.Signer({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addProfilePermission(params);
+  const data = await client.addProfilePermission(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sms/README.md
+++ b/clients/client-sms/README.md
@@ -148,7 +148,7 @@ const client = new AWS.SMS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createApp(params);
+  const data = await client.createApp(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-snowball/README.md
+++ b/clients/client-snowball/README.md
@@ -137,7 +137,7 @@ const client = new AWS.Snowball({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelCluster(params);
+  const data = await client.cancelCluster(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sns/README.md
+++ b/clients/client-sns/README.md
@@ -145,7 +145,7 @@ const client = new AWS.SNS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addPermission(params);
+  const data = await client.addPermission(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sqs/README.md
+++ b/clients/client-sqs/README.md
@@ -199,7 +199,7 @@ const client = new AWS.SQS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addPermission(params);
+  const data = await client.addPermission(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-ssm/README.md
+++ b/clients/client-ssm/README.md
@@ -145,7 +145,7 @@ const client = new AWS.SSM({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addTagsToResource(params);
+  const data = await client.addTagsToResource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sso-admin/README.md
+++ b/clients/client-sso-admin/README.md
@@ -129,7 +129,7 @@ const client = new AWS.SSOAdmin({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.attachManagedPolicyToPermissionSet(params);
+  const data = await client.attachManagedPolicyToPermissionSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sso-oidc/README.md
+++ b/clients/client-sso-oidc/README.md
@@ -148,7 +148,7 @@ const client = new AWS.SSOOIDC({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createToken(params);
+  const data = await client.createToken(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sso/README.md
+++ b/clients/client-sso/README.md
@@ -146,7 +146,7 @@ const client = new AWS.SSO({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getRoleCredentials(params);
+  const data = await client.getRoleCredentials(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-storage-gateway/README.md
+++ b/clients/client-storage-gateway/README.md
@@ -202,7 +202,7 @@ const client = new AWS.StorageGateway({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.activateGateway(params);
+  const data = await client.activateGateway(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-sts/README.md
+++ b/clients/client-sts/README.md
@@ -136,7 +136,7 @@ const client = new AWS.STS({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.assumeRole(params);
+  const data = await client.assumeRole(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-support/README.md
+++ b/clients/client-support/README.md
@@ -208,7 +208,7 @@ const client = new AWS.Support({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.addAttachmentsToSet(params);
+  const data = await client.addAttachmentsToSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-swf/README.md
+++ b/clients/client-swf/README.md
@@ -146,7 +146,7 @@ const client = new AWS.SWF({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.countClosedWorkflowExecutions(params);
+  const data = await client.countClosedWorkflowExecutions(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-synthetics/README.md
+++ b/clients/client-synthetics/README.md
@@ -147,7 +147,7 @@ const client = new AWS.Synthetics({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createCanary(params);
+  const data = await client.createCanary(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-textract/README.md
+++ b/clients/client-textract/README.md
@@ -133,7 +133,7 @@ const client = new AWS.Textract({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.analyzeDocument(params);
+  const data = await client.analyzeDocument(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-timestream-query/README.md
+++ b/clients/client-timestream-query/README.md
@@ -133,7 +133,7 @@ const client = new AWS.TimestreamQuery({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.cancelQuery(params);
+  const data = await client.cancelQuery(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-timestream-write/README.md
+++ b/clients/client-timestream-write/README.md
@@ -131,7 +131,7 @@ const client = new AWS.TimestreamWrite({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createDatabase(params);
+  const data = await client.createDatabase(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-transcribe-streaming/README.md
+++ b/clients/client-transcribe-streaming/README.md
@@ -137,7 +137,7 @@ const client = new AWS.TranscribeStreaming({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.startMedicalStreamTranscription(params);
+  const data = await client.startMedicalStreamTranscription(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-transcribe/README.md
+++ b/clients/client-transcribe/README.md
@@ -131,7 +131,7 @@ const client = new AWS.Transcribe({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createLanguageModel(params);
+  const data = await client.createLanguageModel(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-transfer/README.md
+++ b/clients/client-transfer/README.md
@@ -139,7 +139,7 @@ const client = new AWS.Transfer({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createServer(params);
+  const data = await client.createServer(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-translate/README.md
+++ b/clients/client-translate/README.md
@@ -132,7 +132,7 @@ const client = new AWS.Translate({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createParallelData(params);
+  const data = await client.createParallelData(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-waf-regional/README.md
+++ b/clients/client-waf-regional/README.md
@@ -141,7 +141,7 @@ const client = new AWS.WAFRegional({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateWebACL(params);
+  const data = await client.associateWebACL(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-waf/README.md
+++ b/clients/client-waf/README.md
@@ -141,7 +141,7 @@ const client = new AWS.WAF({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.createByteMatchSet(params);
+  const data = await client.createByteMatchSet(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-wafv2/README.md
+++ b/clients/client-wafv2/README.md
@@ -187,7 +187,7 @@ const client = new AWS.WAFV2({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateWebACL(params);
+  const data = await client.associateWebACL(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-workdocs/README.md
+++ b/clients/client-workdocs/README.md
@@ -163,7 +163,7 @@ const client = new AWS.WorkDocs({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.abortDocumentVersionUpload(params);
+  const data = await client.abortDocumentVersionUpload(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-worklink/README.md
+++ b/clients/client-worklink/README.md
@@ -137,7 +137,7 @@ const client = new AWS.WorkLink({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateDomain(params);
+  const data = await client.associateDomain(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-workmail/README.md
+++ b/clients/client-workmail/README.md
@@ -165,7 +165,7 @@ const client = new AWS.WorkMail({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateDelegateToResource(params);
+  const data = await client.associateDelegateToResource(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-workmailmessageflow/README.md
+++ b/clients/client-workmailmessageflow/README.md
@@ -135,7 +135,7 @@ const client = new AWS.WorkMailMessageFlow({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.getRawMessageContent(params);
+  const data = await client.getRawMessageContent(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-workspaces/README.md
+++ b/clients/client-workspaces/README.md
@@ -134,7 +134,7 @@ const client = new AWS.WorkSpaces({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.associateConnectionAlias(params);
+  const data = await client.associateConnectionAlias(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/clients/client-xray/README.md
+++ b/clients/client-xray/README.md
@@ -132,7 +132,7 @@ const client = new AWS.XRay({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.batchGetTraces(params);
+  const data = await client.batchGetTraces(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
@@ -127,7 +127,7 @@ const client = new AWS.${serviceId}({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.${operationName}(params);
+  const data = await client.${operationName}(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/protocol_tests/aws-ec2/README.md
+++ b/protocol_tests/aws-ec2/README.md
@@ -131,7 +131,7 @@ const client = new AWS.EC2Protocol({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.emptyInputAndEmptyOutput(params);
+  const data = await client.emptyInputAndEmptyOutput(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/protocol_tests/aws-json/README.md
+++ b/protocol_tests/aws-json/README.md
@@ -129,7 +129,7 @@ const client = new AWS.JsonProtocol({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.emptyOperation(params);
+  const data = await client.emptyOperation(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/protocol_tests/aws-query/README.md
+++ b/protocol_tests/aws-query/README.md
@@ -131,7 +131,7 @@ const client = new AWS.QueryProtocol({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.emptyInputAndEmptyOutput(params);
+  const data = await client.emptyInputAndEmptyOutput(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/protocol_tests/aws-restjson/README.md
+++ b/protocol_tests/aws-restjson/README.md
@@ -131,7 +131,7 @@ const client = new AWS.RestJsonProtocol({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.allQueryStringTypes(params);
+  const data = await client.allQueryStringTypes(params);
   // process data.
 } catch (error) {
   // error handling.

--- a/protocol_tests/aws-restxml/README.md
+++ b/protocol_tests/aws-restxml/README.md
@@ -131,7 +131,7 @@ const client = new AWS.RestXmlProtocol({ region: "REGION" });
 
 // async/await.
 try {
-  const data = client.allQueryStringTypes(params);
+  const data = await client.allQueryStringTypes(params);
   // process data.
 } catch (error) {
   // error handling.


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2231

### Description
Adds missing await for client.operationName call in README

### Testing
Verified that missing await is added in README

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
