### PR TITLE
fix(lib-dynamodb): remove stripInternal=true from tsconfig

### DIFF
--- a/lib/lib-dynamodb/tsconfig.cjs.json
+++ b/lib/lib-dynamodb/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "stripInternal": true,
     "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -4,7 +4,6 @@
     "strict": true,
     "sourceMap": false,
     "declaration": true,
-    "stripInternal": true,
     "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2216
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2193
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2244

### Description
Remove `stripInternal=true` from tsconfig

### Testing
The build succeeds with repro repo shared in https://github.com/JeremyDurnell/aws-sdk-js-v3-dynamo-ts-bug

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
