### PR TITLE
fix(e2e): explicitly use ChromeHeadless with no-sandbox

### DIFF
--- a/clients/client-cognito-identity/karma.conf.js
+++ b/clients/client-cognito-identity/karma.conf.js
@@ -52,8 +52,12 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_WARN,
     autoWatch: false,
-    browsers: ["ChromeHeadless", "FirefoxHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox", "FirefoxHeadless"],
     customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"],
+      },
       FirefoxHeadless: {
         base: "Firefox",
         flags: ["-headless"],

--- a/clients/client-s3/karma.conf.js
+++ b/clients/client-s3/karma.conf.js
@@ -52,8 +52,12 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_WARN,
     autoWatch: false,
-    browsers: ["ChromeHeadless", "FirefoxHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox", "FirefoxHeadless"],
     customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"],
+      },
       FirefoxHeadless: {
         base: "Firefox",
         flags: ["-headless"],


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2265

### Description
Explicitly use ChromeHeadless with no-sandbox in e2e tests.

### Testing
Verified that E2E tests are successfully run:
```console
$ node ./tests/e2e/index.js
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
