### PR TITLE
feat(credential-provider-node): add support for web identity provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
       "**/karma*/**",
       "**/@types/mocha*",
       "**/@types/mocha*/**",
+      "**/@aws-sdk/client-sts/**",
       "**/@aws-sdk/client-sso/**"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
       "**/karma*/**",
       "**/@types/mocha*",
       "**/@types/mocha*/**",
-      "**/@aws-sdk/client-sts/**",
       "**/@aws-sdk/client-sso/**"
     ]
   },

--- a/packages/credential-provider-node/README.md
+++ b/packages/credential-provider-node/README.md
@@ -8,8 +8,12 @@
 This module provides a factory function, `fromEnv`, that will attempt to source
 AWS credentials from a Node.JS environment. It will attempt to find credentials
 from the following sources (listed in order of precedence):
-_ Environment variables exposed via `process.env`
-_ Shared credentials and config ini files \* The EC2/ECS Instance Metadata Service
+
+- Environment variables exposed via `process.env`
+- SSO credentials from token cache
+- Web identity token credentials
+- Shared credentials and config ini files
+- The EC2/ECS Instance Metadata Service
 
 The default credential provider will invoke one provider at a time and only
 continue to the next if no credentials have been located. For example, if the
@@ -45,6 +49,11 @@ supported:
 - `roleAssumer` - A function that assumes a role and returns a promise
   fulfilled with credentials for the assumed role. If not specified, the SDK
   will create an STS client and call its `assumeRole` method.
+- `roleArn` - ARN to assume. If not specified, the provider will use the value
+  in the `AWS_ROLE_ARN` environment variable.
+- `webIdentityTokenFile` - File location of where the `OIDC` token is stored.
+  If not specified, the provider will use the value in the `AWS_WEB_IDENTITY_TOKEN_FILE`
+  environment variable.
 - `timeout` - The connection timeout (in milliseconds) to apply to any remote
   requests. If not specified, a default value of `1000` (one second) is used.
 - `maxRetries` - The maximum number of times any HTTP connections should be
@@ -53,6 +62,8 @@ supported:
 ## Related packages:
 
 - [AWS Credential Provider for Node.JS - Environment Variables](../credential-provider-env)
+- [AWS Credential Provider for Node.JS - SSO](../credential-provider-sso)
+- [AWS Credential Provider for Node.JS - Web Identity](../credential-provider-web-identity)
 - [AWS Credential Provider for Node.JS - Shared Configuration Files](../credential-provider-ini)
 - [AWS Credential Provider for Node.JS - Instance and Container Metadata](../credential-provider-imds)
 - [AWS Shared Configuration File Loader](../shared-ini-file-loader)

--- a/packages/credential-provider-node/README.md
+++ b/packages/credential-provider-node/README.md
@@ -27,6 +27,24 @@ If invalid configuration is encountered (such as a profile in
 that does not exist), then the chained provider will be rejected with an error
 and will not invoke the next provider in the list.
 
+_IMPORTANT_: if you intend for your code to run using EKS roles at some point
+(for example in a production environment, but not when working locally) then
+you must explicitly specify a value for `roleAssumerWithWebIdentity`. There is a
+default function available in `@aws-sdk/client-sts` package. An example of using
+this:
+
+```js
+const { getDefaultRoleAssumerWithWebIdentity } = require("@aws-sdk/client-sts");
+const { defaultProvider } = require("@aws-sdk/credential-provider-node");
+const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
+
+const provider = defaultProvider({
+  roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity,
+});
+
+const client = new S3Client({ credentialDefaultProvider: provider });
+```
+
 ## Supported configuration
 
 You may customize how credentials are resolved by providing an options hash to
@@ -54,6 +72,8 @@ supported:
 - `webIdentityTokenFile` - File location of where the `OIDC` token is stored.
   If not specified, the provider will use the value in the `AWS_WEB_IDENTITY_TOKEN_FILE`
   environment variable.
+- `roleAssumerWithWebIdentity` - A function that assumes a role with web identity and
+  returns a promise fulfilled with credentials for the assumed role.
 - `timeout` - The connection timeout (in milliseconds) to apply to any remote
   requests. If not specified, a default value of `1000` (one second) is used.
 - `maxRetries` - The maximum number of times any HTTP connections should be

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -25,6 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/credential-provider-env": "3.13.1",
+    "@aws-sdk/credential-provider-web-identity": "3.13.1",
     "@aws-sdk/credential-provider-imds": "3.13.1",
     "@aws-sdk/credential-provider-ini": "3.13.1",
     "@aws-sdk/credential-provider-process": "3.13.1",

