### PR TITLE
chore(protocol_tests): consume httpQueryParams trait

### DIFF
--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -150,6 +150,11 @@ export const serializeAws_restJson1AllQueryStringTypesCommand = async (
   const headers: any = {};
   let resolvedPath = "/AllQueryStringTypesInput";
   const query: any = {
+    ...(input.queryParamsMapOfStrings !== undefined &&
+      Object.entries(input.queryParamsMapOfStrings || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
     ...(input.queryString !== undefined && { String: input.queryString }),
     ...(input.queryStringList !== undefined && { StringList: (input.queryStringList || []).map((_entry) => _entry) }),
     ...(input.queryStringSet !== undefined && {
@@ -1233,6 +1238,11 @@ export const serializeAws_restJson1QueryParamsAsStringListMapCommand = async (
   const headers: any = {};
   let resolvedPath = "/StringListMap";
   const query: any = {
+    ...(input.foo !== undefined &&
+      Object.entries(input.foo || {}).reduce(
+        (acc: any, [key, value]: [string, string[]]) => ({ ...acc, [key]: (value || []).map((_entry) => _entry) }),
+        {}
+      )),
     ...(input.qux !== undefined && { corge: input.qux }),
   };
   let body: any;
@@ -1256,6 +1266,11 @@ export const serializeAws_restJson1QueryPrecedenceCommand = async (
   const headers: any = {};
   let resolvedPath = "/Precedence";
   const query: any = {
+    ...(input.baz !== undefined &&
+      Object.entries(input.baz || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
     ...(input.foo !== undefined && { bar: input.foo }),
   };
   let body: any;

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -150,11 +150,7 @@ export const serializeAws_restJson1AllQueryStringTypesCommand = async (
   const headers: any = {};
   let resolvedPath = "/AllQueryStringTypesInput";
   const query: any = {
-    ...(input.queryParamsMapOfStrings !== undefined &&
-      Object.entries(input.queryParamsMapOfStrings || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.queryParamsMapOfStrings !== undefined && input.queryParamsMapOfStrings),
     ...(input.queryString !== undefined && { String: input.queryString }),
     ...(input.queryStringList !== undefined && { StringList: (input.queryStringList || []).map((_entry) => _entry) }),
     ...(input.queryStringSet !== undefined && {
@@ -1238,11 +1234,7 @@ export const serializeAws_restJson1QueryParamsAsStringListMapCommand = async (
   const headers: any = {};
   let resolvedPath = "/StringListMap";
   const query: any = {
-    ...(input.foo !== undefined &&
-      Object.entries(input.foo || {}).reduce(
-        (acc: any, [key, value]: [string, string[]]) => ({ ...acc, [key]: (value || []).map((_entry) => _entry) }),
-        {}
-      )),
+    ...(input.foo !== undefined && input.foo),
     ...(input.qux !== undefined && { corge: input.qux }),
   };
   let body: any;
@@ -1266,11 +1258,7 @@ export const serializeAws_restJson1QueryPrecedenceCommand = async (
   const headers: any = {};
   let resolvedPath = "/Precedence";
   const query: any = {
-    ...(input.baz !== undefined &&
-      Object.entries(input.baz || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.baz !== undefined && input.baz),
     ...(input.foo !== undefined && { bar: input.foo }),
   };
   let body: any;

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -173,6 +173,11 @@ export const serializeAws_restXmlAllQueryStringTypesCommand = async (
   const headers: any = {};
   let resolvedPath = "/AllQueryStringTypesInput";
   const query: any = {
+    ...(input.queryParamsMapOfStrings !== undefined &&
+      Object.entries(input.queryParamsMapOfStrings || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
     ...(input.queryString !== undefined && { String: input.queryString }),
     ...(input.queryStringList !== undefined && { StringList: (input.queryStringList || []).map((_entry) => _entry) }),
     ...(input.queryStringSet !== undefined && {
@@ -1148,6 +1153,11 @@ export const serializeAws_restXmlQueryParamsAsStringListMapCommand = async (
   const headers: any = {};
   let resolvedPath = "/StringListMap";
   const query: any = {
+    ...(input.foo !== undefined &&
+      Object.entries(input.foo || {}).reduce(
+        (acc: any, [key, value]: [string, string[]]) => ({ ...acc, [key]: (value || []).map((_entry) => _entry) }),
+        {}
+      )),
     ...(input.qux !== undefined && { corge: input.qux }),
   };
   let body: any;
@@ -1171,6 +1181,11 @@ export const serializeAws_restXmlQueryPrecedenceCommand = async (
   const headers: any = {};
   let resolvedPath = "/Precedence";
   const query: any = {
+    ...(input.baz !== undefined &&
+      Object.entries(input.baz || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
     ...(input.foo !== undefined && { bar: input.foo }),
   };
   let body: any;

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -173,11 +173,7 @@ export const serializeAws_restXmlAllQueryStringTypesCommand = async (
   const headers: any = {};
   let resolvedPath = "/AllQueryStringTypesInput";
   const query: any = {
-    ...(input.queryParamsMapOfStrings !== undefined &&
-      Object.entries(input.queryParamsMapOfStrings || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.queryParamsMapOfStrings !== undefined && input.queryParamsMapOfStrings),
     ...(input.queryString !== undefined && { String: input.queryString }),
     ...(input.queryStringList !== undefined && { StringList: (input.queryStringList || []).map((_entry) => _entry) }),
     ...(input.queryStringSet !== undefined && {
@@ -1153,11 +1149,7 @@ export const serializeAws_restXmlQueryParamsAsStringListMapCommand = async (
   const headers: any = {};
   let resolvedPath = "/StringListMap";
   const query: any = {
-    ...(input.foo !== undefined &&
-      Object.entries(input.foo || {}).reduce(
-        (acc: any, [key, value]: [string, string[]]) => ({ ...acc, [key]: (value || []).map((_entry) => _entry) }),
-        {}
-      )),
+    ...(input.foo !== undefined && input.foo),
     ...(input.qux !== undefined && { corge: input.qux }),
   };
   let body: any;
@@ -1181,11 +1173,7 @@ export const serializeAws_restXmlQueryPrecedenceCommand = async (
   const headers: any = {};
   let resolvedPath = "/Precedence";
   const query: any = {
-    ...(input.baz !== undefined &&
-      Object.entries(input.baz || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.baz !== undefined && input.baz),
     ...(input.foo !== undefined && { bar: input.foo }),
   };
   let body: any;


### PR DESCRIPTION
### Issue
Internal JS-2492

### Description
Generated code to consume smithy [httpQueryParams](https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#httpqueryparams-trait) trait. Codegen PR in https://github.com/awslabs/smithy-typescript/pull/311

### Testing
CI, as well as with API Gateway client in https://github.com/aws/aws-sdk-js-v3/pull/2249

This PR will be merged to `pin-smithy-1.7.x` branch which would update PR https://github.com/aws/aws-sdk-js-v3/pull/2197

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
