### PR TITLE
chore(api-gateway): generate client with httpQueryParams

### DIFF
--- a/clients/client-api-gateway/models/models_0.ts
+++ b/clients/client-api-gateway/models/models_0.ts
@@ -2743,7 +2743,7 @@ export interface QuotaSettings {
   limit?: number;
 
   /**
-   * <p>The number of requests subtracted from the given limit in the initial time period.</p>
+   * <p>The day that a time period starts. For example, with a time period of <code>WEEK</code>, an offset of <code>0</code> starts on Sunday, and an offset of <code>1</code> starts on Monday.</p>
    */
   offset?: number;
 
@@ -5899,6 +5899,11 @@ export namespace VpcLinks {
  */
 export interface ImportApiKeysRequest {
   /**
+   * <p>The payload of the POST request to import API keys. For the payload format, see <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/api-key-file-format.html">API Key File Format</a>.</p>
+   */
+  body: Uint8Array | undefined;
+
+  /**
    * <p>A query parameter to specify the input format to imported API keys. Currently, only the <code>csv</code> format is supported.</p>
    */
   format: ApiKeysFormat | string | undefined;
@@ -5963,6 +5968,11 @@ export interface ImportDocumentationPartsRequest {
    * <p>A query parameter to specify whether to rollback the documentation importation (<code>true</code>) or not (<code>false</code>) when a warning is encountered. The default value is <code>false</code>.</p>
    */
   failOnWarnings?: boolean;
+
+  /**
+   * <p>[Required] Raw byte array representing the to-be-imported documentation parts. To import from an OpenAPI file, this is a JSON object.</p>
+   */
+  body: Uint8Array | undefined;
 }
 
 export namespace ImportDocumentationPartsRequest {
@@ -5992,6 +6002,11 @@ export interface ImportRestApiRequest {
    *         <pre><code>aws apigateway import-rest-api --parameters endpointConfigurationTypes=REGIONAL --body 'file:///path/to/imported-api-body.json'</code></pre>
    */
   parameters?: { [key: string]: string };
+
+  /**
+   * <p>[Required] The POST request body containing external API definitions. Currently, only OpenAPI definition JSON/YAML files are supported. The maximum size of the API definition file is 6MB.</p>
+   */
+  body: Uint8Array | undefined;
 }
 
 export namespace ImportRestApiRequest {
@@ -6334,6 +6349,11 @@ export interface PutRestApiRequest {
    * <p>Custom header parameters as part of the request. For example, to exclude <a>DocumentationParts</a> from an imported API, set <code>ignore=documentation</code> as a <code>parameters</code> value, as in the AWS CLI command of <code>aws apigateway import-rest-api --parameters ignore=documentation --body 'file:///path/to/imported-api-body.json'</code>.</p>
    */
   parameters?: { [key: string]: string };
+
+  /**
+   * <p>[Required] The PUT request body containing external API definitions. Currently, only OpenAPI definition JSON/YAML files are supported. The maximum size of the API definition file is 6MB.</p>
+   */
+  body: Uint8Array | undefined;
 }
 
 export namespace PutRestApiRequest {

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -2308,7 +2308,6 @@ export const serializeAws_restJson1GetExportCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    "content-type": "application/json",
     ...(isSerializableHeaderValue(input.accepts) && { accept: input.accepts! }),
   };
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}/exports/{exportType}";
@@ -2339,13 +2338,14 @@ export const serializeAws_restJson1GetExportCommand = async (
   } else {
     throw new Error("No value provided for input HTTP label: exportType.");
   }
-  let body: any;
-  body = JSON.stringify({
+  const query: any = {
     ...(input.parameters !== undefined &&
-      input.parameters !== null && {
-        parameters: serializeAws_restJson1MapOfStringToString(input.parameters, context),
-      }),
-  });
+      Object.entries(input.parameters || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
+  };
+  let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2354,6 +2354,7 @@ export const serializeAws_restJson1GetExportCommand = async (
     method: "GET",
     headers,
     path: resolvedPath,
+    query,
     body,
   });
 };
@@ -2943,9 +2944,7 @@ export const serializeAws_restJson1GetSdkCommand = async (
   input: GetSdkCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {
-    "content-type": "application/json",
-  };
+  const headers: any = {};
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}/sdks/{sdkType}";
   if (input.restApiId !== undefined) {
     const labelValue: string = input.restApiId;
@@ -2974,13 +2973,14 @@ export const serializeAws_restJson1GetSdkCommand = async (
   } else {
     throw new Error("No value provided for input HTTP label: sdkType.");
   }
-  let body: any;
-  body = JSON.stringify({
+  const query: any = {
     ...(input.parameters !== undefined &&
-      input.parameters !== null && {
-        parameters: serializeAws_restJson1MapOfStringToString(input.parameters, context),
-      }),
-  });
+      Object.entries(input.parameters || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
+  };
+  let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -2989,6 +2989,7 @@ export const serializeAws_restJson1GetSdkCommand = async (
     method: "GET",
     headers,
     path: resolvedPath,
+    query,
     body,
   });
 };
@@ -3363,7 +3364,9 @@ export const serializeAws_restJson1ImportApiKeysCommand = async (
   input: ImportApiKeysCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/octet-stream",
+  };
   let resolvedPath = "/apikeys";
   const query: any = {
     mode: "import",
@@ -3371,6 +3374,9 @@ export const serializeAws_restJson1ImportApiKeysCommand = async (
     ...(input.failOnWarnings !== undefined && { failonwarnings: input.failOnWarnings.toString() }),
   };
   let body: any;
+  if (input.body !== undefined) {
+    body = input.body;
+  }
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3388,7 +3394,9 @@ export const serializeAws_restJson1ImportDocumentationPartsCommand = async (
   input: ImportDocumentationPartsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/octet-stream",
+  };
   let resolvedPath = "/restapis/{restApiId}/documentation/parts";
   if (input.restApiId !== undefined) {
     const labelValue: string = input.restApiId;
@@ -3404,6 +3412,9 @@ export const serializeAws_restJson1ImportDocumentationPartsCommand = async (
     ...(input.failOnWarnings !== undefined && { failonwarnings: input.failOnWarnings.toString() }),
   };
   let body: any;
+  if (input.body !== undefined) {
+    body = input.body;
+  }
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3422,20 +3433,22 @@ export const serializeAws_restJson1ImportRestApiCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    "content-type": "application/json",
+    "content-type": "application/octet-stream",
   };
   let resolvedPath = "/restapis";
   const query: any = {
     mode: "import",
+    ...(input.parameters !== undefined &&
+      Object.entries(input.parameters || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
     ...(input.failOnWarnings !== undefined && { failonwarnings: input.failOnWarnings.toString() }),
   };
   let body: any;
-  body = JSON.stringify({
-    ...(input.parameters !== undefined &&
-      input.parameters !== null && {
-        parameters: serializeAws_restJson1MapOfStringToString(input.parameters, context),
-      }),
-  });
+  if (input.body !== undefined) {
+    body = input.body;
+  }
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,
@@ -3793,7 +3806,7 @@ export const serializeAws_restJson1PutRestApiCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    "content-type": "application/json",
+    "content-type": "application/octet-stream",
   };
   let resolvedPath = "/restapis/{restApiId}";
   if (input.restApiId !== undefined) {
@@ -3806,16 +3819,18 @@ export const serializeAws_restJson1PutRestApiCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {
+    ...(input.parameters !== undefined &&
+      Object.entries(input.parameters || {}).reduce(
+        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
+        {}
+      )),
     ...(input.mode !== undefined && { mode: input.mode }),
     ...(input.failOnWarnings !== undefined && { failonwarnings: input.failOnWarnings.toString() }),
   };
   let body: any;
-  body = JSON.stringify({
-    ...(input.parameters !== undefined &&
-      input.parameters !== null && {
-        parameters: serializeAws_restJson1MapOfStringToString(input.parameters, context),
-      }),
-  });
+  if (input.body !== undefined) {
+    body = input.body;
+  }
   const { hostname, protocol = "https", port } = await context.endpoint();
   return new __HttpRequest({
     protocol,

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -2339,11 +2339,7 @@ export const serializeAws_restJson1GetExportCommand = async (
     throw new Error("No value provided for input HTTP label: exportType.");
   }
   const query: any = {
-    ...(input.parameters !== undefined &&
-      Object.entries(input.parameters || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.parameters !== undefined && input.parameters),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
@@ -2974,11 +2970,7 @@ export const serializeAws_restJson1GetSdkCommand = async (
     throw new Error("No value provided for input HTTP label: sdkType.");
   }
   const query: any = {
-    ...(input.parameters !== undefined &&
-      Object.entries(input.parameters || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.parameters !== undefined && input.parameters),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
@@ -3438,11 +3430,7 @@ export const serializeAws_restJson1ImportRestApiCommand = async (
   let resolvedPath = "/restapis";
   const query: any = {
     mode: "import",
-    ...(input.parameters !== undefined &&
-      Object.entries(input.parameters || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.parameters !== undefined && input.parameters),
     ...(input.failOnWarnings !== undefined && { failonwarnings: input.failOnWarnings.toString() }),
   };
   let body: any;
@@ -3819,11 +3807,7 @@ export const serializeAws_restJson1PutRestApiCommand = async (
     throw new Error("No value provided for input HTTP label: restApiId.");
   }
   const query: any = {
-    ...(input.parameters !== undefined &&
-      Object.entries(input.parameters || {}).reduce(
-        (acc: any, [key, value]: [string, string]) => ({ ...acc, [key]: value }),
-        {}
-      )),
+    ...(input.parameters !== undefined && input.parameters),
     ...(input.mode !== undefined && { mode: input.mode }),
     ...(input.failOnWarnings !== undefined && { failonwarnings: input.failOnWarnings.toString() }),
   };

--- a/codegen/sdk-codegen/aws-models/api-gateway.2015-07-09.json
+++ b/codegen/sdk-codegen/aws-models/api-gateway.2015-07-09.json
@@ -3868,13 +3868,16 @@
         "smithy.api#documentation": "<p>The endpoint type. The valid values are <code>EDGE</code> for edge-optimized API setup, most suitable for mobile applications; <code>REGIONAL</code> for regional API endpoint setup, most suitable for calling from AWS Region; and <code>PRIVATE</code> for private APIs.</p>",
         "smithy.api#enum": [
           {
-            "value": "REGIONAL"
+            "value": "REGIONAL",
+            "name": "REGIONAL"
           },
           {
-            "value": "EDGE"
+            "value": "EDGE",
+            "name": "EDGE"
           },
           {
-            "value": "PRIVATE"
+            "value": "PRIVATE",
+            "name": "PRIVATE"
           }
         ]
       }
@@ -5248,7 +5251,8 @@
         "parameters": {
           "target": "com.amazonaws.apigateway#MapOfStringToString",
           "traits": {
-            "smithy.api#documentation": "<p>A key-value map of query string parameters that specify properties of the export, depending on the requested <code>exportType</code>. For <code>exportType</code> <code>oas30</code> and <code>swagger</code>, any combination of the following parameters are supported: <code>extensions='integrations'</code> or <code>extensions='apigateway'</code> will export the API with x-amazon-apigateway-integration extensions. <code>extensions='authorizers'</code> will export the API with  x-amazon-apigateway-authorizer extensions. <code>postman</code> will export the API with Postman extensions, allowing for import to the Postman tool</p>"
+            "smithy.api#documentation": "<p>A key-value map of query string parameters that specify properties of the export, depending on the requested <code>exportType</code>. For <code>exportType</code> <code>oas30</code> and <code>swagger</code>, any combination of the following parameters are supported: <code>extensions='integrations'</code> or <code>extensions='apigateway'</code> will export the API with x-amazon-apigateway-integration extensions. <code>extensions='authorizers'</code> will export the API with  x-amazon-apigateway-authorizer extensions. <code>postman</code> will export the API with Postman extensions, allowing for import to the Postman tool</p>",
+            "smithy.api#httpQueryParams": {}
           }
         },
         "accepts": {
@@ -6223,7 +6227,8 @@
         "parameters": {
           "target": "com.amazonaws.apigateway#MapOfStringToString",
           "traits": {
-            "smithy.api#documentation": "<p>A string-to-string key-value map of query parameters <code>sdkType</code>-dependent properties of the SDK. For <code>sdkType</code> of <code>objectivec</code> or <code>swift</code>,  a parameter named <code>classPrefix</code> is required. For <code>sdkType</code> of <code>android</code>, parameters named <code>groupId</code>, <code>artifactId</code>, <code>artifactVersion</code>, and <code>invokerPackage</code> are required. For <code>sdkType</code> of <code>java</code>, parameters named <code>serviceName</code> and <code>javaPackageName</code> are required. </p>"
+            "smithy.api#documentation": "<p>A string-to-string key-value map of query parameters <code>sdkType</code>-dependent properties of the SDK. For <code>sdkType</code> of <code>objectivec</code> or <code>swift</code>,  a parameter named <code>classPrefix</code> is required. For <code>sdkType</code> of <code>android</code>, parameters named <code>groupId</code>, <code>artifactId</code>, <code>artifactVersion</code>, and <code>invokerPackage</code> are required. For <code>sdkType</code> of <code>java</code>, parameters named <code>serviceName</code> and <code>javaPackageName</code> are required. </p>",
+            "smithy.api#httpQueryParams": {}
           }
         }
       },
@@ -6962,6 +6967,14 @@
     "com.amazonaws.apigateway#ImportApiKeysRequest": {
       "type": "structure",
       "members": {
+        "body": {
+          "target": "com.amazonaws.apigateway#Blob",
+          "traits": {
+            "smithy.api#documentation": "<p>The payload of the POST request to import API keys. For the payload format, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/api-key-file-format.html\">API Key File Format</a>.</p>",
+            "smithy.api#httpPayload": {},
+            "smithy.api#required": {}
+          }
+        },
         "format": {
           "target": "com.amazonaws.apigateway#ApiKeysFormat",
           "traits": {
@@ -7039,6 +7052,14 @@
             "smithy.api#documentation": "<p>A query parameter to specify whether to rollback the documentation importation (<code>true</code>) or not (<code>false</code>) when a warning is encountered. The default value is <code>false</code>.</p>",
             "smithy.api#httpQuery": "failonwarnings"
           }
+        },
+        "body": {
+          "target": "com.amazonaws.apigateway#Blob",
+          "traits": {
+            "smithy.api#documentation": "<p>[Required] Raw byte array representing the to-be-imported documentation parts. To import from an OpenAPI file, this is a JSON object.</p>",
+            "smithy.api#httpPayload": {},
+            "smithy.api#required": {}
+          }
         }
       },
       "traits": {
@@ -7092,7 +7113,16 @@
         "parameters": {
           "target": "com.amazonaws.apigateway#MapOfStringToString",
           "traits": {
-            "smithy.api#documentation": "<p>A key-value map of context-specific query string parameters specifying the behavior of different API importing operations. The following shows operation-specific parameters and their supported values.</p>\n        <p> To exclude <a>DocumentationParts</a> from the import, set <code>parameters</code> as <code>ignore=documentation</code>.</p>\n      <p> To configure the endpoint type, set <code>parameters</code> as <code>endpointConfigurationTypes=EDGE</code>, <code>endpointConfigurationTypes=REGIONAL</code>, or <code>endpointConfigurationTypes=PRIVATE</code>. The default endpoint type is <code>EDGE</code>.</p>\n        <p> To handle imported <code>basepath</code>, set <code>parameters</code> as <code>basepath=ignore</code>, <code>basepath=prepend</code> or <code>basepath=split</code>.</p>\n        <p>For example, the AWS CLI command to exclude documentation from the imported API is:</p> \n        <pre><code>aws apigateway import-rest-api --parameters ignore=documentation --body 'file:///path/to/imported-api-body.json'</code></pre>\n        <p>The AWS CLI command to set the regional endpoint on the imported API is:</p>\n        <pre><code>aws apigateway import-rest-api --parameters endpointConfigurationTypes=REGIONAL --body 'file:///path/to/imported-api-body.json'</code></pre>"
+            "smithy.api#documentation": "<p>A key-value map of context-specific query string parameters specifying the behavior of different API importing operations. The following shows operation-specific parameters and their supported values.</p>\n        <p> To exclude <a>DocumentationParts</a> from the import, set <code>parameters</code> as <code>ignore=documentation</code>.</p>\n      <p> To configure the endpoint type, set <code>parameters</code> as <code>endpointConfigurationTypes=EDGE</code>, <code>endpointConfigurationTypes=REGIONAL</code>, or <code>endpointConfigurationTypes=PRIVATE</code>. The default endpoint type is <code>EDGE</code>.</p>\n        <p> To handle imported <code>basepath</code>, set <code>parameters</code> as <code>basepath=ignore</code>, <code>basepath=prepend</code> or <code>basepath=split</code>.</p>\n        <p>For example, the AWS CLI command to exclude documentation from the imported API is:</p> \n        <pre><code>aws apigateway import-rest-api --parameters ignore=documentation --body 'file:///path/to/imported-api-body.json'</code></pre>\n        <p>The AWS CLI command to set the regional endpoint on the imported API is:</p>\n        <pre><code>aws apigateway import-rest-api --parameters endpointConfigurationTypes=REGIONAL --body 'file:///path/to/imported-api-body.json'</code></pre>",
+            "smithy.api#httpQueryParams": {}
+          }
+        },
+        "body": {
+          "target": "com.amazonaws.apigateway#Blob",
+          "traits": {
+            "smithy.api#documentation": "<p>[Required] The POST request body containing external API definitions. Currently, only OpenAPI definition JSON/YAML files are supported. The maximum size of the API definition file is 6MB.</p>",
+            "smithy.api#httpPayload": {},
+            "smithy.api#required": {}
           }
         }
       },
@@ -7883,22 +7913,28 @@
       "traits": {
         "smithy.api#enum": [
           {
-            "value": "add"
+            "value": "add",
+            "name": "add"
           },
           {
-            "value": "remove"
+            "value": "remove",
+            "name": "remove"
           },
           {
-            "value": "replace"
+            "value": "replace",
+            "name": "replace"
           },
           {
-            "value": "move"
+            "value": "move",
+            "name": "move"
           },
           {
-            "value": "copy"
+            "value": "copy",
+            "name": "copy"
           },
           {
-            "value": "test"
+            "value": "test",
+            "name": "test"
           }
         ]
       }
@@ -8560,7 +8596,16 @@
         "parameters": {
           "target": "com.amazonaws.apigateway#MapOfStringToString",
           "traits": {
-            "smithy.api#documentation": "<p>Custom header parameters as part of the request. For example, to exclude <a>DocumentationParts</a> from an imported API, set <code>ignore=documentation</code> as a <code>parameters</code> value, as in the AWS CLI command of <code>aws apigateway import-rest-api --parameters ignore=documentation --body 'file:///path/to/imported-api-body.json'</code>.</p>"
+            "smithy.api#documentation": "<p>Custom header parameters as part of the request. For example, to exclude <a>DocumentationParts</a> from an imported API, set <code>ignore=documentation</code> as a <code>parameters</code> value, as in the AWS CLI command of <code>aws apigateway import-rest-api --parameters ignore=documentation --body 'file:///path/to/imported-api-body.json'</code>.</p>",
+            "smithy.api#httpQueryParams": {}
+          }
+        },
+        "body": {
+          "target": "com.amazonaws.apigateway#Blob",
+          "traits": {
+            "smithy.api#documentation": "<p>[Required] The PUT request body containing external API definitions. Currently, only OpenAPI definition JSON/YAML files are supported. The maximum size of the API definition file is 6MB.</p>",
+            "smithy.api#httpPayload": {},
+            "smithy.api#required": {}
           }
         }
       },
@@ -8599,7 +8644,7 @@
         "offset": {
           "target": "com.amazonaws.apigateway#Integer",
           "traits": {
-            "smithy.api#documentation": "<p>The number of requests subtracted from the given limit in the initial time period.</p>"
+            "smithy.api#documentation": "<p>The day that a time period starts. For example, with a time period of <code>WEEK</code>, an offset of <code>0</code> starts on Sunday, and an offset of <code>1</code> starts on Monday.</p>"
           }
         },
         "period": {
@@ -8954,10 +8999,12 @@
       "traits": {
         "smithy.api#enum": [
           {
-            "value": "TLS_1_0"
+            "value": "TLS_1_0",
+            "name": "TLS_1_0"
           },
           {
-            "value": "TLS_1_2"
+            "value": "TLS_1_2",
+            "name": "TLS_1_2"
           }
         ]
       }


### PR DESCRIPTION
### Issue
Draft PR (not to be merged) for testing https://github.com/aws/aws-sdk-js-v3/pull/2246

### Description
chore(api-gateway): generate client with httpQueryParams

### Testing
Verified the operation `getSdk` which uses httpQueryParams trait for `parameters` key returns same output from workspace client:

```js
const { APIGateway } = require("@aws-sdk/client-api-gateway");
// const { APIGateway } = require("../aws-sdk-js-v3/clients/client-api-gateway");

(async () => {
  const region = "us-west-2";
  const client = new APIGateway({ region });

  const restApiId = "restApiId"; // Populate rest API ID
  const stageName = "latest"; // Populate Stage Name
  const sdkType = "ruby";
  const parameters = { "service.name": "name" }; // Populate Service Name

  console.log(
    await client.getSdk({ restApiId, stageName, sdkType, parameters })
  );
})();

```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