--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -135,9 +135,9 @@ describe("defaultProvider", () => {
     expect(await defaultProvider()()).toEqual(creds);
     expect((fromEnv() as any).mock.calls.length).toBe(1);
     expect((fromSSO() as any).mock.calls.length).toBe(1);
-    expect((fromTokenFile() as any).mock.calls.length).toBe(0);
     expect((fromIni() as any).mock.calls.length).toBe(0);
     expect((fromProcess() as any).mock.calls.length).toBe(0);
+    expect((fromTokenFile() as any).mock.calls.length).toBe(0);
     expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
     expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
   });
@@ -150,14 +150,16 @@ describe("defaultProvider", () => {
 
     (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromTokenFile() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
     expect((fromEnv() as any).mock.calls.length).toBe(1);
     expect((fromSSO() as any).mock.calls.length).toBe(1);
+    expect((fromIni() as any).mock.calls.length).toBe(1);
+    expect((fromProcess() as any).mock.calls.length).toBe(1);
     expect((fromTokenFile() as any).mock.calls.length).toBe(1);
-    expect((fromIni() as any).mock.calls.length).toBe(0);
-    expect((fromProcess() as any).mock.calls.length).toBe(0);
     expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
     expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
   });
@@ -176,8 +178,8 @@ describe("defaultProvider", () => {
     expect(await defaultProvider()()).toEqual(creds);
     expect((fromEnv() as any).mock.calls.length).toBe(1);
     expect((fromSSO() as any).mock.calls.length).toBe(1);
-    expect((fromTokenFile() as any).mock.calls.length).toBe(1);
     expect((fromIni() as any).mock.calls.length).toBe(1);
+    expect((fromTokenFile() as any).mock.calls.length).toBe(0);
     expect((fromProcess() as any).mock.calls.length).toBe(0);
     expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
     expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
@@ -191,16 +193,15 @@ describe("defaultProvider", () => {
 
     (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromProcess() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
     expect((fromEnv() as any).mock.calls.length).toBe(1);
     expect((fromSSO() as any).mock.calls.length).toBe(1);
-    expect((fromTokenFile() as any).mock.calls.length).toBe(1);
     expect((fromIni() as any).mock.calls.length).toBe(1);
     expect((fromProcess() as any).mock.calls.length).toBe(1);
+    expect((fromTokenFile() as any).mock.calls.length).toBe(0);
     expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
     expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
   });
@@ -212,16 +213,16 @@ describe("defaultProvider", () => {
     };
     (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
     (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
     expect((fromEnv() as any).mock.calls.length).toBe(1);
     expect((fromSSO() as any).mock.calls.length).toBe(1);
-    expect((fromTokenFile() as any).mock.calls.length).toBe(1);
     expect((fromIni() as any).mock.calls.length).toBe(1);
+    expect((fromTokenFile() as any).mock.calls.length).toBe(1);
     expect((fromProcess() as any).mock.calls.length).toBe(1);
     expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
     expect((fromInstanceMetadata() as any).mock.calls.length).toBe(1);
@@ -235,8 +236,8 @@ describe("defaultProvider", () => {
 
     (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
     (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.resolve(creds));
 
@@ -255,8 +256,8 @@ describe("defaultProvider", () => {
 
     (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
     (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new Error("PANIC")));
     (fromContainerMetadata() as any).mockImplementation(() => Promise.resolve(creds));
@@ -266,8 +267,8 @@ describe("defaultProvider", () => {
     expect(await defaultProvider()()).toEqual(creds);
     expect((fromEnv() as any).mock.calls.length).toBe(1);
     expect((fromSSO() as any).mock.calls.length).toBe(1);
-    expect((fromTokenFile() as any).mock.calls.length).toBe(1);
     expect((fromIni() as any).mock.calls.length).toBe(1);
+    expect((fromTokenFile() as any).mock.calls.length).toBe(1);
     expect((fromProcess() as any).mock.calls.length).toBe(1);
     expect((fromContainerMetadata() as any).mock.calls.length).toBe(1);
     expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
@@ -281,8 +282,8 @@ describe("defaultProvider", () => {
 
     (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
     (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
     (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.resolve(creds));
 
@@ -320,7 +321,7 @@ describe("defaultProvider", () => {
   it("should pass configuration on to the Web Identity provider", async () => {
     const webIdentityConfig: FromTokenFileInit = {
       roleArn: "someRoleArn",
-      webIdentityTokenFile: "/home/user/.secrets/tokenFile"
+      webIdentityTokenFile: "/home/user/.secrets/tokenFile",
     };
 
     (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
@@ -505,16 +506,16 @@ describe("defaultProvider", () => {
 
       (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromSSO() as any).mockImplementation(() => Promise.resolve(Promise.resolve(creds)));
-      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
 
       expect(await defaultProvider({ profile: "foo" })()).toEqual(creds);
       expect((fromEnv() as any).mock.calls.length).toBe(0);
       expect((fromSSO() as any).mock.calls.length).toBe(1);
-      expect((fromTokenFile() as any).mock.calls.length).toBe(0);
       expect((fromIni() as any).mock.calls.length).toBe(0);
+      expect((fromTokenFile() as any).mock.calls.length).toBe(0);
       expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
       expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
     });
@@ -527,8 +528,8 @@ describe("defaultProvider", () => {
 
       (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromSSO() as any).mockImplementation(() => Promise.resolve(creds));
-      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
@@ -537,8 +538,8 @@ describe("defaultProvider", () => {
       expect(await defaultProvider()()).toEqual(creds);
       expect((fromEnv() as any).mock.calls.length).toBe(0);
       expect((fromSSO() as any).mock.calls.length).toBe(1);
-      expect((fromTokenFile() as any).mock.calls.length).toBe(0);
       expect((fromIni() as any).mock.calls.length).toBe(0);
+      expect((fromTokenFile() as any).mock.calls.length).toBe(0);
       expect((fromProcess() as any).mock.calls.length).toBe(0);
       expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
       expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
@@ -552,7 +553,6 @@ describe("defaultProvider", () => {
 
       (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromIni() as any).mockImplementation(() => Promise.resolve(Promise.resolve(creds)));
       (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
@@ -560,8 +560,8 @@ describe("defaultProvider", () => {
       expect(await defaultProvider({ profile: "foo" })()).toEqual(creds);
       expect((fromEnv() as any).mock.calls.length).toBe(0);
       expect((fromSSO() as any).mock.calls.length).toBe(1);
-      expect((fromTokenFile() as any).mock.calls.length).toBe(1);
       expect((fromIni() as any).mock.calls.length).toBe(1);
+      expect((fromTokenFile() as any).mock.calls.length).toBe(0);
       expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
       expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
     });
@@ -574,7 +574,6 @@ describe("defaultProvider", () => {
 
       (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
       (fromProcess() as any).mockImplementation(() => Promise.resolve(creds));
       (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
@@ -584,9 +583,9 @@ describe("defaultProvider", () => {
       expect(await defaultProvider()()).toEqual(creds);
       expect((fromEnv() as any).mock.calls.length).toBe(0);
       expect((fromSSO() as any).mock.calls.length).toBe(1);
-      expect((fromTokenFile() as any).mock.calls.length).toBe(1);
       expect((fromIni() as any).mock.calls.length).toBe(1);
       expect((fromProcess() as any).mock.calls.length).toBe(1);
+      expect((fromTokenFile() as any).mock.calls.length).toBe(0);
       expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
       expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
     });

--- a/packages/credential-provider-node/src/index.ts
+++ b/packages/credential-provider-node/src/index.ts
@@ -55,7 +55,7 @@ export const defaultProvider = (
 ): CredentialProvider => {
   const options = { profile: process.env[ENV_PROFILE], ...init };
   if (!options.loadedConfig) options.loadedConfig = loadSharedConfigFiles(init);
-  const providers = [fromSSO(options), fromTokenFile(options), fromIni(options), fromProcess(options), remoteProvider(options)];
+  const providers = [fromSSO(options), fromIni(options), fromProcess(options), fromTokenFile(options), remoteProvider(options)];
   if (!options.profile) providers.unshift(fromEnv());
   const providerChain = chain(...providers);
 

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@aws-sdk/property-provider": "3.13.1",
     "@aws-sdk/types": "3.13.1",
-    "@aws-sdk/client-sts": "3.13.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aws-sdk/property-provider": "3.13.1",
     "@aws-sdk/types": "3.13.1",
+    "@aws-sdk/client-sts": "3.13.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
@@ -9,6 +9,14 @@ const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 const ENV_ROLE_ARN = "AWS_ROLE_ARN";
 const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
 
+jest.mock("@aws-sdk/client-sts", () => {
+  return {
+    getDefaultRoleAssumerWithWebIdentity: jest.fn().mockReturnValue(jest.fn()),
+  };
+});
+import { getDefaultRoleAssumerWithWebIdentity } from "@aws-sdk/client-sts";
+import { ProviderError } from "@aws-sdk/property-provider";
+
 jest.mock("fs");
 
 const MOCK_CREDS = {
@@ -63,6 +71,18 @@ describe(fromTokenFile.name, () => {
       expect(webTokenInit.roleAssumerWithWebIdentity).toBe(roleAssumerWithWebIdentity);
     });
 
+    it(`passes default roleAssumeWithWebIdentity function ${fromWebToken.name} if not specified`, async () => {
+      (getDefaultRoleAssumerWithWebIdentity() as any).mockImplementation(() => Promise.resolve("default credentials"));
+      const creds = await fromTokenFile({})();
+      expect(creds).toEqual(MOCK_CREDS);
+      expect(fromWebToken as jest.Mock).toBeCalledTimes(1);
+      const webTokenInit = (fromWebToken as jest.Mock).mock.calls[0][0];
+      expect(webTokenInit.webIdentityToken).toBe(mockTokenValue);
+      expect(webTokenInit.roleSessionName).toBe(mockRoleSessionName);
+      expect(webTokenInit.roleArn).toBe(mockRoleArn);
+      expect(webTokenInit.roleAssumerWithWebIdentity()).resolves.toBe("default credentials");
+    });
+
     it("prefers init parameters over environmental variables", async () => {
       const roleAssumerWithWebIdentity = jest.fn();
       const init = {
@@ -113,6 +133,28 @@ describe(fromTokenFile.name, () => {
         expect(error).toEqual(readFileSyncError);
       }
       expect(readFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws if web_identity_token_file is not specified", async () => {
+      try {
+        delete process.env[ENV_TOKEN_FILE]
+        await fromTokenFile()();
+        fail(`Expected error to be thrown`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProviderError);
+        expect(error.tryNextLink).toBe(true);
+      }
+    });
+
+    it("throws if role_arn is not specified", async () => {
+      try {
+        delete process.env[ENV_ROLE_ARN]
+        await fromTokenFile()();
+        fail(`Expected error to be thrown`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProviderError);
+        expect(error.tryNextLink).toBe(true);
+      }
     });
   });
 });

--- a/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
@@ -9,12 +9,6 @@ const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 const ENV_ROLE_ARN = "AWS_ROLE_ARN";
 const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
 
-jest.mock("@aws-sdk/client-sts", () => {
-  return {
-    getDefaultRoleAssumerWithWebIdentity: jest.fn().mockReturnValue(jest.fn()),
-  };
-});
-import { getDefaultRoleAssumerWithWebIdentity } from "@aws-sdk/client-sts";
 import { ProviderError } from "@aws-sdk/property-provider";
 
 jest.mock("fs");
@@ -71,18 +65,6 @@ describe(fromTokenFile.name, () => {
       expect(webTokenInit.roleAssumerWithWebIdentity).toBe(roleAssumerWithWebIdentity);
     });
 
-    it(`passes default roleAssumeWithWebIdentity function ${fromWebToken.name} if not specified`, async () => {
-      (getDefaultRoleAssumerWithWebIdentity() as any).mockImplementation(() => Promise.resolve("default credentials"));
-      const creds = await fromTokenFile({})();
-      expect(creds).toEqual(MOCK_CREDS);
-      expect(fromWebToken as jest.Mock).toBeCalledTimes(1);
-      const webTokenInit = (fromWebToken as jest.Mock).mock.calls[0][0];
-      expect(webTokenInit.webIdentityToken).toBe(mockTokenValue);
-      expect(webTokenInit.roleSessionName).toBe(mockRoleSessionName);
-      expect(webTokenInit.roleArn).toBe(mockRoleArn);
-      expect(webTokenInit.roleAssumerWithWebIdentity()).resolves.toBe("default credentials");
-    });
-
     it("prefers init parameters over environmental variables", async () => {
       const roleAssumerWithWebIdentity = jest.fn();
       const init = {
@@ -137,7 +119,7 @@ describe(fromTokenFile.name, () => {
 
     it("throws if web_identity_token_file is not specified", async () => {
       try {
-        delete process.env[ENV_TOKEN_FILE]
+        delete process.env[ENV_TOKEN_FILE];
         await fromTokenFile()();
         fail(`Expected error to be thrown`);
       } catch (error) {
@@ -148,7 +130,7 @@ describe(fromTokenFile.name, () => {
 
     it("throws if role_arn is not specified", async () => {
       try {
-        delete process.env[ENV_ROLE_ARN]
+        delete process.env[ENV_ROLE_ARN];
         await fromTokenFile()();
         fail(`Expected error to be thrown`);
       } catch (error) {

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -1,4 +1,3 @@
-import { getDefaultRoleAssumerWithWebIdentity } from "@aws-sdk/client-sts";
 import { ProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { readFileSync } from "fs";

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -35,7 +35,6 @@ const resolveTokenFile = (init?: FromTokenFileInit): Promise<Credentials> => {
     ...init,
     webIdentityToken: readFileSync(webIdentityTokenFile, { encoding: "ascii" }),
     roleArn,
-    roleSessionName,
-    roleAssumerWithWebIdentity: init?.roleAssumerWithWebIdentity ?? getDefaultRoleAssumerWithWebIdentity()
+    roleSessionName
   })();
 };

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -1,4 +1,6 @@
-import { CredentialProvider } from "@aws-sdk/types";
+import { getDefaultRoleAssumerWithWebIdentity } from "@aws-sdk/client-sts";
+import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { readFileSync } from "fs";
 
 import { fromWebToken, FromWebTokenInit } from "./fromWebToken";
@@ -17,13 +19,24 @@ export interface FromTokenFileInit extends Partial<Omit<FromWebTokenInit, "webId
 /**
  * Represents OIDC credentials from a file on disk.
  */
-export const fromTokenFile = (init: FromTokenFileInit): CredentialProvider => {
-  const { webIdentityTokenFile, roleArn, roleSessionName } = init;
+export const fromTokenFile = (init: FromTokenFileInit = {}): CredentialProvider => async () => {
+  return resolveTokenFile(init);
+};
+
+const resolveTokenFile = (init?: FromTokenFileInit): Promise<Credentials> => {
+  const webIdentityTokenFile = init?.webIdentityTokenFile ?? process.env[ENV_TOKEN_FILE];
+  const roleArn = init?.roleArn ?? process.env[ENV_ROLE_ARN];
+  const roleSessionName = init?.roleSessionName ?? process.env[ENV_ROLE_SESSION_NAME];
+
+  if (!webIdentityTokenFile || !roleArn) {
+    throw new ProviderError("Web identity configuration not specified");
+  }
 
   return fromWebToken({
     ...init,
-    webIdentityToken: readFileSync(webIdentityTokenFile ?? process.env[ENV_TOKEN_FILE]!, { encoding: "ascii" }),
-    roleArn: roleArn ?? process.env[ENV_ROLE_ARN]!,
-    roleSessionName: roleSessionName ?? process.env[ENV_ROLE_SESSION_NAME],
-  });
+    webIdentityToken: readFileSync(webIdentityTokenFile, { encoding: "ascii" }),
+    roleArn,
+    roleSessionName,
+    roleAssumerWithWebIdentity: init?.roleAssumerWithWebIdentity ?? getDefaultRoleAssumerWithWebIdentity()
+  })();
 };


### PR DESCRIPTION
### Issue
Fixes #2148 

### Description
Adds default support for web identity credentials. This is useful when using this SDK with [IAM Roles for Service accounts in EKS](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) which set `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` behind the scenes. Without this the default behavior of the SDK is to use credentials from IMDS.

### Testing
Tests have been updated.

### Additional context
Additional updates include:
- Update `README.md` to include web identity params and default load order information (fixes typo)
- Set `init` param of `fromTokenFile` to optional. Default to the default web identity assume role function from `client-sts` if not provided

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
