### PR TITLE
docs(clients): use interface for client input and resolved config

### DIFF
--- a/clients/client-accessanalyzer/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/AccessAnalyzerClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AccessAnalyzerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AccessAnalyzerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -220,8 +220,12 @@ export type AccessAnalyzerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AccessAnalyzerClient class constructor that set the region, credentials and other options.
+ */
+export interface AccessAnalyzerClientConfig extends AccessAnalyzerClientConfigType {}
 
-export type AccessAnalyzerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AccessAnalyzerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -229,6 +233,10 @@ export type AccessAnalyzerClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AccessAnalyzerClient class. This is resolved and normalized from the {@link AccessAnalyzerClientConfig | constructor configuration interface}.
+ */
+export interface AccessAnalyzerClientResolvedConfig extends AccessAnalyzerClientResolvedConfigType {}
 
 /**
  * <p>AWS IAM Access Analyzer helps identify potential resource-access risks by enabling you to identify
@@ -245,6 +253,9 @@ export class AccessAnalyzerClient extends __Client<
   ServiceOutputTypes,
   AccessAnalyzerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AccessAnalyzerClient class. This is resolved and normalized from the {@link AccessAnalyzerClientConfig | constructor configuration interface}.
+   */
   readonly config: AccessAnalyzerClientResolvedConfig;
 
   constructor(configuration: AccessAnalyzerClientConfig) {

--- a/clients/client-acm-pca/ACMPCAClient.ts
+++ b/clients/client-acm-pca/ACMPCAClient.ts
@@ -257,7 +257,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ACMPCAClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ACMPCAClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -265,8 +265,12 @@ export type ACMPCAClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ACMPCAClient class constructor that set the region, credentials and other options.
+ */
+export interface ACMPCAClientConfig extends ACMPCAClientConfigType {}
 
-export type ACMPCAClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ACMPCAClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -274,6 +278,10 @@ export type ACMPCAClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ACMPCAClient class. This is resolved and normalized from the {@link ACMPCAClientConfig | constructor configuration interface}.
+ */
+export interface ACMPCAClientResolvedConfig extends ACMPCAClientResolvedConfigType {}
 
 /**
  * <note>
@@ -299,6 +307,9 @@ export class ACMPCAClient extends __Client<
   ServiceOutputTypes,
   ACMPCAClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ACMPCAClient class. This is resolved and normalized from the {@link ACMPCAClientConfig | constructor configuration interface}.
+   */
   readonly config: ACMPCAClientResolvedConfig;
 
   constructor(configuration: ACMPCAClientConfig) {

--- a/clients/client-acm/ACMClient.ts
+++ b/clients/client-acm/ACMClient.ts
@@ -206,7 +206,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ACMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ACMClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -214,8 +214,12 @@ export type ACMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ACMClient class constructor that set the region, credentials and other options.
+ */
+export interface ACMClientConfig extends ACMClientConfigType {}
 
-export type ACMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ACMClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -223,6 +227,10 @@ export type ACMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ACMClient class. This is resolved and normalized from the {@link ACMClientConfig | constructor configuration interface}.
+ */
+export interface ACMClientResolvedConfig extends ACMClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Certificate Manager</fullname>
@@ -238,6 +246,9 @@ export class ACMClient extends __Client<
   ServiceOutputTypes,
   ACMClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ACMClient class. This is resolved and normalized from the {@link ACMClientConfig | constructor configuration interface}.
+   */
   readonly config: ACMClientResolvedConfig;
 
   constructor(configuration: ACMClientConfig) {

--- a/clients/client-alexa-for-business/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/AlexaForBusinessClient.ts
@@ -545,7 +545,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AlexaForBusinessClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AlexaForBusinessClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -553,8 +553,12 @@ export type AlexaForBusinessClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AlexaForBusinessClient class constructor that set the region, credentials and other options.
+ */
+export interface AlexaForBusinessClientConfig extends AlexaForBusinessClientConfigType {}
 
-export type AlexaForBusinessClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AlexaForBusinessClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -562,6 +566,10 @@ export type AlexaForBusinessClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AlexaForBusinessClient class. This is resolved and normalized from the {@link AlexaForBusinessClientConfig | constructor configuration interface}.
+ */
+export interface AlexaForBusinessClientResolvedConfig extends AlexaForBusinessClientResolvedConfigType {}
 
 /**
  * <p>Alexa for Business helps you use Alexa in your organization. Alexa for Business provides you with the tools
@@ -579,6 +587,9 @@ export class AlexaForBusinessClient extends __Client<
   ServiceOutputTypes,
   AlexaForBusinessClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AlexaForBusinessClient class. This is resolved and normalized from the {@link AlexaForBusinessClientConfig | constructor configuration interface}.
+   */
   readonly config: AlexaForBusinessClientResolvedConfig;
 
   constructor(configuration: AlexaForBusinessClientConfig) {

--- a/clients/client-amplify/AmplifyClient.ts
+++ b/clients/client-amplify/AmplifyClient.ts
@@ -290,7 +290,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AmplifyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AmplifyClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -298,8 +298,12 @@ export type AmplifyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AmplifyClient class constructor that set the region, credentials and other options.
+ */
+export interface AmplifyClientConfig extends AmplifyClientConfigType {}
 
-export type AmplifyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AmplifyClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -307,6 +311,10 @@ export type AmplifyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AmplifyClient class. This is resolved and normalized from the {@link AmplifyClientConfig | constructor configuration interface}.
+ */
+export interface AmplifyClientResolvedConfig extends AmplifyClientResolvedConfigType {}
 
 /**
  * <p>Amplify enables developers to develop and deploy cloud-powered mobile and web apps.
@@ -322,6 +330,9 @@ export class AmplifyClient extends __Client<
   ServiceOutputTypes,
   AmplifyClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AmplifyClient class. This is resolved and normalized from the {@link AmplifyClientConfig | constructor configuration interface}.
+   */
   readonly config: AmplifyClientResolvedConfig;
 
   constructor(configuration: AmplifyClientConfig) {

--- a/clients/client-amplifybackend/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/AmplifyBackendClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AmplifyBackendClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AmplifyBackendClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -244,8 +244,12 @@ export type AmplifyBackendClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AmplifyBackendClient class constructor that set the region, credentials and other options.
+ */
+export interface AmplifyBackendClientConfig extends AmplifyBackendClientConfigType {}
 
-export type AmplifyBackendClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AmplifyBackendClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -253,6 +257,10 @@ export type AmplifyBackendClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AmplifyBackendClient class. This is resolved and normalized from the {@link AmplifyBackendClientConfig | constructor configuration interface}.
+ */
+export interface AmplifyBackendClientResolvedConfig extends AmplifyBackendClientResolvedConfigType {}
 
 /**
  * <p>AWS Amplify Admin API</p>
@@ -263,6 +271,9 @@ export class AmplifyBackendClient extends __Client<
   ServiceOutputTypes,
   AmplifyBackendClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AmplifyBackendClient class. This is resolved and normalized from the {@link AmplifyBackendClientConfig | constructor configuration interface}.
+   */
   readonly config: AmplifyBackendClientResolvedConfig;
 
   constructor(configuration: AmplifyBackendClientConfig) {

--- a/clients/client-api-gateway/APIGatewayClient.ts
+++ b/clients/client-api-gateway/APIGatewayClient.ts
@@ -618,7 +618,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type APIGatewayClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type APIGatewayClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -626,8 +626,12 @@ export type APIGatewayClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of APIGatewayClient class constructor that set the region, credentials and other options.
+ */
+export interface APIGatewayClientConfig extends APIGatewayClientConfigType {}
 
-export type APIGatewayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type APIGatewayClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -635,6 +639,10 @@ export type APIGatewayClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of APIGatewayClient class. This is resolved and normalized from the {@link APIGatewayClientConfig | constructor configuration interface}.
+ */
+export interface APIGatewayClientResolvedConfig extends APIGatewayClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon API Gateway</fullname>
@@ -646,6 +654,9 @@ export class APIGatewayClient extends __Client<
   ServiceOutputTypes,
   APIGatewayClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of APIGatewayClient class. This is resolved and normalized from the {@link APIGatewayClientConfig | constructor configuration interface}.
+   */
   readonly config: APIGatewayClientResolvedConfig;
 
   constructor(configuration: APIGatewayClientConfig) {

--- a/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
@@ -155,7 +155,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ApiGatewayManagementApiClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ApiGatewayManagementApiClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -163,8 +163,12 @@ export type ApiGatewayManagementApiClientConfig = Partial<__SmithyConfiguration<
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ApiGatewayManagementApiClient class constructor that set the region, credentials and other options.
+ */
+export interface ApiGatewayManagementApiClientConfig extends ApiGatewayManagementApiClientConfigType {}
 
-export type ApiGatewayManagementApiClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ApiGatewayManagementApiClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -172,6 +176,10 @@ export type ApiGatewayManagementApiClientResolvedConfig = __SmithyResolvedConfig
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ApiGatewayManagementApiClient class. This is resolved and normalized from the {@link ApiGatewayManagementApiClientConfig | constructor configuration interface}.
+ */
+export interface ApiGatewayManagementApiClientResolvedConfig extends ApiGatewayManagementApiClientResolvedConfigType {}
 
 /**
  * <p>The Amazon API Gateway Management API allows you to directly manage runtime aspects of your deployed APIs. To use it, you must explicitly set the SDK's endpoint to point to the endpoint of your deployed API. The endpoint will be of the form https://{api-id}.execute-api.{region}.amazonaws.com/{stage}, or will be the endpoint corresponding to your API's custom domain and base path, if applicable.</p>
@@ -182,6 +190,9 @@ export class ApiGatewayManagementApiClient extends __Client<
   ServiceOutputTypes,
   ApiGatewayManagementApiClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ApiGatewayManagementApiClient class. This is resolved and normalized from the {@link ApiGatewayManagementApiClientConfig | constructor configuration interface}.
+   */
   readonly config: ApiGatewayManagementApiClientResolvedConfig;
 
   constructor(configuration: ApiGatewayManagementApiClientConfig) {

--- a/clients/client-apigatewayv2/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/ApiGatewayV2Client.ts
@@ -404,7 +404,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ApiGatewayV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ApiGatewayV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -412,8 +412,12 @@ export type ApiGatewayV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ApiGatewayV2Client class constructor that set the region, credentials and other options.
+ */
+export interface ApiGatewayV2ClientConfig extends ApiGatewayV2ClientConfigType {}
 
-export type ApiGatewayV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ApiGatewayV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -421,6 +425,10 @@ export type ApiGatewayV2ClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ApiGatewayV2Client class. This is resolved and normalized from the {@link ApiGatewayV2ClientConfig | constructor configuration interface}.
+ */
+export interface ApiGatewayV2ClientResolvedConfig extends ApiGatewayV2ClientResolvedConfigType {}
 
 /**
  * <p>Amazon API Gateway V2</p>
@@ -431,6 +439,9 @@ export class ApiGatewayV2Client extends __Client<
   ServiceOutputTypes,
   ApiGatewayV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ApiGatewayV2Client class. This is resolved and normalized from the {@link ApiGatewayV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: ApiGatewayV2ClientResolvedConfig;
 
   constructor(configuration: ApiGatewayV2ClientConfig) {

--- a/clients/client-app-mesh/AppMeshClient.ts
+++ b/clients/client-app-mesh/AppMeshClient.ts
@@ -314,7 +314,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AppMeshClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AppMeshClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -322,8 +322,12 @@ export type AppMeshClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AppMeshClient class constructor that set the region, credentials and other options.
+ */
+export interface AppMeshClientConfig extends AppMeshClientConfigType {}
 
-export type AppMeshClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AppMeshClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -331,6 +335,10 @@ export type AppMeshClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AppMeshClient class. This is resolved and normalized from the {@link AppMeshClientConfig | constructor configuration interface}.
+ */
+export interface AppMeshClientResolvedConfig extends AppMeshClientResolvedConfigType {}
 
 /**
  * <p>AWS App Mesh is a service mesh based on the Envoy proxy that makes it easy to monitor and
@@ -353,6 +361,9 @@ export class AppMeshClient extends __Client<
   ServiceOutputTypes,
   AppMeshClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AppMeshClient class. This is resolved and normalized from the {@link AppMeshClientConfig | constructor configuration interface}.
+   */
   readonly config: AppMeshClientResolvedConfig;
 
   constructor(configuration: AppMeshClientConfig) {

--- a/clients/client-appconfig/AppConfigClient.ts
+++ b/clients/client-appconfig/AppConfigClient.ts
@@ -296,7 +296,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AppConfigClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AppConfigClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -304,8 +304,12 @@ export type AppConfigClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AppConfigClient class constructor that set the region, credentials and other options.
+ */
+export interface AppConfigClientConfig extends AppConfigClientConfigType {}
 
-export type AppConfigClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AppConfigClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -313,6 +317,10 @@ export type AppConfigClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AppConfigClient class. This is resolved and normalized from the {@link AppConfigClientConfig | constructor configuration interface}.
+ */
+export interface AppConfigClientResolvedConfig extends AppConfigClientResolvedConfigType {}
 
 /**
  * <fullname>AWS AppConfig</fullname>
@@ -371,6 +379,9 @@ export class AppConfigClient extends __Client<
   ServiceOutputTypes,
   AppConfigClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AppConfigClient class. This is resolved and normalized from the {@link AppConfigClientConfig | constructor configuration interface}.
+   */
   readonly config: AppConfigClientResolvedConfig;
 
   constructor(configuration: AppConfigClientConfig) {

--- a/clients/client-appflow/AppflowClient.ts
+++ b/clients/client-appflow/AppflowClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AppflowClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AppflowClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -235,8 +235,12 @@ export type AppflowClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AppflowClient class constructor that set the region, credentials and other options.
+ */
+export interface AppflowClientConfig extends AppflowClientConfigType {}
 
-export type AppflowClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AppflowClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -244,6 +248,10 @@ export type AppflowClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AppflowClient class. This is resolved and normalized from the {@link AppflowClientConfig | constructor configuration interface}.
+ */
+export interface AppflowClientResolvedConfig extends AppflowClientResolvedConfigType {}
 
 /**
  * <p>Welcome to the Amazon AppFlow API reference. This guide is for developers who need detailed information about the Amazon AppFlow API operations, data types, and errors. </p>
@@ -284,6 +292,9 @@ export class AppflowClient extends __Client<
   ServiceOutputTypes,
   AppflowClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AppflowClient class. This is resolved and normalized from the {@link AppflowClientConfig | constructor configuration interface}.
+   */
   readonly config: AppflowClientResolvedConfig;
 
   constructor(configuration: AppflowClientConfig) {

--- a/clients/client-appintegrations/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/AppIntegrationsClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AppIntegrationsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AppIntegrationsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -211,8 +211,12 @@ export type AppIntegrationsClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AppIntegrationsClient class constructor that set the region, credentials and other options.
+ */
+export interface AppIntegrationsClientConfig extends AppIntegrationsClientConfigType {}
 
-export type AppIntegrationsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AppIntegrationsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -220,6 +224,10 @@ export type AppIntegrationsClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AppIntegrationsClient class. This is resolved and normalized from the {@link AppIntegrationsClientConfig | constructor configuration interface}.
+ */
+export interface AppIntegrationsClientResolvedConfig extends AppIntegrationsClientResolvedConfigType {}
 
 /**
  * <p>The Amazon AppIntegrations APIs are in preview release and are subject to change.</p>
@@ -233,6 +241,9 @@ export class AppIntegrationsClient extends __Client<
   ServiceOutputTypes,
   AppIntegrationsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AppIntegrationsClient class. This is resolved and normalized from the {@link AppIntegrationsClientConfig | constructor configuration interface}.
+   */
   readonly config: AppIntegrationsClientResolvedConfig;
 
   constructor(configuration: AppIntegrationsClientConfig) {

--- a/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ApplicationAutoScalingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ApplicationAutoScalingClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -211,8 +211,12 @@ export type ApplicationAutoScalingClientConfig = Partial<__SmithyConfiguration<_
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ApplicationAutoScalingClient class constructor that set the region, credentials and other options.
+ */
+export interface ApplicationAutoScalingClientConfig extends ApplicationAutoScalingClientConfigType {}
 
-export type ApplicationAutoScalingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ApplicationAutoScalingClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -220,6 +224,10 @@ export type ApplicationAutoScalingClientResolvedConfig = __SmithyResolvedConfigu
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ApplicationAutoScalingClient class. This is resolved and normalized from the {@link ApplicationAutoScalingClientConfig | constructor configuration interface}.
+ */
+export interface ApplicationAutoScalingClientResolvedConfig extends ApplicationAutoScalingClientResolvedConfigType {}
 
 /**
  * <p>With Application Auto Scaling, you can configure automatic scaling for the following
@@ -297,6 +305,9 @@ export class ApplicationAutoScalingClient extends __Client<
   ServiceOutputTypes,
   ApplicationAutoScalingClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ApplicationAutoScalingClient class. This is resolved and normalized from the {@link ApplicationAutoScalingClientConfig | constructor configuration interface}.
+   */
   readonly config: ApplicationAutoScalingClientResolvedConfig;
 
   constructor(configuration: ApplicationAutoScalingClientConfig) {

--- a/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
@@ -269,7 +269,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ApplicationDiscoveryServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ApplicationDiscoveryServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -277,8 +277,12 @@ export type ApplicationDiscoveryServiceClientConfig = Partial<__SmithyConfigurat
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ApplicationDiscoveryServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface ApplicationDiscoveryServiceClientConfig extends ApplicationDiscoveryServiceClientConfigType {}
 
-export type ApplicationDiscoveryServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ApplicationDiscoveryServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -286,6 +290,11 @@ export type ApplicationDiscoveryServiceClientResolvedConfig = __SmithyResolvedCo
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ApplicationDiscoveryServiceClient class. This is resolved and normalized from the {@link ApplicationDiscoveryServiceClientConfig | constructor configuration interface}.
+ */
+export interface ApplicationDiscoveryServiceClientResolvedConfig
+  extends ApplicationDiscoveryServiceClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Application Discovery Service</fullname>
@@ -422,6 +431,9 @@ export class ApplicationDiscoveryServiceClient extends __Client<
   ServiceOutputTypes,
   ApplicationDiscoveryServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ApplicationDiscoveryServiceClient class. This is resolved and normalized from the {@link ApplicationDiscoveryServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: ApplicationDiscoveryServiceClientResolvedConfig;
 
   constructor(configuration: ApplicationDiscoveryServiceClientConfig) {

--- a/clients/client-application-insights/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/ApplicationInsightsClient.ts
@@ -254,7 +254,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ApplicationInsightsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ApplicationInsightsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -262,8 +262,12 @@ export type ApplicationInsightsClientConfig = Partial<__SmithyConfiguration<__Ht
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ApplicationInsightsClient class constructor that set the region, credentials and other options.
+ */
+export interface ApplicationInsightsClientConfig extends ApplicationInsightsClientConfigType {}
 
-export type ApplicationInsightsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ApplicationInsightsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -271,6 +275,10 @@ export type ApplicationInsightsClientResolvedConfig = __SmithyResolvedConfigurat
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ApplicationInsightsClient class. This is resolved and normalized from the {@link ApplicationInsightsClientConfig | constructor configuration interface}.
+ */
+export interface ApplicationInsightsClientResolvedConfig extends ApplicationInsightsClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon CloudWatch Application Insights</fullname>
@@ -293,6 +301,9 @@ export class ApplicationInsightsClient extends __Client<
   ServiceOutputTypes,
   ApplicationInsightsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ApplicationInsightsClient class. This is resolved and normalized from the {@link ApplicationInsightsClientConfig | constructor configuration interface}.
+   */
   readonly config: ApplicationInsightsClientResolvedConfig;
 
   constructor(configuration: ApplicationInsightsClientConfig) {

--- a/clients/client-appstream/AppStreamClient.ts
+++ b/clients/client-appstream/AppStreamClient.ts
@@ -344,7 +344,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AppStreamClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AppStreamClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -352,8 +352,12 @@ export type AppStreamClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AppStreamClient class constructor that set the region, credentials and other options.
+ */
+export interface AppStreamClientConfig extends AppStreamClientConfigType {}
 
-export type AppStreamClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AppStreamClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -361,6 +365,10 @@ export type AppStreamClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AppStreamClient class. This is resolved and normalized from the {@link AppStreamClientConfig | constructor configuration interface}.
+ */
+export interface AppStreamClientResolvedConfig extends AppStreamClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon AppStream 2.0</fullname>
@@ -391,6 +399,9 @@ export class AppStreamClient extends __Client<
   ServiceOutputTypes,
   AppStreamClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AppStreamClient class. This is resolved and normalized from the {@link AppStreamClientConfig | constructor configuration interface}.
+   */
   readonly config: AppStreamClientResolvedConfig;
 
   constructor(configuration: AppStreamClientConfig) {

--- a/clients/client-appsync/AppSyncClient.ts
+++ b/clients/client-appsync/AppSyncClient.ts
@@ -287,7 +287,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AppSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AppSyncClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -295,8 +295,12 @@ export type AppSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AppSyncClient class constructor that set the region, credentials and other options.
+ */
+export interface AppSyncClientConfig extends AppSyncClientConfigType {}
 
-export type AppSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AppSyncClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -304,6 +308,10 @@ export type AppSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AppSyncClient class. This is resolved and normalized from the {@link AppSyncClientConfig | constructor configuration interface}.
+ */
+export interface AppSyncClientResolvedConfig extends AppSyncClientResolvedConfigType {}
 
 /**
  * <p>AWS AppSync provides API actions for creating and interacting with data sources using
@@ -315,6 +323,9 @@ export class AppSyncClient extends __Client<
   ServiceOutputTypes,
   AppSyncClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AppSyncClient class. This is resolved and normalized from the {@link AppSyncClientConfig | constructor configuration interface}.
+   */
   readonly config: AppSyncClientResolvedConfig;
 
   constructor(configuration: AppSyncClientConfig) {

--- a/clients/client-athena/AthenaClient.ts
+++ b/clients/client-athena/AthenaClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AthenaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AthenaClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -253,8 +253,12 @@ export type AthenaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AthenaClient class constructor that set the region, credentials and other options.
+ */
+export interface AthenaClientConfig extends AthenaClientConfigType {}
 
-export type AthenaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AthenaClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -262,6 +266,10 @@ export type AthenaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AthenaClient class. This is resolved and normalized from the {@link AthenaClientConfig | constructor configuration interface}.
+ */
+export interface AthenaClientResolvedConfig extends AthenaClientResolvedConfigType {}
 
 /**
  * <p>Amazon Athena is an interactive query service that lets you use standard SQL to
@@ -284,6 +292,9 @@ export class AthenaClient extends __Client<
   ServiceOutputTypes,
   AthenaClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AthenaClient class. This is resolved and normalized from the {@link AthenaClientConfig | constructor configuration interface}.
+   */
   readonly config: AthenaClientResolvedConfig;
 
   constructor(configuration: AthenaClientConfig) {

--- a/clients/client-auditmanager/AuditManagerClient.ts
+++ b/clients/client-auditmanager/AuditManagerClient.ts
@@ -392,7 +392,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AuditManagerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AuditManagerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -400,8 +400,12 @@ export type AuditManagerClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AuditManagerClient class constructor that set the region, credentials and other options.
+ */
+export interface AuditManagerClientConfig extends AuditManagerClientConfigType {}
 
-export type AuditManagerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AuditManagerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -409,6 +413,10 @@ export type AuditManagerClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AuditManagerClient class. This is resolved and normalized from the {@link AuditManagerClientConfig | constructor configuration interface}.
+ */
+export interface AuditManagerClientResolvedConfig extends AuditManagerClientResolvedConfigType {}
 
 /**
  * <p>Welcome to the AWS Audit Manager API reference. This guide is for developers who need detailed information about the AWS Audit Manager API operations, data types, and errors. </p>
@@ -449,6 +457,9 @@ export class AuditManagerClient extends __Client<
   ServiceOutputTypes,
   AuditManagerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AuditManagerClient class. This is resolved and normalized from the {@link AuditManagerClientConfig | constructor configuration interface}.
+   */
   readonly config: AuditManagerClientResolvedConfig;
 
   constructor(configuration: AuditManagerClientConfig) {

--- a/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
@@ -176,7 +176,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AutoScalingPlansClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AutoScalingPlansClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -184,8 +184,12 @@ export type AutoScalingPlansClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AutoScalingPlansClient class constructor that set the region, credentials and other options.
+ */
+export interface AutoScalingPlansClientConfig extends AutoScalingPlansClientConfigType {}
 
-export type AutoScalingPlansClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AutoScalingPlansClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -193,6 +197,10 @@ export type AutoScalingPlansClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AutoScalingPlansClient class. This is resolved and normalized from the {@link AutoScalingPlansClientConfig | constructor configuration interface}.
+ */
+export interface AutoScalingPlansClientResolvedConfig extends AutoScalingPlansClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Auto Scaling</fullname>
@@ -210,6 +218,9 @@ export class AutoScalingPlansClient extends __Client<
   ServiceOutputTypes,
   AutoScalingPlansClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AutoScalingPlansClient class. This is resolved and normalized from the {@link AutoScalingPlansClientConfig | constructor configuration interface}.
+   */
   readonly config: AutoScalingPlansClientResolvedConfig;
 
   constructor(configuration: AutoScalingPlansClientConfig) {

--- a/clients/client-auto-scaling/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/AutoScalingClient.ts
@@ -443,7 +443,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AutoScalingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AutoScalingClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -451,8 +451,12 @@ export type AutoScalingClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AutoScalingClient class constructor that set the region, credentials and other options.
+ */
+export interface AutoScalingClientConfig extends AutoScalingClientConfigType {}
 
-export type AutoScalingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AutoScalingClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -460,6 +464,10 @@ export type AutoScalingClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AutoScalingClient class. This is resolved and normalized from the {@link AutoScalingClientConfig | constructor configuration interface}.
+ */
+export interface AutoScalingClientResolvedConfig extends AutoScalingClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon EC2 Auto Scaling</fullname>
@@ -476,6 +484,9 @@ export class AutoScalingClient extends __Client<
   ServiceOutputTypes,
   AutoScalingClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AutoScalingClient class. This is resolved and normalized from the {@link AutoScalingClientConfig | constructor configuration interface}.
+   */
   readonly config: AutoScalingClientResolvedConfig;
 
   constructor(configuration: AutoScalingClientConfig) {

--- a/clients/client-backup/BackupClient.ts
+++ b/clients/client-backup/BackupClient.ts
@@ -383,7 +383,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type BackupClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type BackupClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -391,8 +391,12 @@ export type BackupClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of BackupClient class constructor that set the region, credentials and other options.
+ */
+export interface BackupClientConfig extends BackupClientConfigType {}
 
-export type BackupClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type BackupClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -400,6 +404,10 @@ export type BackupClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of BackupClient class. This is resolved and normalized from the {@link BackupClientConfig | constructor configuration interface}.
+ */
+export interface BackupClientResolvedConfig extends BackupClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Backup</fullname>
@@ -413,6 +421,9 @@ export class BackupClient extends __Client<
   ServiceOutputTypes,
   BackupClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of BackupClient class. This is resolved and normalized from the {@link BackupClientConfig | constructor configuration interface}.
+   */
   readonly config: BackupClientResolvedConfig;
 
   constructor(configuration: BackupClientConfig) {

--- a/clients/client-batch/BatchClient.ts
+++ b/clients/client-batch/BatchClient.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type BatchClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type BatchClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -238,8 +238,12 @@ export type BatchClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of BatchClient class constructor that set the region, credentials and other options.
+ */
+export interface BatchClientConfig extends BatchClientConfigType {}
 
-export type BatchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type BatchClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -247,6 +251,10 @@ export type BatchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of BatchClient class. This is resolved and normalized from the {@link BatchClientConfig | constructor configuration interface}.
+ */
+export interface BatchClientResolvedConfig extends BatchClientResolvedConfigType {}
 
 /**
  * <p>Using AWS Batch, you can run batch computing workloads on the AWS Cloud. Batch computing is a common means for
@@ -266,6 +274,9 @@ export class BatchClient extends __Client<
   ServiceOutputTypes,
   BatchClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of BatchClient class. This is resolved and normalized from the {@link BatchClientConfig | constructor configuration interface}.
+   */
   readonly config: BatchClientResolvedConfig;
 
   constructor(configuration: BatchClientConfig) {

--- a/clients/client-braket/BraketClient.ts
+++ b/clients/client-braket/BraketClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type BraketClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type BraketClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -175,8 +175,12 @@ export type BraketClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of BraketClient class constructor that set the region, credentials and other options.
+ */
+export interface BraketClientConfig extends BraketClientConfigType {}
 
-export type BraketClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type BraketClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -184,6 +188,10 @@ export type BraketClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of BraketClient class. This is resolved and normalized from the {@link BraketClientConfig | constructor configuration interface}.
+ */
+export interface BraketClientResolvedConfig extends BraketClientResolvedConfigType {}
 
 /**
  * <p>The Amazon Braket API Reference provides information about the operations and structures supported in Amazon Braket.</p>
@@ -194,6 +202,9 @@ export class BraketClient extends __Client<
   ServiceOutputTypes,
   BraketClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of BraketClient class. This is resolved and normalized from the {@link BraketClientConfig | constructor configuration interface}.
+   */
   readonly config: BraketClientResolvedConfig;
 
   constructor(configuration: BraketClientConfig) {

--- a/clients/client-budgets/BudgetsClient.ts
+++ b/clients/client-budgets/BudgetsClient.ts
@@ -239,7 +239,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type BudgetsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type BudgetsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -247,8 +247,12 @@ export type BudgetsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of BudgetsClient class constructor that set the region, credentials and other options.
+ */
+export interface BudgetsClientConfig extends BudgetsClientConfigType {}
 
-export type BudgetsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type BudgetsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -256,6 +260,10 @@ export type BudgetsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of BudgetsClient class. This is resolved and normalized from the {@link BudgetsClientConfig | constructor configuration interface}.
+ */
+export interface BudgetsClientResolvedConfig extends BudgetsClientResolvedConfigType {}
 
 /**
  * <p>The AWS Budgets API enables you to use AWS Budgets to plan your service usage, service costs, and instance reservations. The API reference provides descriptions, syntax, and usage examples for each of the actions and data types for AWS Budgets. </p>
@@ -308,6 +316,9 @@ export class BudgetsClient extends __Client<
   ServiceOutputTypes,
   BudgetsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of BudgetsClient class. This is resolved and normalized from the {@link BudgetsClientConfig | constructor configuration interface}.
+   */
   readonly config: BudgetsClientResolvedConfig;
 
   constructor(configuration: BudgetsClientConfig) {

--- a/clients/client-chime/ChimeClient.ts
+++ b/clients/client-chime/ChimeClient.ts
@@ -1007,7 +1007,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ChimeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ChimeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -1015,8 +1015,12 @@ export type ChimeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ChimeClient class constructor that set the region, credentials and other options.
+ */
+export interface ChimeClientConfig extends ChimeClientConfigType {}
 
-export type ChimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ChimeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -1024,6 +1028,10 @@ export type ChimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ChimeClient class. This is resolved and normalized from the {@link ChimeClientConfig | constructor configuration interface}.
+ */
+export interface ChimeClientResolvedConfig extends ChimeClientResolvedConfigType {}
 
 /**
  * <p>The Amazon Chime API (application programming interface) is designed for developers to
@@ -1072,6 +1080,9 @@ export class ChimeClient extends __Client<
   ServiceOutputTypes,
   ChimeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ChimeClient class. This is resolved and normalized from the {@link ChimeClientConfig | constructor configuration interface}.
+   */
   readonly config: ChimeClientResolvedConfig;
 
   constructor(configuration: ChimeClientConfig) {

--- a/clients/client-cloud9/Cloud9Client.ts
+++ b/clients/client-cloud9/Cloud9Client.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type Cloud9ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type Cloud9ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -220,8 +220,12 @@ export type Cloud9ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of Cloud9Client class constructor that set the region, credentials and other options.
+ */
+export interface Cloud9ClientConfig extends Cloud9ClientConfigType {}
 
-export type Cloud9ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type Cloud9ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -229,6 +233,10 @@ export type Cloud9ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of Cloud9Client class. This is resolved and normalized from the {@link Cloud9ClientConfig | constructor configuration interface}.
+ */
+export interface Cloud9ClientResolvedConfig extends Cloud9ClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Cloud9</fullname>
@@ -296,6 +304,9 @@ export class Cloud9Client extends __Client<
   ServiceOutputTypes,
   Cloud9ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of Cloud9Client class. This is resolved and normalized from the {@link Cloud9ClientConfig | constructor configuration interface}.
+   */
   readonly config: Cloud9ClientResolvedConfig;
 
   constructor(configuration: Cloud9ClientConfig) {

--- a/clients/client-clouddirectory/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/CloudDirectoryClient.ts
@@ -425,7 +425,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudDirectoryClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudDirectoryClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -433,8 +433,12 @@ export type CloudDirectoryClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudDirectoryClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudDirectoryClientConfig extends CloudDirectoryClientConfigType {}
 
-export type CloudDirectoryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudDirectoryClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -442,6 +446,10 @@ export type CloudDirectoryClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudDirectoryClient class. This is resolved and normalized from the {@link CloudDirectoryClientConfig | constructor configuration interface}.
+ */
+export interface CloudDirectoryClientResolvedConfig extends CloudDirectoryClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Cloud Directory</fullname>
@@ -457,6 +465,9 @@ export class CloudDirectoryClient extends __Client<
   ServiceOutputTypes,
   CloudDirectoryClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudDirectoryClient class. This is resolved and normalized from the {@link CloudDirectoryClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudDirectoryClientResolvedConfig;
 
   constructor(configuration: CloudDirectoryClientConfig) {

--- a/clients/client-cloudformation/CloudFormationClient.ts
+++ b/clients/client-cloudformation/CloudFormationClient.ts
@@ -383,7 +383,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudFormationClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudFormationClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -391,8 +391,12 @@ export type CloudFormationClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudFormationClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudFormationClientConfig extends CloudFormationClientConfigType {}
 
-export type CloudFormationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudFormationClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -400,6 +404,10 @@ export type CloudFormationClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudFormationClient class. This is resolved and normalized from the {@link CloudFormationClientConfig | constructor configuration interface}.
+ */
+export interface CloudFormationClientResolvedConfig extends CloudFormationClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CloudFormation</fullname>
@@ -424,6 +432,9 @@ export class CloudFormationClient extends __Client<
   ServiceOutputTypes,
   CloudFormationClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudFormationClient class. This is resolved and normalized from the {@link CloudFormationClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudFormationClientResolvedConfig;
 
   constructor(configuration: CloudFormationClientConfig) {

--- a/clients/client-cloudfront/CloudFrontClient.ts
+++ b/clients/client-cloudfront/CloudFrontClient.ts
@@ -518,7 +518,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudFrontClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudFrontClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -526,8 +526,12 @@ export type CloudFrontClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudFrontClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudFrontClientConfig extends CloudFrontClientConfigType {}
 
-export type CloudFrontClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudFrontClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -535,6 +539,10 @@ export type CloudFrontClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudFrontClient class. This is resolved and normalized from the {@link CloudFrontClientConfig | constructor configuration interface}.
+ */
+export interface CloudFrontClientResolvedConfig extends CloudFrontClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon CloudFront</fullname>
@@ -547,6 +555,9 @@ export class CloudFrontClient extends __Client<
   ServiceOutputTypes,
   CloudFrontClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudFrontClient class. This is resolved and normalized from the {@link CloudFrontClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudFrontClientResolvedConfig;
 
   constructor(configuration: CloudFrontClientConfig) {

--- a/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudHSMV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudHSMV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -205,8 +205,12 @@ export type CloudHSMV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudHSMV2Client class constructor that set the region, credentials and other options.
+ */
+export interface CloudHSMV2ClientConfig extends CloudHSMV2ClientConfigType {}
 
-export type CloudHSMV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudHSMV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -214,6 +218,10 @@ export type CloudHSMV2ClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudHSMV2Client class. This is resolved and normalized from the {@link CloudHSMV2ClientConfig | constructor configuration interface}.
+ */
+export interface CloudHSMV2ClientResolvedConfig extends CloudHSMV2ClientResolvedConfigType {}
 
 /**
  * <p>For more information about AWS CloudHSM, see <a href="http://aws.amazon.com/cloudhsm/">AWS CloudHSM</a> and the <a href="https://docs.aws.amazon.com/cloudhsm/latest/userguide/">AWS
@@ -225,6 +233,9 @@ export class CloudHSMV2Client extends __Client<
   ServiceOutputTypes,
   CloudHSMV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudHSMV2Client class. This is resolved and normalized from the {@link CloudHSMV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudHSMV2ClientResolvedConfig;
 
   constructor(configuration: CloudHSMV2ClientConfig) {

--- a/clients/client-cloudhsm/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/CloudHSMClient.ts
@@ -215,7 +215,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudHSMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudHSMClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -223,8 +223,12 @@ export type CloudHSMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudHSMClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudHSMClientConfig extends CloudHSMClientConfigType {}
 
-export type CloudHSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudHSMClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -232,6 +236,10 @@ export type CloudHSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudHSMClient class. This is resolved and normalized from the {@link CloudHSMClientConfig | constructor configuration interface}.
+ */
+export interface CloudHSMClientResolvedConfig extends CloudHSMClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CloudHSM Service</fullname>
@@ -252,6 +260,9 @@ export class CloudHSMClient extends __Client<
   ServiceOutputTypes,
   CloudHSMClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudHSMClient class. This is resolved and normalized from the {@link CloudHSMClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudHSMClientResolvedConfig;
 
   constructor(configuration: CloudHSMClientConfig) {

--- a/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudSearchDomainClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudSearchDomainClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -160,8 +160,12 @@ export type CloudSearchDomainClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudSearchDomainClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudSearchDomainClientConfig extends CloudSearchDomainClientConfigType {}
 
-export type CloudSearchDomainClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudSearchDomainClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -169,6 +173,10 @@ export type CloudSearchDomainClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudSearchDomainClient class. This is resolved and normalized from the {@link CloudSearchDomainClientConfig | constructor configuration interface}.
+ */
+export interface CloudSearchDomainClientResolvedConfig extends CloudSearchDomainClientResolvedConfigType {}
 
 /**
  * <p>You use the AmazonCloudSearch2013 API to upload documents to a search domain and search those documents.</p>
@@ -182,6 +190,9 @@ export class CloudSearchDomainClient extends __Client<
   ServiceOutputTypes,
   CloudSearchDomainClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudSearchDomainClient class. This is resolved and normalized from the {@link CloudSearchDomainClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudSearchDomainClientResolvedConfig;
 
   constructor(configuration: CloudSearchDomainClientConfig) {

--- a/clients/client-cloudsearch/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/CloudSearchClient.ts
@@ -266,7 +266,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudSearchClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudSearchClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -274,8 +274,12 @@ export type CloudSearchClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudSearchClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudSearchClientConfig extends CloudSearchClientConfigType {}
 
-export type CloudSearchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudSearchClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -283,6 +287,10 @@ export type CloudSearchClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudSearchClient class. This is resolved and normalized from the {@link CloudSearchClientConfig | constructor configuration interface}.
+ */
+export interface CloudSearchClientResolvedConfig extends CloudSearchClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon CloudSearch Configuration Service</fullname>
@@ -299,6 +307,9 @@ export class CloudSearchClient extends __Client<
   ServiceOutputTypes,
   CloudSearchClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudSearchClient class. This is resolved and normalized from the {@link CloudSearchClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudSearchClientResolvedConfig;
 
   constructor(configuration: CloudSearchClientConfig) {

--- a/clients/client-cloudtrail/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/CloudTrailClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudTrailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudTrailClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -217,8 +217,12 @@ export type CloudTrailClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudTrailClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudTrailClientConfig extends CloudTrailClientConfigType {}
 
-export type CloudTrailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudTrailClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -226,6 +230,10 @@ export type CloudTrailClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudTrailClient class. This is resolved and normalized from the {@link CloudTrailClientConfig | constructor configuration interface}.
+ */
+export interface CloudTrailClientResolvedConfig extends CloudTrailClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CloudTrail</fullname>
@@ -250,6 +258,9 @@ export class CloudTrailClient extends __Client<
   ServiceOutputTypes,
   CloudTrailClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudTrailClient class. This is resolved and normalized from the {@link CloudTrailClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudTrailClientResolvedConfig;
 
   constructor(configuration: CloudTrailClientConfig) {

--- a/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
@@ -299,7 +299,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudWatchEventsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudWatchEventsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -307,8 +307,12 @@ export type CloudWatchEventsClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudWatchEventsClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudWatchEventsClientConfig extends CloudWatchEventsClientConfigType {}
 
-export type CloudWatchEventsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudWatchEventsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -316,6 +320,10 @@ export type CloudWatchEventsClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudWatchEventsClient class. This is resolved and normalized from the {@link CloudWatchEventsClientConfig | constructor configuration interface}.
+ */
+export interface CloudWatchEventsClientResolvedConfig extends CloudWatchEventsClientResolvedConfigType {}
 
 /**
  * <p>Amazon EventBridge helps you to respond to state changes in your AWS resources.
@@ -347,6 +355,9 @@ export class CloudWatchEventsClient extends __Client<
   ServiceOutputTypes,
   CloudWatchEventsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudWatchEventsClient class. This is resolved and normalized from the {@link CloudWatchEventsClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudWatchEventsClientResolvedConfig;
 
   constructor(configuration: CloudWatchEventsClientConfig) {

--- a/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
@@ -311,7 +311,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudWatchLogsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudWatchLogsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -319,8 +319,12 @@ export type CloudWatchLogsClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudWatchLogsClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudWatchLogsClientConfig extends CloudWatchLogsClientConfigType {}
 
-export type CloudWatchLogsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudWatchLogsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -328,6 +332,10 @@ export type CloudWatchLogsClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudWatchLogsClient class. This is resolved and normalized from the {@link CloudWatchLogsClientConfig | constructor configuration interface}.
+ */
+export interface CloudWatchLogsClientResolvedConfig extends CloudWatchLogsClientResolvedConfigType {}
 
 /**
  * <p>You can use Amazon CloudWatch Logs to monitor, store, and access your log files from
@@ -371,6 +379,9 @@ export class CloudWatchLogsClient extends __Client<
   ServiceOutputTypes,
   CloudWatchLogsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudWatchLogsClient class. This is resolved and normalized from the {@link CloudWatchLogsClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudWatchLogsClientResolvedConfig;
 
   constructor(configuration: CloudWatchLogsClientConfig) {

--- a/clients/client-cloudwatch/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/CloudWatchClient.ts
@@ -272,7 +272,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CloudWatchClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CloudWatchClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -280,8 +280,12 @@ export type CloudWatchClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CloudWatchClient class constructor that set the region, credentials and other options.
+ */
+export interface CloudWatchClientConfig extends CloudWatchClientConfigType {}
 
-export type CloudWatchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CloudWatchClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -289,6 +293,10 @@ export type CloudWatchClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CloudWatchClient class. This is resolved and normalized from the {@link CloudWatchClientConfig | constructor configuration interface}.
+ */
+export interface CloudWatchClientResolvedConfig extends CloudWatchClientResolvedConfigType {}
 
 /**
  * <p>Amazon CloudWatch monitors your Amazon Web Services (AWS) resources and the
@@ -313,6 +321,9 @@ export class CloudWatchClient extends __Client<
   ServiceOutputTypes,
   CloudWatchClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CloudWatchClient class. This is resolved and normalized from the {@link CloudWatchClientConfig | constructor configuration interface}.
+   */
   readonly config: CloudWatchClientResolvedConfig;
 
   constructor(configuration: CloudWatchClientConfig) {

--- a/clients/client-codeartifact/CodeartifactClient.ts
+++ b/clients/client-codeartifact/CodeartifactClient.ts
@@ -317,7 +317,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeartifactClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeartifactClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -325,8 +325,12 @@ export type CodeartifactClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeartifactClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeartifactClientConfig extends CodeartifactClientConfigType {}
 
-export type CodeartifactClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeartifactClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -334,6 +338,10 @@ export type CodeartifactClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeartifactClient class. This is resolved and normalized from the {@link CodeartifactClientConfig | constructor configuration interface}.
+ */
+export interface CodeartifactClientResolvedConfig extends CodeartifactClientResolvedConfigType {}
 
 /**
  * <p> AWS CodeArtifact is a fully managed artifact repository compatible with language-native
@@ -619,6 +627,9 @@ export class CodeartifactClient extends __Client<
   ServiceOutputTypes,
   CodeartifactClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeartifactClient class. This is resolved and normalized from the {@link CodeartifactClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeartifactClientResolvedConfig;
 
   constructor(configuration: CodeartifactClientConfig) {

--- a/clients/client-codebuild/CodeBuildClient.ts
+++ b/clients/client-codebuild/CodeBuildClient.ts
@@ -323,7 +323,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeBuildClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeBuildClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -331,8 +331,12 @@ export type CodeBuildClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeBuildClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeBuildClientConfig extends CodeBuildClientConfigType {}
 
-export type CodeBuildClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeBuildClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -340,6 +344,10 @@ export type CodeBuildClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeBuildClient class. This is resolved and normalized from the {@link CodeBuildClientConfig | constructor configuration interface}.
+ */
+export interface CodeBuildClientResolvedConfig extends CodeBuildClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CodeBuild</fullname>
@@ -534,6 +542,9 @@ export class CodeBuildClient extends __Client<
   ServiceOutputTypes,
   CodeBuildClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeBuildClient class. This is resolved and normalized from the {@link CodeBuildClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeBuildClientResolvedConfig;
 
   constructor(configuration: CodeBuildClientConfig) {

--- a/clients/client-codecommit/CodeCommitClient.ts
+++ b/clients/client-codecommit/CodeCommitClient.ts
@@ -524,7 +524,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeCommitClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeCommitClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -532,8 +532,12 @@ export type CodeCommitClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeCommitClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeCommitClientConfig extends CodeCommitClientConfigType {}
 
-export type CodeCommitClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeCommitClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -541,6 +545,10 @@ export type CodeCommitClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeCommitClient class. This is resolved and normalized from the {@link CodeCommitClientConfig | constructor configuration interface}.
+ */
+export interface CodeCommitClientResolvedConfig extends CodeCommitClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CodeCommit</fullname>
@@ -947,6 +955,9 @@ export class CodeCommitClient extends __Client<
   ServiceOutputTypes,
   CodeCommitClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeCommitClient class. This is resolved and normalized from the {@link CodeCommitClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeCommitClientResolvedConfig;
 
   constructor(configuration: CodeCommitClientConfig) {

--- a/clients/client-codedeploy/CodeDeployClient.ts
+++ b/clients/client-codedeploy/CodeDeployClient.ts
@@ -392,7 +392,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeDeployClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeDeployClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -400,8 +400,12 @@ export type CodeDeployClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeDeployClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeDeployClientConfig extends CodeDeployClientConfigType {}
 
-export type CodeDeployClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeDeployClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -409,6 +413,10 @@ export type CodeDeployClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeDeployClient class. This is resolved and normalized from the {@link CodeDeployClientConfig | constructor configuration interface}.
+ */
+export interface CodeDeployClientResolvedConfig extends CodeDeployClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CodeDeploy</fullname>
@@ -518,6 +526,9 @@ export class CodeDeployClient extends __Client<
   ServiceOutputTypes,
   CodeDeployClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeDeployClient class. This is resolved and normalized from the {@link CodeDeployClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeDeployClientResolvedConfig;
 
   constructor(configuration: CodeDeployClientConfig) {

--- a/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
@@ -218,7 +218,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeGuruReviewerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeGuruReviewerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -226,8 +226,12 @@ export type CodeGuruReviewerClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeGuruReviewerClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeGuruReviewerClientConfig extends CodeGuruReviewerClientConfigType {}
 
-export type CodeGuruReviewerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeGuruReviewerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -235,6 +239,10 @@ export type CodeGuruReviewerClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeGuruReviewerClient class. This is resolved and normalized from the {@link CodeGuruReviewerClientConfig | constructor configuration interface}.
+ */
+export interface CodeGuruReviewerClientResolvedConfig extends CodeGuruReviewerClientResolvedConfigType {}
 
 /**
  * <p>This section provides documentation for the Amazon CodeGuru Reviewer API operations. CodeGuru Reviewer is a service
@@ -260,6 +268,9 @@ export class CodeGuruReviewerClient extends __Client<
   ServiceOutputTypes,
   CodeGuruReviewerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeGuruReviewerClient class. This is resolved and normalized from the {@link CodeGuruReviewerClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeGuruReviewerClientResolvedConfig;
 
   constructor(configuration: CodeGuruReviewerClientConfig) {

--- a/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeGuruProfilerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeGuruProfilerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -211,8 +211,12 @@ export type CodeGuruProfilerClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeGuruProfilerClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeGuruProfilerClientConfig extends CodeGuruProfilerClientConfigType {}
 
-export type CodeGuruProfilerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeGuruProfilerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -220,6 +224,10 @@ export type CodeGuruProfilerClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeGuruProfilerClient class. This is resolved and normalized from the {@link CodeGuruProfilerClientConfig | constructor configuration interface}.
+ */
+export interface CodeGuruProfilerClientResolvedConfig extends CodeGuruProfilerClientResolvedConfigType {}
 
 /**
  * <p>This section provides documentation for the Amazon CodeGuru Profiler API operations.</p>
@@ -230,6 +238,9 @@ export class CodeGuruProfilerClient extends __Client<
   ServiceOutputTypes,
   CodeGuruProfilerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeGuruProfilerClient class. This is resolved and normalized from the {@link CodeGuruProfilerClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeGuruProfilerClientResolvedConfig;
 
   constructor(configuration: CodeGuruProfilerClientConfig) {

--- a/clients/client-codepipeline/CodePipelineClient.ts
+++ b/clients/client-codepipeline/CodePipelineClient.ts
@@ -320,7 +320,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodePipelineClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodePipelineClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -328,8 +328,12 @@ export type CodePipelineClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodePipelineClient class constructor that set the region, credentials and other options.
+ */
+export interface CodePipelineClientConfig extends CodePipelineClientConfigType {}
 
-export type CodePipelineClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodePipelineClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -337,6 +341,10 @@ export type CodePipelineClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodePipelineClient class. This is resolved and normalized from the {@link CodePipelineClientConfig | constructor configuration interface}.
+ */
+export interface CodePipelineClientResolvedConfig extends CodePipelineClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CodePipeline</fullname>
@@ -541,6 +549,9 @@ export class CodePipelineClient extends __Client<
   ServiceOutputTypes,
   CodePipelineClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodePipelineClient class. This is resolved and normalized from the {@link CodePipelineClientConfig | constructor configuration interface}.
+   */
   readonly config: CodePipelineClientResolvedConfig;
 
   constructor(configuration: CodePipelineClientConfig) {

--- a/clients/client-codestar-connections/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/CodeStarConnectionsClient.ts
@@ -188,7 +188,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeStarConnectionsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeStarConnectionsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -196,8 +196,12 @@ export type CodeStarConnectionsClientConfig = Partial<__SmithyConfiguration<__Ht
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeStarConnectionsClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeStarConnectionsClientConfig extends CodeStarConnectionsClientConfigType {}
 
-export type CodeStarConnectionsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeStarConnectionsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -205,6 +209,10 @@ export type CodeStarConnectionsClientResolvedConfig = __SmithyResolvedConfigurat
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeStarConnectionsClient class. This is resolved and normalized from the {@link CodeStarConnectionsClientConfig | constructor configuration interface}.
+ */
+export interface CodeStarConnectionsClientResolvedConfig extends CodeStarConnectionsClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CodeStar Connections</fullname>
@@ -294,6 +302,9 @@ export class CodeStarConnectionsClient extends __Client<
   ServiceOutputTypes,
   CodeStarConnectionsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeStarConnectionsClient class. This is resolved and normalized from the {@link CodeStarConnectionsClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeStarConnectionsClientResolvedConfig;
 
   constructor(configuration: CodeStarConnectionsClientConfig) {

--- a/clients/client-codestar-notifications/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/CodestarNotificationsClient.ts
@@ -206,7 +206,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodestarNotificationsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodestarNotificationsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -214,8 +214,12 @@ export type CodestarNotificationsClientConfig = Partial<__SmithyConfiguration<__
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodestarNotificationsClient class constructor that set the region, credentials and other options.
+ */
+export interface CodestarNotificationsClientConfig extends CodestarNotificationsClientConfigType {}
 
-export type CodestarNotificationsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodestarNotificationsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -223,6 +227,10 @@ export type CodestarNotificationsClientResolvedConfig = __SmithyResolvedConfigur
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodestarNotificationsClient class. This is resolved and normalized from the {@link CodestarNotificationsClientConfig | constructor configuration interface}.
+ */
+export interface CodestarNotificationsClientResolvedConfig extends CodestarNotificationsClientResolvedConfigType {}
 
 /**
  * <p>This AWS CodeStar Notifications API Reference provides descriptions and usage examples of the
@@ -316,6 +324,9 @@ export class CodestarNotificationsClient extends __Client<
   ServiceOutputTypes,
   CodestarNotificationsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodestarNotificationsClient class. This is resolved and normalized from the {@link CodestarNotificationsClientConfig | constructor configuration interface}.
+   */
   readonly config: CodestarNotificationsClientResolvedConfig;
 
   constructor(configuration: CodestarNotificationsClientConfig) {

--- a/clients/client-codestar/CodeStarClient.ts
+++ b/clients/client-codestar/CodeStarClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CodeStarClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CodeStarClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -220,8 +220,12 @@ export type CodeStarClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CodeStarClient class constructor that set the region, credentials and other options.
+ */
+export interface CodeStarClientConfig extends CodeStarClientConfigType {}
 
-export type CodeStarClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CodeStarClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -229,6 +233,10 @@ export type CodeStarClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CodeStarClient class. This is resolved and normalized from the {@link CodeStarClientConfig | constructor configuration interface}.
+ */
+export interface CodeStarClientResolvedConfig extends CodeStarClientResolvedConfigType {}
 
 /**
  * <fullname>AWS CodeStar</fullname>
@@ -328,6 +336,9 @@ export class CodeStarClient extends __Client<
   ServiceOutputTypes,
   CodeStarClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CodeStarClient class. This is resolved and normalized from the {@link CodeStarClientConfig | constructor configuration interface}.
+   */
   readonly config: CodeStarClientResolvedConfig;
 
   constructor(configuration: CodeStarClientConfig) {

--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -612,7 +612,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CognitoIdentityProviderClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CognitoIdentityProviderClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -620,8 +620,12 @@ export type CognitoIdentityProviderClientConfig = Partial<__SmithyConfiguration<
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CognitoIdentityProviderClient class constructor that set the region, credentials and other options.
+ */
+export interface CognitoIdentityProviderClientConfig extends CognitoIdentityProviderClientConfigType {}
 
-export type CognitoIdentityProviderClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CognitoIdentityProviderClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -629,6 +633,10 @@ export type CognitoIdentityProviderClientResolvedConfig = __SmithyResolvedConfig
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CognitoIdentityProviderClient class. This is resolved and normalized from the {@link CognitoIdentityProviderClientConfig | constructor configuration interface}.
+ */
+export interface CognitoIdentityProviderClientResolvedConfig extends CognitoIdentityProviderClientResolvedConfigType {}
 
 /**
  * <p>Using the Amazon Cognito User Pools API, you can create a user pool to manage
@@ -644,6 +652,9 @@ export class CognitoIdentityProviderClient extends __Client<
   ServiceOutputTypes,
   CognitoIdentityProviderClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CognitoIdentityProviderClient class. This is resolved and normalized from the {@link CognitoIdentityProviderClientConfig | constructor configuration interface}.
+   */
   readonly config: CognitoIdentityProviderClientResolvedConfig;
 
   constructor(configuration: CognitoIdentityProviderClientConfig) {

--- a/clients/client-cognito-identity/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/CognitoIdentityClient.ts
@@ -234,7 +234,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CognitoIdentityClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CognitoIdentityClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -242,8 +242,12 @@ export type CognitoIdentityClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CognitoIdentityClient class constructor that set the region, credentials and other options.
+ */
+export interface CognitoIdentityClientConfig extends CognitoIdentityClientConfigType {}
 
-export type CognitoIdentityClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CognitoIdentityClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -251,6 +255,10 @@ export type CognitoIdentityClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CognitoIdentityClient class. This is resolved and normalized from the {@link CognitoIdentityClientConfig | constructor configuration interface}.
+ */
+export interface CognitoIdentityClientResolvedConfig extends CognitoIdentityClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Cognito Federated Identities</fullname>
@@ -274,6 +282,9 @@ export class CognitoIdentityClient extends __Client<
   ServiceOutputTypes,
   CognitoIdentityClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CognitoIdentityClient class. This is resolved and normalized from the {@link CognitoIdentityClientConfig | constructor configuration interface}.
+   */
   readonly config: CognitoIdentityClientResolvedConfig;
 
   constructor(configuration: CognitoIdentityClientConfig) {

--- a/clients/client-cognito-sync/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/CognitoSyncClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CognitoSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CognitoSyncClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -229,8 +229,12 @@ export type CognitoSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CognitoSyncClient class constructor that set the region, credentials and other options.
+ */
+export interface CognitoSyncClientConfig extends CognitoSyncClientConfigType {}
 
-export type CognitoSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CognitoSyncClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -238,6 +242,10 @@ export type CognitoSyncClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CognitoSyncClient class. This is resolved and normalized from the {@link CognitoSyncClientConfig | constructor configuration interface}.
+ */
+export interface CognitoSyncClientResolvedConfig extends CognitoSyncClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Cognito Sync</fullname>
@@ -254,6 +262,9 @@ export class CognitoSyncClient extends __Client<
   ServiceOutputTypes,
   CognitoSyncClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CognitoSyncClient class. This is resolved and normalized from the {@link CognitoSyncClientConfig | constructor configuration interface}.
+   */
   readonly config: CognitoSyncClientResolvedConfig;
 
   constructor(configuration: CognitoSyncClientConfig) {

--- a/clients/client-comprehend/ComprehendClient.ts
+++ b/clients/client-comprehend/ComprehendClient.ts
@@ -467,7 +467,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ComprehendClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ComprehendClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -475,8 +475,12 @@ export type ComprehendClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ComprehendClient class constructor that set the region, credentials and other options.
+ */
+export interface ComprehendClientConfig extends ComprehendClientConfigType {}
 
-export type ComprehendClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ComprehendClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -484,6 +488,10 @@ export type ComprehendClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ComprehendClient class. This is resolved and normalized from the {@link ComprehendClientConfig | constructor configuration interface}.
+ */
+export interface ComprehendClientResolvedConfig extends ComprehendClientResolvedConfigType {}
 
 /**
  * <p>Amazon Comprehend is an AWS service for gaining insight into the content of documents.
@@ -497,6 +505,9 @@ export class ComprehendClient extends __Client<
   ServiceOutputTypes,
   ComprehendClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ComprehendClient class. This is resolved and normalized from the {@link ComprehendClientConfig | constructor configuration interface}.
+   */
   readonly config: ComprehendClientResolvedConfig;
 
   constructor(configuration: ComprehendClientConfig) {

--- a/clients/client-comprehendmedical/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/ComprehendMedicalClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ComprehendMedicalClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ComprehendMedicalClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -268,8 +268,12 @@ export type ComprehendMedicalClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ComprehendMedicalClient class constructor that set the region, credentials and other options.
+ */
+export interface ComprehendMedicalClientConfig extends ComprehendMedicalClientConfigType {}
 
-export type ComprehendMedicalClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ComprehendMedicalClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -277,6 +281,10 @@ export type ComprehendMedicalClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ComprehendMedicalClient class. This is resolved and normalized from the {@link ComprehendMedicalClientConfig | constructor configuration interface}.
+ */
+export interface ComprehendMedicalClientResolvedConfig extends ComprehendMedicalClientResolvedConfigType {}
 
 /**
  * <p> Amazon Comprehend Medical extracts structured information from unstructured clinical text. Use these actions
@@ -288,6 +296,9 @@ export class ComprehendMedicalClient extends __Client<
   ServiceOutputTypes,
   ComprehendMedicalClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ComprehendMedicalClient class. This is resolved and normalized from the {@link ComprehendMedicalClientConfig | constructor configuration interface}.
+   */
   readonly config: ComprehendMedicalClientResolvedConfig;
 
   constructor(configuration: ComprehendMedicalClientConfig) {

--- a/clients/client-compute-optimizer/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/ComputeOptimizerClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ComputeOptimizerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ComputeOptimizerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -217,8 +217,12 @@ export type ComputeOptimizerClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ComputeOptimizerClient class constructor that set the region, credentials and other options.
+ */
+export interface ComputeOptimizerClientConfig extends ComputeOptimizerClientConfigType {}
 
-export type ComputeOptimizerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ComputeOptimizerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -226,6 +230,10 @@ export type ComputeOptimizerClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ComputeOptimizerClient class. This is resolved and normalized from the {@link ComputeOptimizerClientConfig | constructor configuration interface}.
+ */
+export interface ComputeOptimizerClientResolvedConfig extends ComputeOptimizerClientResolvedConfigType {}
 
 /**
  * <p>AWS Compute Optimizer is a service that analyzes the configuration and utilization metrics of your
@@ -245,6 +253,9 @@ export class ComputeOptimizerClient extends __Client<
   ServiceOutputTypes,
   ComputeOptimizerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ComputeOptimizerClient class. This is resolved and normalized from the {@link ComputeOptimizerClientConfig | constructor configuration interface}.
+   */
   readonly config: ComputeOptimizerClientResolvedConfig;
 
   constructor(configuration: ComputeOptimizerClientConfig) {

--- a/clients/client-config-service/ConfigServiceClient.ts
+++ b/clients/client-config-service/ConfigServiceClient.ts
@@ -599,7 +599,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ConfigServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ConfigServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -607,8 +607,12 @@ export type ConfigServiceClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ConfigServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface ConfigServiceClientConfig extends ConfigServiceClientConfigType {}
 
-export type ConfigServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ConfigServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -616,6 +620,10 @@ export type ConfigServiceClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ConfigServiceClient class. This is resolved and normalized from the {@link ConfigServiceClientConfig | constructor configuration interface}.
+ */
+export interface ConfigServiceClientResolvedConfig extends ConfigServiceClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Config</fullname>
@@ -649,6 +657,9 @@ export class ConfigServiceClient extends __Client<
   ServiceOutputTypes,
   ConfigServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ConfigServiceClient class. This is resolved and normalized from the {@link ConfigServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: ConfigServiceClientResolvedConfig;
 
   constructor(configuration: ConfigServiceClientConfig) {

--- a/clients/client-connect-contact-lens/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/ConnectContactLensClient.ts
@@ -159,7 +159,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ConnectContactLensClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ConnectContactLensClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -167,8 +167,12 @@ export type ConnectContactLensClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ConnectContactLensClient class constructor that set the region, credentials and other options.
+ */
+export interface ConnectContactLensClientConfig extends ConnectContactLensClientConfigType {}
 
-export type ConnectContactLensClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ConnectContactLensClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -176,6 +180,10 @@ export type ConnectContactLensClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ConnectContactLensClient class. This is resolved and normalized from the {@link ConnectContactLensClientConfig | constructor configuration interface}.
+ */
+export interface ConnectContactLensClientResolvedConfig extends ConnectContactLensClientResolvedConfigType {}
 
 /**
  * <p>Contact Lens for Amazon Connect enables you to analyze conversations between customer and agents,
@@ -192,6 +200,9 @@ export class ConnectContactLensClient extends __Client<
   ServiceOutputTypes,
   ConnectContactLensClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ConnectContactLensClient class. This is resolved and normalized from the {@link ConnectContactLensClientConfig | constructor configuration interface}.
+   */
   readonly config: ConnectContactLensClientResolvedConfig;
 
   constructor(configuration: ConnectContactLensClientConfig) {

--- a/clients/client-connect/ConnectClient.ts
+++ b/clients/client-connect/ConnectClient.ts
@@ -560,7 +560,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ConnectClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -568,8 +568,12 @@ export type ConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ConnectClient class constructor that set the region, credentials and other options.
+ */
+export interface ConnectClientConfig extends ConnectClientConfigType {}
 
-export type ConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ConnectClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -577,6 +581,10 @@ export type ConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ConnectClient class. This is resolved and normalized from the {@link ConnectClientConfig | constructor configuration interface}.
+ */
+export interface ConnectClientResolvedConfig extends ConnectClientResolvedConfigType {}
 
 /**
  * <p>Amazon Connect is a cloud-based contact center solution that makes it easy to set up and manage a
@@ -600,6 +608,9 @@ export class ConnectClient extends __Client<
   ServiceOutputTypes,
   ConnectClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ConnectClient class. This is resolved and normalized from the {@link ConnectClientConfig | constructor configuration interface}.
+   */
   readonly config: ConnectClientResolvedConfig;
 
   constructor(configuration: ConnectClientConfig) {

--- a/clients/client-connectparticipant/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/ConnectParticipantClient.ts
@@ -176,7 +176,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ConnectParticipantClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ConnectParticipantClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -184,8 +184,12 @@ export type ConnectParticipantClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ConnectParticipantClient class constructor that set the region, credentials and other options.
+ */
+export interface ConnectParticipantClientConfig extends ConnectParticipantClientConfigType {}
 
-export type ConnectParticipantClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ConnectParticipantClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -193,6 +197,10 @@ export type ConnectParticipantClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ConnectParticipantClient class. This is resolved and normalized from the {@link ConnectParticipantClientConfig | constructor configuration interface}.
+ */
+export interface ConnectParticipantClientResolvedConfig extends ConnectParticipantClientResolvedConfigType {}
 
 /**
  * <p>Amazon Connect is a cloud-based contact center solution that makes it easy to set up and manage
@@ -208,6 +216,9 @@ export class ConnectParticipantClient extends __Client<
   ServiceOutputTypes,
   ConnectParticipantClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ConnectParticipantClient class. This is resolved and normalized from the {@link ConnectParticipantClientConfig | constructor configuration interface}.
+   */
   readonly config: ConnectParticipantClientResolvedConfig;
 
   constructor(configuration: ConnectParticipantClientConfig) {

--- a/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CostAndUsageReportServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CostAndUsageReportServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -181,8 +181,12 @@ export type CostAndUsageReportServiceClientConfig = Partial<__SmithyConfiguratio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CostAndUsageReportServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface CostAndUsageReportServiceClientConfig extends CostAndUsageReportServiceClientConfigType {}
 
-export type CostAndUsageReportServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CostAndUsageReportServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -190,6 +194,11 @@ export type CostAndUsageReportServiceClientResolvedConfig = __SmithyResolvedConf
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CostAndUsageReportServiceClient class. This is resolved and normalized from the {@link CostAndUsageReportServiceClientConfig | constructor configuration interface}.
+ */
+export interface CostAndUsageReportServiceClientResolvedConfig
+  extends CostAndUsageReportServiceClientResolvedConfigType {}
 
 /**
  * <p>The AWS Cost and Usage Report API enables you to programmatically create, query, and delete
@@ -218,6 +227,9 @@ export class CostAndUsageReportServiceClient extends __Client<
   ServiceOutputTypes,
   CostAndUsageReportServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CostAndUsageReportServiceClient class. This is resolved and normalized from the {@link CostAndUsageReportServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: CostAndUsageReportServiceClientResolvedConfig;
 
   constructor(configuration: CostAndUsageReportServiceClientConfig) {

--- a/clients/client-cost-explorer/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/CostExplorerClient.ts
@@ -302,7 +302,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CostExplorerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CostExplorerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -310,8 +310,12 @@ export type CostExplorerClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CostExplorerClient class constructor that set the region, credentials and other options.
+ */
+export interface CostExplorerClientConfig extends CostExplorerClientConfigType {}
 
-export type CostExplorerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CostExplorerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -319,6 +323,10 @@ export type CostExplorerClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CostExplorerClient class. This is resolved and normalized from the {@link CostExplorerClientConfig | constructor configuration interface}.
+ */
+export interface CostExplorerClientResolvedConfig extends CostExplorerClientResolvedConfigType {}
 
 /**
  * <p>The Cost Explorer API enables you to programmatically query your cost and usage data. You can query for aggregated data
@@ -342,6 +350,9 @@ export class CostExplorerClient extends __Client<
   ServiceOutputTypes,
   CostExplorerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CostExplorerClient class. This is resolved and normalized from the {@link CostExplorerClientConfig | constructor configuration interface}.
+   */
   readonly config: CostExplorerClientResolvedConfig;
 
   constructor(configuration: CostExplorerClientConfig) {

--- a/clients/client-customer-profiles/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/CustomerProfilesClient.ts
@@ -266,7 +266,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type CustomerProfilesClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type CustomerProfilesClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -274,8 +274,12 @@ export type CustomerProfilesClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of CustomerProfilesClient class constructor that set the region, credentials and other options.
+ */
+export interface CustomerProfilesClientConfig extends CustomerProfilesClientConfigType {}
 
-export type CustomerProfilesClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type CustomerProfilesClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -283,6 +287,10 @@ export type CustomerProfilesClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of CustomerProfilesClient class. This is resolved and normalized from the {@link CustomerProfilesClientConfig | constructor configuration interface}.
+ */
+export interface CustomerProfilesClientResolvedConfig extends CustomerProfilesClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Connect Customer Profiles</fullname>
@@ -302,6 +310,9 @@ export class CustomerProfilesClient extends __Client<
   ServiceOutputTypes,
   CustomerProfilesClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of CustomerProfilesClient class. This is resolved and normalized from the {@link CustomerProfilesClientConfig | constructor configuration interface}.
+   */
   readonly config: CustomerProfilesClientResolvedConfig;
 
   constructor(configuration: CustomerProfilesClientConfig) {

--- a/clients/client-data-pipeline/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/DataPipelineClient.ts
@@ -218,7 +218,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DataPipelineClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DataPipelineClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -226,8 +226,12 @@ export type DataPipelineClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DataPipelineClient class constructor that set the region, credentials and other options.
+ */
+export interface DataPipelineClientConfig extends DataPipelineClientConfigType {}
 
-export type DataPipelineClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DataPipelineClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -235,6 +239,10 @@ export type DataPipelineClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DataPipelineClient class. This is resolved and normalized from the {@link DataPipelineClientConfig | constructor configuration interface}.
+ */
+export interface DataPipelineClientResolvedConfig extends DataPipelineClientResolvedConfigType {}
 
 /**
  * <p>AWS Data Pipeline configures and manages a data-driven workflow called a pipeline. AWS Data Pipeline handles the details of scheduling and ensuring that data dependencies are met so that your application can focus on processing the data.</p>
@@ -249,6 +257,9 @@ export class DataPipelineClient extends __Client<
   ServiceOutputTypes,
   DataPipelineClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DataPipelineClient class. This is resolved and normalized from the {@link DataPipelineClientConfig | constructor configuration interface}.
+   */
   readonly config: DataPipelineClientResolvedConfig;
 
   constructor(configuration: DataPipelineClientConfig) {

--- a/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
@@ -434,7 +434,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DatabaseMigrationServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DatabaseMigrationServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -442,8 +442,12 @@ export type DatabaseMigrationServiceClientConfig = Partial<__SmithyConfiguration
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DatabaseMigrationServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface DatabaseMigrationServiceClientConfig extends DatabaseMigrationServiceClientConfigType {}
 
-export type DatabaseMigrationServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DatabaseMigrationServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -451,6 +455,11 @@ export type DatabaseMigrationServiceClientResolvedConfig = __SmithyResolvedConfi
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DatabaseMigrationServiceClient class. This is resolved and normalized from the {@link DatabaseMigrationServiceClientConfig | constructor configuration interface}.
+ */
+export interface DatabaseMigrationServiceClientResolvedConfig
+  extends DatabaseMigrationServiceClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Database Migration Service</fullname>
@@ -470,6 +479,9 @@ export class DatabaseMigrationServiceClient extends __Client<
   ServiceOutputTypes,
   DatabaseMigrationServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DatabaseMigrationServiceClient class. This is resolved and normalized from the {@link DatabaseMigrationServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: DatabaseMigrationServiceClientResolvedConfig;
 
   constructor(configuration: DatabaseMigrationServiceClientConfig) {

--- a/clients/client-databrew/DataBrewClient.ts
+++ b/clients/client-databrew/DataBrewClient.ts
@@ -278,7 +278,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DataBrewClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DataBrewClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -286,8 +286,12 @@ export type DataBrewClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DataBrewClient class constructor that set the region, credentials and other options.
+ */
+export interface DataBrewClientConfig extends DataBrewClientConfigType {}
 
-export type DataBrewClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DataBrewClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -295,6 +299,10 @@ export type DataBrewClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DataBrewClient class. This is resolved and normalized from the {@link DataBrewClientConfig | constructor configuration interface}.
+ */
+export interface DataBrewClientResolvedConfig extends DataBrewClientResolvedConfigType {}
 
 /**
  * <p>AWS Glue DataBrew is a visual, cloud-scale data-preparation service. DataBrew
@@ -308,6 +316,9 @@ export class DataBrewClient extends __Client<
   ServiceOutputTypes,
   DataBrewClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DataBrewClient class. This is resolved and normalized from the {@link DataBrewClientConfig | constructor configuration interface}.
+   */
   readonly config: DataBrewClientResolvedConfig;
 
   constructor(configuration: DataBrewClientConfig) {

--- a/clients/client-dataexchange/DataExchangeClient.ts
+++ b/clients/client-dataexchange/DataExchangeClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DataExchangeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DataExchangeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -229,8 +229,12 @@ export type DataExchangeClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DataExchangeClient class constructor that set the region, credentials and other options.
+ */
+export interface DataExchangeClientConfig extends DataExchangeClientConfigType {}
 
-export type DataExchangeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DataExchangeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -238,6 +242,10 @@ export type DataExchangeClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DataExchangeClient class. This is resolved and normalized from the {@link DataExchangeClientConfig | constructor configuration interface}.
+ */
+export interface DataExchangeClientResolvedConfig extends DataExchangeClientResolvedConfigType {}
 
 /**
  * <p>AWS Data Exchange is a service that makes it easy for AWS customers to exchange data in the cloud. You can use the AWS Data Exchange APIs to create, update, manage, and access file-based data set in the AWS Cloud.</p><p>As a subscriber, you can view and access the data sets that you have an entitlement to through a subscription. You can use the APIS to download or copy your entitled data sets to Amazon S3 for use across a variety of AWS analytics and machine learning services.</p><p>As a provider, you can create and manage your data sets that you would like to publish to a product. Being able to package and provide your data sets into products requires a few steps to determine eligibility. For more information, visit the AWS Data Exchange User Guide.</p><p>A data set is a collection of data that can be changed or updated over time. Data sets can be updated using revisions, which represent a new version or incremental change to a data set.  A revision contains one or more assets. An asset in AWS Data Exchange is a piece of data that can be stored as an Amazon S3 object. The asset can be a structured data file, an image file, or some other data file. Jobs are asynchronous import or export operations used to create or copy assets.</p>
@@ -248,6 +256,9 @@ export class DataExchangeClient extends __Client<
   ServiceOutputTypes,
   DataExchangeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DataExchangeClient class. This is resolved and normalized from the {@link DataExchangeClientConfig | constructor configuration interface}.
+   */
   readonly config: DataExchangeClientResolvedConfig;
 
   constructor(configuration: DataExchangeClientConfig) {

--- a/clients/client-datasync/DataSyncClient.ts
+++ b/clients/client-datasync/DataSyncClient.ts
@@ -278,7 +278,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DataSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DataSyncClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -286,8 +286,12 @@ export type DataSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DataSyncClient class constructor that set the region, credentials and other options.
+ */
+export interface DataSyncClientConfig extends DataSyncClientConfigType {}
 
-export type DataSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DataSyncClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -295,6 +299,10 @@ export type DataSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DataSyncClient class. This is resolved and normalized from the {@link DataSyncClientConfig | constructor configuration interface}.
+ */
+export interface DataSyncClientResolvedConfig extends DataSyncClientResolvedConfigType {}
 
 /**
  * <fullname>AWS DataSync</fullname>
@@ -311,6 +319,9 @@ export class DataSyncClient extends __Client<
   ServiceOutputTypes,
   DataSyncClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DataSyncClient class. This is resolved and normalized from the {@link DataSyncClientConfig | constructor configuration interface}.
+   */
   readonly config: DataSyncClientResolvedConfig;
 
   constructor(configuration: DataSyncClientConfig) {

--- a/clients/client-dax/DAXClient.ts
+++ b/clients/client-dax/DAXClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DAXClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DAXClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -244,8 +244,12 @@ export type DAXClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DAXClient class constructor that set the region, credentials and other options.
+ */
+export interface DAXClientConfig extends DAXClientConfigType {}
 
-export type DAXClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DAXClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -253,6 +257,10 @@ export type DAXClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DAXClient class. This is resolved and normalized from the {@link DAXClientConfig | constructor configuration interface}.
+ */
+export interface DAXClientResolvedConfig extends DAXClientResolvedConfigType {}
 
 /**
  * <p>DAX is a managed caching service engineered for Amazon DynamoDB. DAX
@@ -268,6 +276,9 @@ export class DAXClient extends __Client<
   ServiceOutputTypes,
   DAXClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DAXClient class. This is resolved and normalized from the {@link DAXClientConfig | constructor configuration interface}.
+   */
   readonly config: DAXClientResolvedConfig;
 
   constructor(configuration: DAXClientConfig) {

--- a/clients/client-detective/DetectiveClient.ts
+++ b/clients/client-detective/DetectiveClient.ts
@@ -191,7 +191,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DetectiveClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DetectiveClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -199,8 +199,12 @@ export type DetectiveClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DetectiveClient class constructor that set the region, credentials and other options.
+ */
+export interface DetectiveClientConfig extends DetectiveClientConfigType {}
 
-export type DetectiveClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DetectiveClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -208,6 +212,10 @@ export type DetectiveClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DetectiveClient class. This is resolved and normalized from the {@link DetectiveClientConfig | constructor configuration interface}.
+ */
+export interface DetectiveClientResolvedConfig extends DetectiveClientResolvedConfigType {}
 
 /**
  * <p>Detective uses machine learning and purpose-built visualizations to help you analyze and
@@ -258,6 +266,9 @@ export class DetectiveClient extends __Client<
   ServiceOutputTypes,
   DetectiveClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DetectiveClient class. This is resolved and normalized from the {@link DetectiveClientConfig | constructor configuration interface}.
+   */
   readonly config: DetectiveClientResolvedConfig;
 
   constructor(configuration: DetectiveClientConfig) {

--- a/clients/client-device-farm/DeviceFarmClient.ts
+++ b/clients/client-device-farm/DeviceFarmClient.ts
@@ -476,7 +476,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DeviceFarmClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DeviceFarmClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -484,8 +484,12 @@ export type DeviceFarmClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DeviceFarmClient class constructor that set the region, credentials and other options.
+ */
+export interface DeviceFarmClientConfig extends DeviceFarmClientConfigType {}
 
-export type DeviceFarmClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DeviceFarmClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -493,6 +497,10 @@ export type DeviceFarmClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DeviceFarmClient class. This is resolved and normalized from the {@link DeviceFarmClientConfig | constructor configuration interface}.
+ */
+export interface DeviceFarmClientResolvedConfig extends DeviceFarmClientResolvedConfigType {}
 
 /**
  * <p>Welcome to the AWS Device Farm API documentation, which contains APIs for:</p>
@@ -517,6 +525,9 @@ export class DeviceFarmClient extends __Client<
   ServiceOutputTypes,
   DeviceFarmClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DeviceFarmClient class. This is resolved and normalized from the {@link DeviceFarmClientConfig | constructor configuration interface}.
+   */
   readonly config: DeviceFarmClientResolvedConfig;
 
   constructor(configuration: DeviceFarmClientConfig) {

--- a/clients/client-devops-guru/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/DevOpsGuruClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DevOpsGuruClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DevOpsGuruClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -253,8 +253,12 @@ export type DevOpsGuruClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DevOpsGuruClient class constructor that set the region, credentials and other options.
+ */
+export interface DevOpsGuruClientConfig extends DevOpsGuruClientConfigType {}
 
-export type DevOpsGuruClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DevOpsGuruClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -262,6 +266,10 @@ export type DevOpsGuruClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DevOpsGuruClient class. This is resolved and normalized from the {@link DevOpsGuruClientConfig | constructor configuration interface}.
+ */
+export interface DevOpsGuruClientResolvedConfig extends DevOpsGuruClientResolvedConfigType {}
 
 export class DevOpsGuruClient extends __Client<
   __HttpHandlerOptions,
@@ -269,6 +277,9 @@ export class DevOpsGuruClient extends __Client<
   ServiceOutputTypes,
   DevOpsGuruClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DevOpsGuruClient class. This is resolved and normalized from the {@link DevOpsGuruClientConfig | constructor configuration interface}.
+   */
   readonly config: DevOpsGuruClientResolvedConfig;
 
   constructor(configuration: DevOpsGuruClientConfig) {

--- a/clients/client-direct-connect/DirectConnectClient.ts
+++ b/clients/client-direct-connect/DirectConnectClient.ts
@@ -437,7 +437,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DirectConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DirectConnectClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -445,8 +445,12 @@ export type DirectConnectClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DirectConnectClient class constructor that set the region, credentials and other options.
+ */
+export interface DirectConnectClientConfig extends DirectConnectClientConfigType {}
 
-export type DirectConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DirectConnectClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -454,6 +458,10 @@ export type DirectConnectClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DirectConnectClient class. This is resolved and normalized from the {@link DirectConnectClientConfig | constructor configuration interface}.
+ */
+export interface DirectConnectClientResolvedConfig extends DirectConnectClientResolvedConfigType {}
 
 /**
  * <p>AWS Direct Connect links your internal network to an AWS Direct Connect location over a standard Ethernet fiber-optic cable.
@@ -469,6 +477,9 @@ export class DirectConnectClient extends __Client<
   ServiceOutputTypes,
   DirectConnectClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DirectConnectClient class. This is resolved and normalized from the {@link DirectConnectClientConfig | constructor configuration interface}.
+   */
   readonly config: DirectConnectClientResolvedConfig;
 
   constructor(configuration: DirectConnectClientConfig) {

--- a/clients/client-directory-service/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/DirectoryServiceClient.ts
@@ -416,7 +416,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DirectoryServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DirectoryServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -424,8 +424,12 @@ export type DirectoryServiceClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DirectoryServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface DirectoryServiceClientConfig extends DirectoryServiceClientConfigType {}
 
-export type DirectoryServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DirectoryServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -433,6 +437,10 @@ export type DirectoryServiceClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DirectoryServiceClient class. This is resolved and normalized from the {@link DirectoryServiceClientConfig | constructor configuration interface}.
+ */
+export interface DirectoryServiceClientResolvedConfig extends DirectoryServiceClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Directory Service</fullname>
@@ -448,6 +456,9 @@ export class DirectoryServiceClient extends __Client<
   ServiceOutputTypes,
   DirectoryServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DirectoryServiceClient class. This is resolved and normalized from the {@link DirectoryServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: DirectoryServiceClientResolvedConfig;
 
   constructor(configuration: DirectoryServiceClientConfig) {

--- a/clients/client-dlm/DLMClient.ts
+++ b/clients/client-dlm/DLMClient.ts
@@ -188,7 +188,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DLMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DLMClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -196,8 +196,12 @@ export type DLMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DLMClient class constructor that set the region, credentials and other options.
+ */
+export interface DLMClientConfig extends DLMClientConfigType {}
 
-export type DLMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DLMClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -205,6 +209,10 @@ export type DLMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DLMClient class. This is resolved and normalized from the {@link DLMClientConfig | constructor configuration interface}.
+ */
+export interface DLMClientResolvedConfig extends DLMClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Data Lifecycle Manager</fullname> <p>With Amazon Data Lifecycle Manager, you can manage the lifecycle of your AWS resources. You create lifecycle policies, which are used to automate operations on the specified resources.</p> <p>Amazon DLM supports Amazon EBS volumes and snapshots. For information about using Amazon DLM with Amazon EBS, see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html">Automating the Amazon EBS Snapshot Lifecycle</a> in the <i>Amazon EC2 User Guide</i>.</p>
@@ -215,6 +223,9 @@ export class DLMClient extends __Client<
   ServiceOutputTypes,
   DLMClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DLMClient class. This is resolved and normalized from the {@link DLMClientConfig | constructor configuration interface}.
+   */
   readonly config: DLMClientResolvedConfig;
 
   constructor(configuration: DLMClientConfig) {

--- a/clients/client-docdb/DocDBClient.ts
+++ b/clients/client-docdb/DocDBClient.ts
@@ -362,7 +362,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DocDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DocDBClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -370,8 +370,12 @@ export type DocDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DocDBClient class constructor that set the region, credentials and other options.
+ */
+export interface DocDBClientConfig extends DocDBClientConfigType {}
 
-export type DocDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DocDBClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -379,6 +383,10 @@ export type DocDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DocDBClient class. This is resolved and normalized from the {@link DocDBClientConfig | constructor configuration interface}.
+ */
+export interface DocDBClientResolvedConfig extends DocDBClientResolvedConfigType {}
 
 /**
  * <p>Amazon DocumentDB API documentation</p>
@@ -389,6 +397,9 @@ export class DocDBClient extends __Client<
   ServiceOutputTypes,
   DocDBClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DocDBClient class. This is resolved and normalized from the {@link DocDBClientConfig | constructor configuration interface}.
+   */
   readonly config: DocDBClientResolvedConfig;
 
   constructor(configuration: DocDBClientConfig) {

--- a/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
@@ -161,7 +161,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DynamoDBStreamsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DynamoDBStreamsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -169,8 +169,12 @@ export type DynamoDBStreamsClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DynamoDBStreamsClient class constructor that set the region, credentials and other options.
+ */
+export interface DynamoDBStreamsClientConfig extends DynamoDBStreamsClientConfigType {}
 
-export type DynamoDBStreamsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DynamoDBStreamsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -178,6 +182,10 @@ export type DynamoDBStreamsClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DynamoDBStreamsClient class. This is resolved and normalized from the {@link DynamoDBStreamsClientConfig | constructor configuration interface}.
+ */
+export interface DynamoDBStreamsClientResolvedConfig extends DynamoDBStreamsClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon DynamoDB</fullname>
@@ -193,6 +201,9 @@ export class DynamoDBStreamsClient extends __Client<
   ServiceOutputTypes,
   DynamoDBStreamsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DynamoDBStreamsClient class. This is resolved and normalized from the {@link DynamoDBStreamsClientConfig | constructor configuration interface}.
+   */
   readonly config: DynamoDBStreamsClientResolvedConfig;
 
   constructor(configuration: DynamoDBStreamsClientConfig) {

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -350,7 +350,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type DynamoDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type DynamoDBClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -358,8 +358,12 @@ export type DynamoDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of DynamoDBClient class constructor that set the region, credentials and other options.
+ */
+export interface DynamoDBClientConfig extends DynamoDBClientConfigType {}
 
-export type DynamoDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type DynamoDBClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -367,6 +371,10 @@ export type DynamoDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of DynamoDBClient class. This is resolved and normalized from the {@link DynamoDBClientConfig | constructor configuration interface}.
+ */
+export interface DynamoDBClientResolvedConfig extends DynamoDBClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon DynamoDB</fullname>
@@ -395,6 +403,9 @@ export class DynamoDBClient extends __Client<
   ServiceOutputTypes,
   DynamoDBClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of DynamoDBClient class. This is resolved and normalized from the {@link DynamoDBClientConfig | constructor configuration interface}.
+   */
   readonly config: DynamoDBClientResolvedConfig;
 
   constructor(configuration: DynamoDBClientConfig) {

--- a/clients/client-ebs/EBSClient.ts
+++ b/clients/client-ebs/EBSClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EBSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EBSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -175,8 +175,12 @@ export type EBSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EBSClient class constructor that set the region, credentials and other options.
+ */
+export interface EBSClientConfig extends EBSClientConfigType {}
 
-export type EBSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EBSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -184,6 +188,10 @@ export type EBSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EBSClient class. This is resolved and normalized from the {@link EBSClientConfig | constructor configuration interface}.
+ */
+export interface EBSClientResolvedConfig extends EBSClientResolvedConfigType {}
 
 /**
  * <p>You can use the Amazon Elastic Block Store (Amazon EBS) direct APIs to create EBS snapshots, write data directly to
@@ -213,6 +221,9 @@ export class EBSClient extends __Client<
   ServiceOutputTypes,
   EBSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EBSClient class. This is resolved and normalized from the {@link EBSClientConfig | constructor configuration interface}.
+   */
   readonly config: EBSClientResolvedConfig;
 
   constructor(configuration: EBSClientConfig) {

--- a/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
@@ -150,7 +150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EC2InstanceConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EC2InstanceConnectClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -158,8 +158,12 @@ export type EC2InstanceConnectClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EC2InstanceConnectClient class constructor that set the region, credentials and other options.
+ */
+export interface EC2InstanceConnectClientConfig extends EC2InstanceConnectClientConfigType {}
 
-export type EC2InstanceConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EC2InstanceConnectClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -167,6 +171,10 @@ export type EC2InstanceConnectClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EC2InstanceConnectClient class. This is resolved and normalized from the {@link EC2InstanceConnectClientConfig | constructor configuration interface}.
+ */
+export interface EC2InstanceConnectClientResolvedConfig extends EC2InstanceConnectClientResolvedConfigType {}
 
 /**
  * <p>AWS EC2 Connect Service is a service that enables system administrators to publish
@@ -179,6 +187,9 @@ export class EC2InstanceConnectClient extends __Client<
   ServiceOutputTypes,
   EC2InstanceConnectClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EC2InstanceConnectClient class. This is resolved and normalized from the {@link EC2InstanceConnectClientConfig | constructor configuration interface}.
+   */
   readonly config: EC2InstanceConnectClientResolvedConfig;
 
   constructor(configuration: EC2InstanceConnectClientConfig) {

--- a/clients/client-ec2/EC2Client.ts
+++ b/clients/client-ec2/EC2Client.ts
@@ -2468,7 +2468,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EC2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EC2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -2476,8 +2476,12 @@ export type EC2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EC2Client class constructor that set the region, credentials and other options.
+ */
+export interface EC2ClientConfig extends EC2ClientConfigType {}
 
-export type EC2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EC2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -2485,6 +2489,10 @@ export type EC2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EC2Client class. This is resolved and normalized from the {@link EC2ClientConfig | constructor configuration interface}.
+ */
+export interface EC2ClientResolvedConfig extends EC2ClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Elastic Compute Cloud</fullname>
@@ -2517,6 +2525,9 @@ export class EC2Client extends __Client<
   ServiceOutputTypes,
   EC2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EC2Client class. This is resolved and normalized from the {@link EC2ClientConfig | constructor configuration interface}.
+   */
   readonly config: EC2ClientResolvedConfig;
 
   constructor(configuration: EC2ClientConfig) {

--- a/clients/client-ecr-public/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/ECRPUBLICClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ECRPUBLICClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ECRPUBLICClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -253,8 +253,12 @@ export type ECRPUBLICClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ECRPUBLICClient class constructor that set the region, credentials and other options.
+ */
+export interface ECRPUBLICClientConfig extends ECRPUBLICClientConfigType {}
 
-export type ECRPUBLICClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ECRPUBLICClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -262,6 +266,10 @@ export type ECRPUBLICClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ECRPUBLICClient class. This is resolved and normalized from the {@link ECRPUBLICClientConfig | constructor configuration interface}.
+ */
+export interface ECRPUBLICClientResolvedConfig extends ECRPUBLICClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Elastic Container Registry Public</fullname>
@@ -278,6 +286,9 @@ export class ECRPUBLICClient extends __Client<
   ServiceOutputTypes,
   ECRPUBLICClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ECRPUBLICClient class. This is resolved and normalized from the {@link ECRPUBLICClientConfig | constructor configuration interface}.
+   */
   readonly config: ECRPUBLICClientResolvedConfig;
 
   constructor(configuration: ECRPUBLICClientConfig) {

--- a/clients/client-ecr/ECRClient.ts
+++ b/clients/client-ecr/ECRClient.ts
@@ -305,7 +305,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ECRClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ECRClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -313,8 +313,12 @@ export type ECRClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ECRClient class constructor that set the region, credentials and other options.
+ */
+export interface ECRClientConfig extends ECRClientConfigType {}
 
-export type ECRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ECRClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -322,6 +326,10 @@ export type ECRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ECRClient class. This is resolved and normalized from the {@link ECRClientConfig | constructor configuration interface}.
+ */
+export interface ECRClientResolvedConfig extends ECRClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Elastic Container Registry</fullname>
@@ -338,6 +346,9 @@ export class ECRClient extends __Client<
   ServiceOutputTypes,
   ECRClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ECRClient class. This is resolved and normalized from the {@link ECRClientConfig | constructor configuration interface}.
+   */
   readonly config: ECRClientResolvedConfig;
 
   constructor(configuration: ECRClientConfig) {

--- a/clients/client-ecs/ECSClient.ts
+++ b/clients/client-ecs/ECSClient.ts
@@ -377,7 +377,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ECSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ECSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -385,8 +385,12 @@ export type ECSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ECSClient class constructor that set the region, credentials and other options.
+ */
+export interface ECSClientConfig extends ECSClientConfigType {}
 
-export type ECSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ECSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -394,6 +398,10 @@ export type ECSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ECSClient class. This is resolved and normalized from the {@link ECSClientConfig | constructor configuration interface}.
+ */
+export interface ECSClientResolvedConfig extends ECSClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Elastic Container Service</fullname>
@@ -418,6 +426,9 @@ export class ECSClient extends __Client<
   ServiceOutputTypes,
   ECSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ECSClient class. This is resolved and normalized from the {@link ECSClientConfig | constructor configuration interface}.
+   */
   readonly config: ECSClientResolvedConfig;
 
   constructor(configuration: ECSClientConfig) {

--- a/clients/client-efs/EFSClient.ts
+++ b/clients/client-efs/EFSClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EFSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EFSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -268,8 +268,12 @@ export type EFSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EFSClient class constructor that set the region, credentials and other options.
+ */
+export interface EFSClientConfig extends EFSClientConfigType {}
 
-export type EFSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EFSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -277,6 +281,10 @@ export type EFSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EFSClient class. This is resolved and normalized from the {@link EFSClientConfig | constructor configuration interface}.
+ */
+export interface EFSClientResolvedConfig extends EFSClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Elastic File System</fullname>
@@ -291,6 +299,9 @@ export class EFSClient extends __Client<
   ServiceOutputTypes,
   EFSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EFSClient class. This is resolved and normalized from the {@link EFSClientConfig | constructor configuration interface}.
+   */
   readonly config: EFSClientResolvedConfig;
 
   constructor(configuration: EFSClientConfig) {

--- a/clients/client-eks/EKSClient.ts
+++ b/clients/client-eks/EKSClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EKSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EKSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -268,8 +268,12 @@ export type EKSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EKSClient class constructor that set the region, credentials and other options.
+ */
+export interface EKSClientConfig extends EKSClientConfigType {}
 
-export type EKSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EKSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -277,6 +281,10 @@ export type EKSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EKSClient class. This is resolved and normalized from the {@link EKSClientConfig | constructor configuration interface}.
+ */
+export interface EKSClientResolvedConfig extends EKSClientResolvedConfigType {}
 
 /**
  * <p>Amazon Elastic Kubernetes Service (Amazon EKS) is a managed service that makes it easy for you to run Kubernetes on
@@ -296,6 +304,9 @@ export class EKSClient extends __Client<
   ServiceOutputTypes,
   EKSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EKSClient class. This is resolved and normalized from the {@link EKSClientConfig | constructor configuration interface}.
+   */
   readonly config: EKSClientResolvedConfig;
 
   constructor(configuration: EKSClientConfig) {

--- a/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
@@ -407,7 +407,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ElasticBeanstalkClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ElasticBeanstalkClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -415,8 +415,12 @@ export type ElasticBeanstalkClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ElasticBeanstalkClient class constructor that set the region, credentials and other options.
+ */
+export interface ElasticBeanstalkClientConfig extends ElasticBeanstalkClientConfigType {}
 
-export type ElasticBeanstalkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ElasticBeanstalkClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -424,6 +428,10 @@ export type ElasticBeanstalkClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ElasticBeanstalkClient class. This is resolved and normalized from the {@link ElasticBeanstalkClientConfig | constructor configuration interface}.
+ */
+export interface ElasticBeanstalkClientResolvedConfig extends ElasticBeanstalkClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Elastic Beanstalk</fullname>
@@ -448,6 +456,9 @@ export class ElasticBeanstalkClient extends __Client<
   ServiceOutputTypes,
   ElasticBeanstalkClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ElasticBeanstalkClient class. This is resolved and normalized from the {@link ElasticBeanstalkClientConfig | constructor configuration interface}.
+   */
   readonly config: ElasticBeanstalkClientResolvedConfig;
 
   constructor(configuration: ElasticBeanstalkClientConfig) {

--- a/clients/client-elastic-inference/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/ElasticInferenceClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ElasticInferenceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ElasticInferenceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -187,8 +187,12 @@ export type ElasticInferenceClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ElasticInferenceClient class constructor that set the region, credentials and other options.
+ */
+export interface ElasticInferenceClientConfig extends ElasticInferenceClientConfigType {}
 
-export type ElasticInferenceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ElasticInferenceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -196,6 +200,10 @@ export type ElasticInferenceClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ElasticInferenceClient class. This is resolved and normalized from the {@link ElasticInferenceClientConfig | constructor configuration interface}.
+ */
+export interface ElasticInferenceClientResolvedConfig extends ElasticInferenceClientResolvedConfigType {}
 
 /**
  * <p>
@@ -208,6 +216,9 @@ export class ElasticInferenceClient extends __Client<
   ServiceOutputTypes,
   ElasticInferenceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ElasticInferenceClient class. This is resolved and normalized from the {@link ElasticInferenceClientConfig | constructor configuration interface}.
+   */
   readonly config: ElasticInferenceClientResolvedConfig;
 
   constructor(configuration: ElasticInferenceClientConfig) {

--- a/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
@@ -287,7 +287,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ElasticLoadBalancingV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ElasticLoadBalancingV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -295,8 +295,12 @@ export type ElasticLoadBalancingV2ClientConfig = Partial<__SmithyConfiguration<_
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ElasticLoadBalancingV2Client class constructor that set the region, credentials and other options.
+ */
+export interface ElasticLoadBalancingV2ClientConfig extends ElasticLoadBalancingV2ClientConfigType {}
 
-export type ElasticLoadBalancingV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ElasticLoadBalancingV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -304,6 +308,10 @@ export type ElasticLoadBalancingV2ClientResolvedConfig = __SmithyResolvedConfigu
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ElasticLoadBalancingV2Client class. This is resolved and normalized from the {@link ElasticLoadBalancingV2ClientConfig | constructor configuration interface}.
+ */
+export interface ElasticLoadBalancingV2ClientResolvedConfig extends ElasticLoadBalancingV2ClientResolvedConfigType {}
 
 /**
  * <fullname>Elastic Load Balancing</fullname>
@@ -349,6 +357,9 @@ export class ElasticLoadBalancingV2Client extends __Client<
   ServiceOutputTypes,
   ElasticLoadBalancingV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ElasticLoadBalancingV2Client class. This is resolved and normalized from the {@link ElasticLoadBalancingV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: ElasticLoadBalancingV2ClientResolvedConfig;
 
   constructor(configuration: ElasticLoadBalancingV2ClientConfig) {

--- a/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
@@ -308,7 +308,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ElasticLoadBalancingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ElasticLoadBalancingClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -316,8 +316,12 @@ export type ElasticLoadBalancingClientConfig = Partial<__SmithyConfiguration<__H
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ElasticLoadBalancingClient class constructor that set the region, credentials and other options.
+ */
+export interface ElasticLoadBalancingClientConfig extends ElasticLoadBalancingClientConfigType {}
 
-export type ElasticLoadBalancingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ElasticLoadBalancingClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -325,6 +329,10 @@ export type ElasticLoadBalancingClientResolvedConfig = __SmithyResolvedConfigura
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ElasticLoadBalancingClient class. This is resolved and normalized from the {@link ElasticLoadBalancingClientConfig | constructor configuration interface}.
+ */
+export interface ElasticLoadBalancingClientResolvedConfig extends ElasticLoadBalancingClientResolvedConfigType {}
 
 /**
  * <fullname>Elastic Load Balancing</fullname>
@@ -355,6 +363,9 @@ export class ElasticLoadBalancingClient extends __Client<
   ServiceOutputTypes,
   ElasticLoadBalancingClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ElasticLoadBalancingClient class. This is resolved and normalized from the {@link ElasticLoadBalancingClientConfig | constructor configuration interface}.
+   */
   readonly config: ElasticLoadBalancingClientResolvedConfig;
 
   constructor(configuration: ElasticLoadBalancingClientConfig) {

--- a/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
@@ -206,7 +206,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ElasticTranscoderClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ElasticTranscoderClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -214,8 +214,12 @@ export type ElasticTranscoderClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ElasticTranscoderClient class constructor that set the region, credentials and other options.
+ */
+export interface ElasticTranscoderClientConfig extends ElasticTranscoderClientConfigType {}
 
-export type ElasticTranscoderClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ElasticTranscoderClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -223,6 +227,10 @@ export type ElasticTranscoderClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ElasticTranscoderClient class. This is resolved and normalized from the {@link ElasticTranscoderClientConfig | constructor configuration interface}.
+ */
+export interface ElasticTranscoderClientResolvedConfig extends ElasticTranscoderClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Elastic Transcoder Service</fullname>
@@ -234,6 +242,9 @@ export class ElasticTranscoderClient extends __Client<
   ServiceOutputTypes,
   ElasticTranscoderClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ElasticTranscoderClient class. This is resolved and normalized from the {@link ElasticTranscoderClientConfig | constructor configuration interface}.
+   */
   readonly config: ElasticTranscoderClientResolvedConfig;
 
   constructor(configuration: ElasticTranscoderClientConfig) {

--- a/clients/client-elasticache/ElastiCacheClient.ts
+++ b/clients/client-elasticache/ElastiCacheClient.ts
@@ -476,7 +476,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ElastiCacheClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ElastiCacheClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -484,8 +484,12 @@ export type ElastiCacheClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ElastiCacheClient class constructor that set the region, credentials and other options.
+ */
+export interface ElastiCacheClientConfig extends ElastiCacheClientConfigType {}
 
-export type ElastiCacheClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ElastiCacheClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -493,6 +497,10 @@ export type ElastiCacheClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ElastiCacheClient class. This is resolved and normalized from the {@link ElastiCacheClientConfig | constructor configuration interface}.
+ */
+export interface ElastiCacheClientResolvedConfig extends ElastiCacheClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon ElastiCache</fullname>
@@ -512,6 +520,9 @@ export class ElastiCacheClient extends __Client<
   ServiceOutputTypes,
   ElastiCacheClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ElastiCacheClient class. This is resolved and normalized from the {@link ElastiCacheClientConfig | constructor configuration interface}.
+   */
   readonly config: ElastiCacheClientResolvedConfig;
 
   constructor(configuration: ElastiCacheClientConfig) {

--- a/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
@@ -347,7 +347,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ElasticsearchServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ElasticsearchServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -355,8 +355,12 @@ export type ElasticsearchServiceClientConfig = Partial<__SmithyConfiguration<__H
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ElasticsearchServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface ElasticsearchServiceClientConfig extends ElasticsearchServiceClientConfigType {}
 
-export type ElasticsearchServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ElasticsearchServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -364,6 +368,10 @@ export type ElasticsearchServiceClientResolvedConfig = __SmithyResolvedConfigura
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ElasticsearchServiceClient class. This is resolved and normalized from the {@link ElasticsearchServiceClientConfig | constructor configuration interface}.
+ */
+export interface ElasticsearchServiceClientResolvedConfig extends ElasticsearchServiceClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Elasticsearch Configuration Service</fullname>
@@ -380,6 +388,9 @@ export class ElasticsearchServiceClient extends __Client<
   ServiceOutputTypes,
   ElasticsearchServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ElasticsearchServiceClient class. This is resolved and normalized from the {@link ElasticsearchServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: ElasticsearchServiceClientResolvedConfig;
 
   constructor(configuration: ElasticsearchServiceClientConfig) {

--- a/clients/client-emr-containers/EMRContainersClient.ts
+++ b/clients/client-emr-containers/EMRContainersClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EMRContainersClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EMRContainersClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -229,8 +229,12 @@ export type EMRContainersClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EMRContainersClient class constructor that set the region, credentials and other options.
+ */
+export interface EMRContainersClientConfig extends EMRContainersClientConfigType {}
 
-export type EMRContainersClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EMRContainersClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -238,6 +242,10 @@ export type EMRContainersClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EMRContainersClient class. This is resolved and normalized from the {@link EMRContainersClientConfig | constructor configuration interface}.
+ */
+export interface EMRContainersClientResolvedConfig extends EMRContainersClientResolvedConfigType {}
 
 /**
  * <p>Amazon EMR on EKS provides a deployment option for Amazon EMR that allows you to run
@@ -269,6 +277,9 @@ export class EMRContainersClient extends __Client<
   ServiceOutputTypes,
   EMRContainersClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EMRContainersClient class. This is resolved and normalized from the {@link EMRContainersClientConfig | constructor configuration interface}.
+   */
   readonly config: EMRContainersClientResolvedConfig;
 
   constructor(configuration: EMRContainersClientConfig) {

--- a/clients/client-emr/EMRClient.ts
+++ b/clients/client-emr/EMRClient.ts
@@ -362,7 +362,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EMRClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EMRClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -370,8 +370,12 @@ export type EMRClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EMRClient class constructor that set the region, credentials and other options.
+ */
+export interface EMRClientConfig extends EMRClientConfigType {}
 
-export type EMRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EMRClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -379,6 +383,10 @@ export type EMRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EMRClient class. This is resolved and normalized from the {@link EMRClientConfig | constructor configuration interface}.
+ */
+export interface EMRClientResolvedConfig extends EMRClientResolvedConfigType {}
 
 /**
  * <p>Amazon EMR is a web service that makes it easier to process large amounts of data
@@ -392,6 +400,9 @@ export class EMRClient extends __Client<
   ServiceOutputTypes,
   EMRClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EMRClient class. This is resolved and normalized from the {@link EMRClientConfig | constructor configuration interface}.
+   */
   readonly config: EMRClientResolvedConfig;
 
   constructor(configuration: EMRClientConfig) {

--- a/clients/client-eventbridge/EventBridgeClient.ts
+++ b/clients/client-eventbridge/EventBridgeClient.ts
@@ -299,7 +299,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EventBridgeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EventBridgeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -307,8 +307,12 @@ export type EventBridgeClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EventBridgeClient class constructor that set the region, credentials and other options.
+ */
+export interface EventBridgeClientConfig extends EventBridgeClientConfigType {}
 
-export type EventBridgeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EventBridgeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -316,6 +320,10 @@ export type EventBridgeClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EventBridgeClient class. This is resolved and normalized from the {@link EventBridgeClientConfig | constructor configuration interface}.
+ */
+export interface EventBridgeClientResolvedConfig extends EventBridgeClientResolvedConfigType {}
 
 /**
  * <p>Amazon EventBridge helps you to respond to state changes in your AWS resources.
@@ -347,6 +355,9 @@ export class EventBridgeClient extends __Client<
   ServiceOutputTypes,
   EventBridgeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EventBridgeClient class. This is resolved and normalized from the {@link EventBridgeClientConfig | constructor configuration interface}.
+   */
   readonly config: EventBridgeClientResolvedConfig;
 
   constructor(configuration: EventBridgeClientConfig) {

--- a/clients/client-firehose/FirehoseClient.ts
+++ b/clients/client-firehose/FirehoseClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type FirehoseClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type FirehoseClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -217,8 +217,12 @@ export type FirehoseClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of FirehoseClient class constructor that set the region, credentials and other options.
+ */
+export interface FirehoseClientConfig extends FirehoseClientConfigType {}
 
-export type FirehoseClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type FirehoseClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -226,6 +230,10 @@ export type FirehoseClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of FirehoseClient class. This is resolved and normalized from the {@link FirehoseClientConfig | constructor configuration interface}.
+ */
+export interface FirehoseClientResolvedConfig extends FirehoseClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Kinesis Data Firehose API Reference</fullname>
@@ -239,6 +247,9 @@ export class FirehoseClient extends __Client<
   ServiceOutputTypes,
   FirehoseClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of FirehoseClient class. This is resolved and normalized from the {@link FirehoseClientConfig | constructor configuration interface}.
+   */
   readonly config: FirehoseClientResolvedConfig;
 
   constructor(configuration: FirehoseClientConfig) {

--- a/clients/client-fms/FMSClient.ts
+++ b/clients/client-fms/FMSClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type FMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type FMSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -268,8 +268,12 @@ export type FMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of FMSClient class constructor that set the region, credentials and other options.
+ */
+export interface FMSClientConfig extends FMSClientConfigType {}
 
-export type FMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type FMSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -277,6 +281,10 @@ export type FMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of FMSClient class. This is resolved and normalized from the {@link FMSClientConfig | constructor configuration interface}.
+ */
+export interface FMSClientResolvedConfig extends FMSClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Firewall Manager</fullname>
@@ -294,6 +302,9 @@ export class FMSClient extends __Client<
   ServiceOutputTypes,
   FMSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of FMSClient class. This is resolved and normalized from the {@link FMSClientConfig | constructor configuration interface}.
+   */
   readonly config: FMSClientResolvedConfig;
 
   constructor(configuration: FMSClientConfig) {

--- a/clients/client-forecast/ForecastClient.ts
+++ b/clients/client-forecast/ForecastClient.ts
@@ -290,7 +290,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ForecastClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ForecastClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -298,8 +298,12 @@ export type ForecastClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ForecastClient class constructor that set the region, credentials and other options.
+ */
+export interface ForecastClientConfig extends ForecastClientConfigType {}
 
-export type ForecastClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ForecastClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -307,6 +311,10 @@ export type ForecastClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ForecastClient class. This is resolved and normalized from the {@link ForecastClientConfig | constructor configuration interface}.
+ */
+export interface ForecastClientResolvedConfig extends ForecastClientResolvedConfigType {}
 
 /**
  * <p>Provides APIs for creating and managing Amazon Forecast resources.</p>
@@ -317,6 +325,9 @@ export class ForecastClient extends __Client<
   ServiceOutputTypes,
   ForecastClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ForecastClient class. This is resolved and normalized from the {@link ForecastClientConfig | constructor configuration interface}.
+   */
   readonly config: ForecastClientResolvedConfig;
 
   constructor(configuration: ForecastClientConfig) {

--- a/clients/client-forecastquery/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/ForecastqueryClient.ts
@@ -150,7 +150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ForecastqueryClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ForecastqueryClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -158,8 +158,12 @@ export type ForecastqueryClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ForecastqueryClient class constructor that set the region, credentials and other options.
+ */
+export interface ForecastqueryClientConfig extends ForecastqueryClientConfigType {}
 
-export type ForecastqueryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ForecastqueryClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -167,6 +171,10 @@ export type ForecastqueryClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ForecastqueryClient class. This is resolved and normalized from the {@link ForecastqueryClientConfig | constructor configuration interface}.
+ */
+export interface ForecastqueryClientResolvedConfig extends ForecastqueryClientResolvedConfigType {}
 
 /**
  * <p>Provides APIs for creating and managing Amazon Forecast resources.</p>
@@ -177,6 +185,9 @@ export class ForecastqueryClient extends __Client<
   ServiceOutputTypes,
   ForecastqueryClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ForecastqueryClient class. This is resolved and normalized from the {@link ForecastqueryClientConfig | constructor configuration interface}.
+   */
   readonly config: ForecastqueryClientResolvedConfig;
 
   constructor(configuration: ForecastqueryClientConfig) {

--- a/clients/client-frauddetector/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/FraudDetectorClient.ts
@@ -344,7 +344,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type FraudDetectorClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type FraudDetectorClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -352,8 +352,12 @@ export type FraudDetectorClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of FraudDetectorClient class constructor that set the region, credentials and other options.
+ */
+export interface FraudDetectorClientConfig extends FraudDetectorClientConfigType {}
 
-export type FraudDetectorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type FraudDetectorClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -361,6 +365,10 @@ export type FraudDetectorClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of FraudDetectorClient class. This is resolved and normalized from the {@link FraudDetectorClientConfig | constructor configuration interface}.
+ */
+export interface FraudDetectorClientResolvedConfig extends FraudDetectorClientResolvedConfigType {}
 
 /**
  * <p>This is the Amazon Fraud Detector API Reference. This guide is for developers who need
@@ -373,6 +381,9 @@ export class FraudDetectorClient extends __Client<
   ServiceOutputTypes,
   FraudDetectorClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of FraudDetectorClient class. This is resolved and normalized from the {@link FraudDetectorClientConfig | constructor configuration interface}.
+   */
   readonly config: FraudDetectorClientResolvedConfig;
 
   constructor(configuration: FraudDetectorClientConfig) {

--- a/clients/client-fsx/FSxClient.ts
+++ b/clients/client-fsx/FSxClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type FSxClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type FSxClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -235,8 +235,12 @@ export type FSxClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of FSxClient class constructor that set the region, credentials and other options.
+ */
+export interface FSxClientConfig extends FSxClientConfigType {}
 
-export type FSxClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type FSxClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -244,6 +248,10 @@ export type FSxClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of FSxClient class. This is resolved and normalized from the {@link FSxClientConfig | constructor configuration interface}.
+ */
+export interface FSxClientResolvedConfig extends FSxClientResolvedConfigType {}
 
 /**
  * <p>Amazon FSx is a fully managed service that makes it easy for storage and
@@ -255,6 +263,9 @@ export class FSxClient extends __Client<
   ServiceOutputTypes,
   FSxClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of FSxClient class. This is resolved and normalized from the {@link FSxClientConfig | constructor configuration interface}.
+   */
   readonly config: FSxClientResolvedConfig;
 
   constructor(configuration: FSxClientConfig) {

--- a/clients/client-gamelift/GameLiftClient.ts
+++ b/clients/client-gamelift/GameLiftClient.ts
@@ -575,7 +575,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GameLiftClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GameLiftClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -583,8 +583,12 @@ export type GameLiftClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GameLiftClient class constructor that set the region, credentials and other options.
+ */
+export interface GameLiftClientConfig extends GameLiftClientConfigType {}
 
-export type GameLiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GameLiftClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -592,6 +596,10 @@ export type GameLiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GameLiftClient class. This is resolved and normalized from the {@link GameLiftClientConfig | constructor configuration interface}.
+ */
+export interface GameLiftClientResolvedConfig extends GameLiftClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon GameLift Service</fullname>
@@ -652,6 +660,9 @@ export class GameLiftClient extends __Client<
   ServiceOutputTypes,
   GameLiftClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GameLiftClient class. This is resolved and normalized from the {@link GameLiftClientConfig | constructor configuration interface}.
+   */
   readonly config: GameLiftClientResolvedConfig;
 
   constructor(configuration: GameLiftClientConfig) {

--- a/clients/client-glacier/GlacierClient.ts
+++ b/clients/client-glacier/GlacierClient.ts
@@ -306,7 +306,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GlacierClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GlacierClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -314,8 +314,12 @@ export type GlacierClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GlacierClient class constructor that set the region, credentials and other options.
+ */
+export interface GlacierClientConfig extends GlacierClientConfigType {}
 
-export type GlacierClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GlacierClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -323,6 +327,10 @@ export type GlacierClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GlacierClient class. This is resolved and normalized from the {@link GlacierClientConfig | constructor configuration interface}.
+ */
+export interface GlacierClientResolvedConfig extends GlacierClientResolvedConfigType {}
 
 /**
  * <p> Amazon S3 Glacier (Glacier) is a storage solution for "cold data."</p>
@@ -370,6 +378,9 @@ export class GlacierClient extends __Client<
   ServiceOutputTypes,
   GlacierClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GlacierClient class. This is resolved and normalized from the {@link GlacierClientConfig | constructor configuration interface}.
+   */
   readonly config: GlacierClientResolvedConfig;
 
   constructor(configuration: GlacierClientConfig) {

--- a/clients/client-global-accelerator/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/GlobalAcceleratorClient.ts
@@ -383,7 +383,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GlobalAcceleratorClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GlobalAcceleratorClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -391,8 +391,12 @@ export type GlobalAcceleratorClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GlobalAcceleratorClient class constructor that set the region, credentials and other options.
+ */
+export interface GlobalAcceleratorClientConfig extends GlobalAcceleratorClientConfigType {}
 
-export type GlobalAcceleratorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GlobalAcceleratorClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -400,6 +404,10 @@ export type GlobalAcceleratorClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GlobalAcceleratorClient class. This is resolved and normalized from the {@link GlobalAcceleratorClientConfig | constructor configuration interface}.
+ */
+export interface GlobalAcceleratorClientResolvedConfig extends GlobalAcceleratorClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Global Accelerator</fullname>
@@ -557,6 +565,9 @@ export class GlobalAcceleratorClient extends __Client<
   ServiceOutputTypes,
   GlobalAcceleratorClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GlobalAcceleratorClient class. This is resolved and normalized from the {@link GlobalAcceleratorClientConfig | constructor configuration interface}.
+   */
   readonly config: GlobalAcceleratorClientResolvedConfig;
 
   constructor(configuration: GlobalAcceleratorClientConfig) {

--- a/clients/client-glue/GlueClient.ts
+++ b/clients/client-glue/GlueClient.ts
@@ -761,7 +761,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GlueClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GlueClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -769,8 +769,12 @@ export type GlueClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOption
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GlueClient class constructor that set the region, credentials and other options.
+ */
+export interface GlueClientConfig extends GlueClientConfigType {}
 
-export type GlueClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GlueClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -778,6 +782,10 @@ export type GlueClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandl
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GlueClient class. This is resolved and normalized from the {@link GlueClientConfig | constructor configuration interface}.
+ */
+export interface GlueClientResolvedConfig extends GlueClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Glue</fullname>
@@ -789,6 +797,9 @@ export class GlueClient extends __Client<
   ServiceOutputTypes,
   GlueClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GlueClient class. This is resolved and normalized from the {@link GlueClientConfig | constructor configuration interface}.
+   */
   readonly config: GlueClientResolvedConfig;
 
   constructor(configuration: GlueClientConfig) {

--- a/clients/client-greengrass/GreengrassClient.ts
+++ b/clients/client-greengrass/GreengrassClient.ts
@@ -653,7 +653,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GreengrassClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GreengrassClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -661,8 +661,12 @@ export type GreengrassClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GreengrassClient class constructor that set the region, credentials and other options.
+ */
+export interface GreengrassClientConfig extends GreengrassClientConfigType {}
 
-export type GreengrassClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GreengrassClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -670,6 +674,10 @@ export type GreengrassClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GreengrassClient class. This is resolved and normalized from the {@link GreengrassClientConfig | constructor configuration interface}.
+ */
+export interface GreengrassClientResolvedConfig extends GreengrassClientResolvedConfigType {}
 
 /**
  * AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act locally on the data they generate, while still using the cloud for management, analytics, and durable storage. AWS IoT Greengrass ensures your devices can respond quickly to local events and operate with intermittent connectivity. AWS IoT Greengrass minimizes the cost of transmitting data to the cloud by allowing you to author AWS Lambda functions that execute locally.
@@ -680,6 +688,9 @@ export class GreengrassClient extends __Client<
   ServiceOutputTypes,
   GreengrassClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GreengrassClient class. This is resolved and normalized from the {@link GreengrassClientConfig | constructor configuration interface}.
+   */
   readonly config: GreengrassClientResolvedConfig;
 
   constructor(configuration: GreengrassClientConfig) {

--- a/clients/client-groundstation/GroundStationClient.ts
+++ b/clients/client-groundstation/GroundStationClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GroundStationClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GroundStationClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -259,8 +259,12 @@ export type GroundStationClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GroundStationClient class constructor that set the region, credentials and other options.
+ */
+export interface GroundStationClientConfig extends GroundStationClientConfigType {}
 
-export type GroundStationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GroundStationClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -268,6 +272,10 @@ export type GroundStationClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GroundStationClient class. This is resolved and normalized from the {@link GroundStationClientConfig | constructor configuration interface}.
+ */
+export interface GroundStationClientResolvedConfig extends GroundStationClientResolvedConfigType {}
 
 /**
  * <p>Welcome to the AWS Ground Station API Reference. AWS Ground Station is a fully managed service that
@@ -281,6 +289,9 @@ export class GroundStationClient extends __Client<
   ServiceOutputTypes,
   GroundStationClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GroundStationClient class. This is resolved and normalized from the {@link GroundStationClientConfig | constructor configuration interface}.
+   */
   readonly config: GroundStationClientResolvedConfig;
 
   constructor(configuration: GroundStationClientConfig) {

--- a/clients/client-guardduty/GuardDutyClient.ts
+++ b/clients/client-guardduty/GuardDutyClient.ts
@@ -395,7 +395,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GuardDutyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GuardDutyClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -403,8 +403,12 @@ export type GuardDutyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GuardDutyClient class constructor that set the region, credentials and other options.
+ */
+export interface GuardDutyClientConfig extends GuardDutyClientConfigType {}
 
-export type GuardDutyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GuardDutyClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -412,6 +416,10 @@ export type GuardDutyClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GuardDutyClient class. This is resolved and normalized from the {@link GuardDutyClientConfig | constructor configuration interface}.
+ */
+export interface GuardDutyClientResolvedConfig extends GuardDutyClientResolvedConfigType {}
 
 /**
  * <p>Amazon GuardDuty is a continuous security monitoring service that analyzes and processes
@@ -438,6 +446,9 @@ export class GuardDutyClient extends __Client<
   ServiceOutputTypes,
   GuardDutyClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GuardDutyClient class. This is resolved and normalized from the {@link GuardDutyClientConfig | constructor configuration interface}.
+   */
   readonly config: GuardDutyClientResolvedConfig;
 
   constructor(configuration: GuardDutyClientConfig) {

--- a/clients/client-health/HealthClient.ts
+++ b/clients/client-health/HealthClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type HealthClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type HealthClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -229,8 +229,12 @@ export type HealthClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of HealthClient class constructor that set the region, credentials and other options.
+ */
+export interface HealthClientConfig extends HealthClientConfigType {}
 
-export type HealthClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type HealthClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -238,6 +242,10 @@ export type HealthClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of HealthClient class. This is resolved and normalized from the {@link HealthClientConfig | constructor configuration interface}.
+ */
+export interface HealthClientResolvedConfig extends HealthClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Health</fullname>
@@ -285,6 +293,9 @@ export class HealthClient extends __Client<
   ServiceOutputTypes,
   HealthClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of HealthClient class. This is resolved and normalized from the {@link HealthClientConfig | constructor configuration interface}.
+   */
   readonly config: HealthClientResolvedConfig;
 
   constructor(configuration: HealthClientConfig) {

--- a/clients/client-healthlake/HealthLakeClient.ts
+++ b/clients/client-healthlake/HealthLakeClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type HealthLakeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type HealthLakeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -187,8 +187,12 @@ export type HealthLakeClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of HealthLakeClient class constructor that set the region, credentials and other options.
+ */
+export interface HealthLakeClientConfig extends HealthLakeClientConfigType {}
 
-export type HealthLakeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type HealthLakeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -196,6 +200,10 @@ export type HealthLakeClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of HealthLakeClient class. This is resolved and normalized from the {@link HealthLakeClientConfig | constructor configuration interface}.
+ */
+export interface HealthLakeClientResolvedConfig extends HealthLakeClientResolvedConfigType {}
 
 /**
  * <p>Amazon HealthLake is a HIPAA eligibile service that allows customers to store,
@@ -207,6 +215,9 @@ export class HealthLakeClient extends __Client<
   ServiceOutputTypes,
   HealthLakeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of HealthLakeClient class. This is resolved and normalized from the {@link HealthLakeClientConfig | constructor configuration interface}.
+   */
   readonly config: HealthLakeClientResolvedConfig;
 
   constructor(configuration: HealthLakeClientConfig) {

--- a/clients/client-honeycode/HoneycodeClient.ts
+++ b/clients/client-honeycode/HoneycodeClient.ts
@@ -206,7 +206,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type HoneycodeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type HoneycodeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -214,8 +214,12 @@ export type HoneycodeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of HoneycodeClient class constructor that set the region, credentials and other options.
+ */
+export interface HoneycodeClientConfig extends HoneycodeClientConfigType {}
 
-export type HoneycodeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type HoneycodeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -223,6 +227,10 @@ export type HoneycodeClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of HoneycodeClient class. This is resolved and normalized from the {@link HoneycodeClientConfig | constructor configuration interface}.
+ */
+export interface HoneycodeClientResolvedConfig extends HoneycodeClientResolvedConfigType {}
 
 /**
  * <p>
@@ -237,6 +245,9 @@ export class HoneycodeClient extends __Client<
   ServiceOutputTypes,
   HoneycodeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of HoneycodeClient class. This is resolved and normalized from the {@link HoneycodeClientConfig | constructor configuration interface}.
+   */
   readonly config: HoneycodeClientResolvedConfig;
 
   constructor(configuration: HoneycodeClientConfig) {

--- a/clients/client-iam/IAMClient.ts
+++ b/clients/client-iam/IAMClient.ts
@@ -767,7 +767,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IAMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IAMClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -775,8 +775,12 @@ export type IAMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IAMClient class constructor that set the region, credentials and other options.
+ */
+export interface IAMClientConfig extends IAMClientConfigType {}
 
-export type IAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IAMClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -784,6 +788,10 @@ export type IAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IAMClient class. This is resolved and normalized from the {@link IAMClientConfig | constructor configuration interface}.
+ */
+export interface IAMClientResolvedConfig extends IAMClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Identity and Access Management</fullname>
@@ -798,6 +806,9 @@ export class IAMClient extends __Client<
   ServiceOutputTypes,
   IAMClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IAMClient class. This is resolved and normalized from the {@link IAMClientConfig | constructor configuration interface}.
+   */
   readonly config: IAMClientResolvedConfig;
 
   constructor(configuration: IAMClientConfig) {

--- a/clients/client-identitystore/IdentitystoreClient.ts
+++ b/clients/client-identitystore/IdentitystoreClient.ts
@@ -161,7 +161,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IdentitystoreClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IdentitystoreClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -169,8 +169,12 @@ export type IdentitystoreClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IdentitystoreClient class constructor that set the region, credentials and other options.
+ */
+export interface IdentitystoreClientConfig extends IdentitystoreClientConfigType {}
 
-export type IdentitystoreClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IdentitystoreClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -178,6 +182,10 @@ export type IdentitystoreClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IdentitystoreClient class. This is resolved and normalized from the {@link IdentitystoreClientConfig | constructor configuration interface}.
+ */
+export interface IdentitystoreClientResolvedConfig extends IdentitystoreClientResolvedConfigType {}
 
 export class IdentitystoreClient extends __Client<
   __HttpHandlerOptions,
@@ -185,6 +193,9 @@ export class IdentitystoreClient extends __Client<
   ServiceOutputTypes,
   IdentitystoreClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IdentitystoreClient class. This is resolved and normalized from the {@link IdentitystoreClientConfig | constructor configuration interface}.
+   */
   readonly config: IdentitystoreClientResolvedConfig;
 
   constructor(configuration: IdentitystoreClientConfig) {

--- a/clients/client-imagebuilder/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/ImagebuilderClient.ts
@@ -338,7 +338,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ImagebuilderClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ImagebuilderClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -346,8 +346,12 @@ export type ImagebuilderClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ImagebuilderClient class constructor that set the region, credentials and other options.
+ */
+export interface ImagebuilderClientConfig extends ImagebuilderClientConfigType {}
 
-export type ImagebuilderClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ImagebuilderClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -355,6 +359,10 @@ export type ImagebuilderClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ImagebuilderClient class. This is resolved and normalized from the {@link ImagebuilderClientConfig | constructor configuration interface}.
+ */
+export interface ImagebuilderClientResolvedConfig extends ImagebuilderClientResolvedConfigType {}
 
 /**
  * <p>EC2 Image Builder is a fully managed AWS service that makes it easier to automate the creation, management, and deployment of customized, secure, and up-to-date “golden” server images that are pre-installed and pre-configured with software and settings to meet specific IT standards.</p>
@@ -365,6 +373,9 @@ export class ImagebuilderClient extends __Client<
   ServiceOutputTypes,
   ImagebuilderClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ImagebuilderClient class. This is resolved and normalized from the {@link ImagebuilderClientConfig | constructor configuration interface}.
+   */
   readonly config: ImagebuilderClientResolvedConfig;
 
   constructor(configuration: ImagebuilderClientConfig) {

--- a/clients/client-inspector/InspectorClient.ts
+++ b/clients/client-inspector/InspectorClient.ts
@@ -338,7 +338,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type InspectorClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type InspectorClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -346,8 +346,12 @@ export type InspectorClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of InspectorClient class constructor that set the region, credentials and other options.
+ */
+export interface InspectorClientConfig extends InspectorClientConfigType {}
 
-export type InspectorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type InspectorClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -355,6 +359,10 @@ export type InspectorClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of InspectorClient class. This is resolved and normalized from the {@link InspectorClientConfig | constructor configuration interface}.
+ */
+export interface InspectorClientResolvedConfig extends InspectorClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Inspector</fullname>
@@ -368,6 +376,9 @@ export class InspectorClient extends __Client<
   ServiceOutputTypes,
   InspectorClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of InspectorClient class. This is resolved and normalized from the {@link InspectorClientConfig | constructor configuration interface}.
+   */
   readonly config: InspectorClientResolvedConfig;
 
   constructor(configuration: InspectorClientConfig) {

--- a/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
@@ -200,7 +200,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoT1ClickDevicesServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoT1ClickDevicesServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -208,8 +208,12 @@ export type IoT1ClickDevicesServiceClientConfig = Partial<__SmithyConfiguration<
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoT1ClickDevicesServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface IoT1ClickDevicesServiceClientConfig extends IoT1ClickDevicesServiceClientConfigType {}
 
-export type IoT1ClickDevicesServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoT1ClickDevicesServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -217,6 +221,10 @@ export type IoT1ClickDevicesServiceClientResolvedConfig = __SmithyResolvedConfig
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoT1ClickDevicesServiceClient class. This is resolved and normalized from the {@link IoT1ClickDevicesServiceClientConfig | constructor configuration interface}.
+ */
+export interface IoT1ClickDevicesServiceClientResolvedConfig extends IoT1ClickDevicesServiceClientResolvedConfigType {}
 
 /**
  * <p>Describes all of the AWS IoT 1-Click device-related API operations for the service.
@@ -229,6 +237,9 @@ export class IoT1ClickDevicesServiceClient extends __Client<
   ServiceOutputTypes,
   IoT1ClickDevicesServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoT1ClickDevicesServiceClient class. This is resolved and normalized from the {@link IoT1ClickDevicesServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: IoT1ClickDevicesServiceClientResolvedConfig;
 
   constructor(configuration: IoT1ClickDevicesServiceClientConfig) {

--- a/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoT1ClickProjectsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoT1ClickProjectsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -217,8 +217,12 @@ export type IoT1ClickProjectsClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoT1ClickProjectsClient class constructor that set the region, credentials and other options.
+ */
+export interface IoT1ClickProjectsClientConfig extends IoT1ClickProjectsClientConfigType {}
 
-export type IoT1ClickProjectsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoT1ClickProjectsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -226,6 +230,10 @@ export type IoT1ClickProjectsClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoT1ClickProjectsClient class. This is resolved and normalized from the {@link IoT1ClickProjectsClientConfig | constructor configuration interface}.
+ */
+export interface IoT1ClickProjectsClientResolvedConfig extends IoT1ClickProjectsClientResolvedConfigType {}
 
 /**
  * <p>The AWS IoT 1-Click Projects API Reference</p>
@@ -236,6 +244,9 @@ export class IoT1ClickProjectsClient extends __Client<
   ServiceOutputTypes,
   IoT1ClickProjectsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoT1ClickProjectsClient class. This is resolved and normalized from the {@link IoT1ClickProjectsClientConfig | constructor configuration interface}.
+   */
   readonly config: IoT1ClickProjectsClientResolvedConfig;
 
   constructor(configuration: IoT1ClickProjectsClientConfig) {

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTDataPlaneClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTDataPlaneClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -181,8 +181,12 @@ export type IoTDataPlaneClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTDataPlaneClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTDataPlaneClientConfig extends IoTDataPlaneClientConfigType {}
 
-export type IoTDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTDataPlaneClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -190,6 +194,10 @@ export type IoTDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTDataPlaneClient class. This is resolved and normalized from the {@link IoTDataPlaneClientConfig | constructor configuration interface}.
+ */
+export interface IoTDataPlaneClientResolvedConfig extends IoTDataPlaneClientResolvedConfigType {}
 
 /**
  * <fullname>AWS IoT</fullname>
@@ -210,6 +218,9 @@ export class IoTDataPlaneClient extends __Client<
   ServiceOutputTypes,
   IoTDataPlaneClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTDataPlaneClient class. This is resolved and normalized from the {@link IoTDataPlaneClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTDataPlaneClientResolvedConfig;
 
   constructor(configuration: IoTDataPlaneClientConfig) {

--- a/clients/client-iot-events-data/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/IoTEventsDataClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTEventsDataClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTEventsDataClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -172,8 +172,12 @@ export type IoTEventsDataClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTEventsDataClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTEventsDataClientConfig extends IoTEventsDataClientConfigType {}
 
-export type IoTEventsDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTEventsDataClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -181,6 +185,10 @@ export type IoTEventsDataClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTEventsDataClient class. This is resolved and normalized from the {@link IoTEventsDataClientConfig | constructor configuration interface}.
+ */
+export interface IoTEventsDataClientResolvedConfig extends IoTEventsDataClientResolvedConfigType {}
 
 /**
  * <p>AWS IoT Events monitors your equipment or device fleets for failures or changes in operation,
@@ -193,6 +201,9 @@ export class IoTEventsDataClient extends __Client<
   ServiceOutputTypes,
   IoTEventsDataClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTEventsDataClient class. This is resolved and normalized from the {@link IoTEventsDataClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTEventsDataClientResolvedConfig;
 
   constructor(configuration: IoTEventsDataClientConfig) {

--- a/clients/client-iot-events/IoTEventsClient.ts
+++ b/clients/client-iot-events/IoTEventsClient.ts
@@ -218,7 +218,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTEventsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTEventsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -226,8 +226,12 @@ export type IoTEventsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTEventsClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTEventsClientConfig extends IoTEventsClientConfigType {}
 
-export type IoTEventsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTEventsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -235,6 +239,10 @@ export type IoTEventsClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTEventsClient class. This is resolved and normalized from the {@link IoTEventsClientConfig | constructor configuration interface}.
+ */
+export interface IoTEventsClientResolvedConfig extends IoTEventsClientResolvedConfigType {}
 
 /**
  * <p>AWS IoT Events monitors your equipment or device fleets for failures or changes in operation, and
@@ -247,6 +255,9 @@ export class IoTEventsClient extends __Client<
   ServiceOutputTypes,
   IoTEventsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTEventsClient class. This is resolved and normalized from the {@link IoTEventsClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTEventsClientResolvedConfig;
 
   constructor(configuration: IoTEventsClientConfig) {

--- a/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
@@ -170,7 +170,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTJobsDataPlaneClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTJobsDataPlaneClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -178,8 +178,12 @@ export type IoTJobsDataPlaneClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTJobsDataPlaneClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTJobsDataPlaneClientConfig extends IoTJobsDataPlaneClientConfigType {}
 
-export type IoTJobsDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTJobsDataPlaneClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -187,6 +191,10 @@ export type IoTJobsDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTJobsDataPlaneClient class. This is resolved and normalized from the {@link IoTJobsDataPlaneClientConfig | constructor configuration interface}.
+ */
+export interface IoTJobsDataPlaneClientResolvedConfig extends IoTJobsDataPlaneClientResolvedConfigType {}
 
 /**
  * <p>AWS IoT Jobs is a service that allows you to define a set of jobs — remote operations that are sent to
@@ -207,6 +215,9 @@ export class IoTJobsDataPlaneClient extends __Client<
   ServiceOutputTypes,
   IoTJobsDataPlaneClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTJobsDataPlaneClient class. This is resolved and normalized from the {@link IoTJobsDataPlaneClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTJobsDataPlaneClientResolvedConfig;
 
   constructor(configuration: IoTJobsDataPlaneClientConfig) {

--- a/clients/client-iot/IoTClient.ts
+++ b/clients/client-iot/IoTClient.ts
@@ -1160,7 +1160,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -1168,8 +1168,12 @@ export type IoTClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTClientConfig extends IoTClientConfigType {}
 
-export type IoTClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -1177,6 +1181,10 @@ export type IoTClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTClient class. This is resolved and normalized from the {@link IoTClientConfig | constructor configuration interface}.
+ */
+export interface IoTClientResolvedConfig extends IoTClientResolvedConfigType {}
 
 /**
  * <fullname>AWS IoT</fullname>
@@ -1202,6 +1210,9 @@ export class IoTClient extends __Client<
   ServiceOutputTypes,
   IoTClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTClient class. This is resolved and normalized from the {@link IoTClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTClientResolvedConfig;
 
   constructor(configuration: IoTClientConfig) {

--- a/clients/client-iotanalytics/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/IoTAnalyticsClient.ts
@@ -275,7 +275,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTAnalyticsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTAnalyticsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -283,8 +283,12 @@ export type IoTAnalyticsClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTAnalyticsClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTAnalyticsClientConfig extends IoTAnalyticsClientConfigType {}
 
-export type IoTAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTAnalyticsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -292,6 +296,10 @@ export type IoTAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTAnalyticsClient class. This is resolved and normalized from the {@link IoTAnalyticsClientConfig | constructor configuration interface}.
+ */
+export interface IoTAnalyticsClientResolvedConfig extends IoTAnalyticsClientResolvedConfigType {}
 
 /**
  * <p>AWS IoT Analytics allows you to collect large amounts of device data, process messages, and store them.
@@ -320,6 +328,9 @@ export class IoTAnalyticsClient extends __Client<
   ServiceOutputTypes,
   IoTAnalyticsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTAnalyticsClient class. This is resolved and normalized from the {@link IoTAnalyticsClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTAnalyticsClientResolvedConfig;
 
   constructor(configuration: IoTAnalyticsClientConfig) {

--- a/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTSecureTunnelingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTSecureTunnelingClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -181,8 +181,12 @@ export type IoTSecureTunnelingClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTSecureTunnelingClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTSecureTunnelingClientConfig extends IoTSecureTunnelingClientConfigType {}
 
-export type IoTSecureTunnelingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTSecureTunnelingClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -190,6 +194,10 @@ export type IoTSecureTunnelingClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTSecureTunnelingClient class. This is resolved and normalized from the {@link IoTSecureTunnelingClientConfig | constructor configuration interface}.
+ */
+export interface IoTSecureTunnelingClientResolvedConfig extends IoTSecureTunnelingClientResolvedConfigType {}
 
 /**
  * <fullname>AWS IoT Secure Tunneling</fullname>
@@ -204,6 +212,9 @@ export class IoTSecureTunnelingClient extends __Client<
   ServiceOutputTypes,
   IoTSecureTunnelingClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTSecureTunnelingClient class. This is resolved and normalized from the {@link IoTSecureTunnelingClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTSecureTunnelingClientResolvedConfig;
 
   constructor(configuration: IoTSecureTunnelingClientConfig) {

--- a/clients/client-iotsitewise/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/IoTSiteWiseClient.ts
@@ -371,7 +371,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTSiteWiseClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTSiteWiseClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -379,8 +379,12 @@ export type IoTSiteWiseClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTSiteWiseClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTSiteWiseClientConfig extends IoTSiteWiseClientConfigType {}
 
-export type IoTSiteWiseClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTSiteWiseClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -388,6 +392,10 @@ export type IoTSiteWiseClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTSiteWiseClient class. This is resolved and normalized from the {@link IoTSiteWiseClientConfig | constructor configuration interface}.
+ */
+export interface IoTSiteWiseClientResolvedConfig extends IoTSiteWiseClientResolvedConfigType {}
 
 /**
  * <p>Welcome to the AWS IoT SiteWise API Reference. AWS IoT SiteWise is an AWS service that connects <a href="https://en.wikipedia.org/wiki/Internet_of_things#Industrial_applications">Industrial Internet of Things (IIoT)</a> devices to the power of the AWS Cloud. For more information, see the
@@ -399,6 +407,9 @@ export class IoTSiteWiseClient extends __Client<
   ServiceOutputTypes,
   IoTSiteWiseClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTSiteWiseClient class. This is resolved and normalized from the {@link IoTSiteWiseClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTSiteWiseClientResolvedConfig;
 
   constructor(configuration: IoTSiteWiseClientConfig) {

--- a/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
@@ -317,7 +317,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTThingsGraphClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTThingsGraphClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -325,8 +325,12 @@ export type IoTThingsGraphClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTThingsGraphClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTThingsGraphClientConfig extends IoTThingsGraphClientConfigType {}
 
-export type IoTThingsGraphClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTThingsGraphClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -334,6 +338,10 @@ export type IoTThingsGraphClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTThingsGraphClient class. This is resolved and normalized from the {@link IoTThingsGraphClientConfig | constructor configuration interface}.
+ */
+export interface IoTThingsGraphClientResolvedConfig extends IoTThingsGraphClientResolvedConfigType {}
 
 /**
  * <fullname>AWS IoT Things Graph</fullname>
@@ -348,6 +356,9 @@ export class IoTThingsGraphClient extends __Client<
   ServiceOutputTypes,
   IoTThingsGraphClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTThingsGraphClient class. This is resolved and normalized from the {@link IoTThingsGraphClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTThingsGraphClientResolvedConfig;
 
   constructor(configuration: IoTThingsGraphClientConfig) {

--- a/clients/client-ivs/IvsClient.ts
+++ b/clients/client-ivs/IvsClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IvsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IvsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -235,8 +235,12 @@ export type IvsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IvsClient class constructor that set the region, credentials and other options.
+ */
+export interface IvsClientConfig extends IvsClientConfigType {}
 
-export type IvsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IvsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -244,6 +248,10 @@ export type IvsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IvsClient class. This is resolved and normalized from the {@link IvsClientConfig | constructor configuration interface}.
+ */
+export interface IvsClientResolvedConfig extends IvsClientResolvedConfigType {}
 
 /**
  * <p>
@@ -529,6 +537,9 @@ export class IvsClient extends __Client<
   ServiceOutputTypes,
   IvsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IvsClient class. This is resolved and normalized from the {@link IvsClientConfig | constructor configuration interface}.
+   */
   readonly config: IvsClientResolvedConfig;
 
   constructor(configuration: IvsClientConfig) {

--- a/clients/client-kafka/KafkaClient.ts
+++ b/clients/client-kafka/KafkaClient.ts
@@ -284,7 +284,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KafkaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KafkaClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -292,8 +292,12 @@ export type KafkaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KafkaClient class constructor that set the region, credentials and other options.
+ */
+export interface KafkaClientConfig extends KafkaClientConfigType {}
 
-export type KafkaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KafkaClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -301,6 +305,10 @@ export type KafkaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KafkaClient class. This is resolved and normalized from the {@link KafkaClientConfig | constructor configuration interface}.
+ */
+export interface KafkaClientResolvedConfig extends KafkaClientResolvedConfigType {}
 
 /**
  * <p>The operations for managing an Amazon MSK cluster.</p>
@@ -311,6 +319,9 @@ export class KafkaClient extends __Client<
   ServiceOutputTypes,
   KafkaClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KafkaClient class. This is resolved and normalized from the {@link KafkaClientConfig | constructor configuration interface}.
+   */
   readonly config: KafkaClientResolvedConfig;
 
   constructor(configuration: KafkaClientConfig) {

--- a/clients/client-kendra/KendraClient.ts
+++ b/clients/client-kendra/KendraClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KendraClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KendraClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -259,8 +259,12 @@ export type KendraClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KendraClient class constructor that set the region, credentials and other options.
+ */
+export interface KendraClientConfig extends KendraClientConfigType {}
 
-export type KendraClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KendraClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -268,6 +272,10 @@ export type KendraClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KendraClient class. This is resolved and normalized from the {@link KendraClientConfig | constructor configuration interface}.
+ */
+export interface KendraClientResolvedConfig extends KendraClientResolvedConfigType {}
 
 /**
  * <p>Amazon Kendra is a service for indexing large document sets.</p>
@@ -278,6 +286,9 @@ export class KendraClient extends __Client<
   ServiceOutputTypes,
   KendraClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KendraClient class. This is resolved and normalized from the {@link KendraClientConfig | constructor configuration interface}.
+   */
   readonly config: KendraClientResolvedConfig;
 
   constructor(configuration: KendraClientConfig) {

--- a/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
@@ -287,7 +287,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KinesisAnalyticsV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KinesisAnalyticsV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -295,8 +295,12 @@ export type KinesisAnalyticsV2ClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KinesisAnalyticsV2Client class constructor that set the region, credentials and other options.
+ */
+export interface KinesisAnalyticsV2ClientConfig extends KinesisAnalyticsV2ClientConfigType {}
 
-export type KinesisAnalyticsV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KinesisAnalyticsV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -304,6 +308,10 @@ export type KinesisAnalyticsV2ClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KinesisAnalyticsV2Client class. This is resolved and normalized from the {@link KinesisAnalyticsV2ClientConfig | constructor configuration interface}.
+ */
+export interface KinesisAnalyticsV2ClientResolvedConfig extends KinesisAnalyticsV2ClientResolvedConfigType {}
 
 /**
  * <p>Amazon Kinesis Data Analytics is a fully managed service that you can use to process and analyze streaming data using Java, SQL, or Scala. The service
@@ -316,6 +324,9 @@ export class KinesisAnalyticsV2Client extends __Client<
   ServiceOutputTypes,
   KinesisAnalyticsV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KinesisAnalyticsV2Client class. This is resolved and normalized from the {@link KinesisAnalyticsV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: KinesisAnalyticsV2ClientResolvedConfig;
 
   constructor(configuration: KinesisAnalyticsV2ClientConfig) {

--- a/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KinesisAnalyticsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KinesisAnalyticsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -253,8 +253,12 @@ export type KinesisAnalyticsClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KinesisAnalyticsClient class constructor that set the region, credentials and other options.
+ */
+export interface KinesisAnalyticsClientConfig extends KinesisAnalyticsClientConfigType {}
 
-export type KinesisAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KinesisAnalyticsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -262,6 +266,10 @@ export type KinesisAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KinesisAnalyticsClient class. This is resolved and normalized from the {@link KinesisAnalyticsClientConfig | constructor configuration interface}.
+ */
+export interface KinesisAnalyticsClientResolvedConfig extends KinesisAnalyticsClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Kinesis Analytics</fullname>
@@ -281,6 +289,9 @@ export class KinesisAnalyticsClient extends __Client<
   ServiceOutputTypes,
   KinesisAnalyticsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KinesisAnalyticsClient class. This is resolved and normalized from the {@link KinesisAnalyticsClientConfig | constructor configuration interface}.
+   */
   readonly config: KinesisAnalyticsClientResolvedConfig;
 
   constructor(configuration: KinesisAnalyticsClientConfig) {

--- a/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KinesisVideoArchivedMediaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KinesisVideoArchivedMediaClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -181,8 +181,12 @@ export type KinesisVideoArchivedMediaClientConfig = Partial<__SmithyConfiguratio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KinesisVideoArchivedMediaClient class constructor that set the region, credentials and other options.
+ */
+export interface KinesisVideoArchivedMediaClientConfig extends KinesisVideoArchivedMediaClientConfigType {}
 
-export type KinesisVideoArchivedMediaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KinesisVideoArchivedMediaClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -190,6 +194,11 @@ export type KinesisVideoArchivedMediaClientResolvedConfig = __SmithyResolvedConf
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KinesisVideoArchivedMediaClient class. This is resolved and normalized from the {@link KinesisVideoArchivedMediaClientConfig | constructor configuration interface}.
+ */
+export interface KinesisVideoArchivedMediaClientResolvedConfig
+  extends KinesisVideoArchivedMediaClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -200,6 +209,9 @@ export class KinesisVideoArchivedMediaClient extends __Client<
   ServiceOutputTypes,
   KinesisVideoArchivedMediaClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KinesisVideoArchivedMediaClient class. This is resolved and normalized from the {@link KinesisVideoArchivedMediaClientConfig | constructor configuration interface}.
+   */
   readonly config: KinesisVideoArchivedMediaClientResolvedConfig;
 
   constructor(configuration: KinesisVideoArchivedMediaClientConfig) {

--- a/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
@@ -150,7 +150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KinesisVideoMediaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KinesisVideoMediaClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -158,8 +158,12 @@ export type KinesisVideoMediaClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KinesisVideoMediaClient class constructor that set the region, credentials and other options.
+ */
+export interface KinesisVideoMediaClientConfig extends KinesisVideoMediaClientConfigType {}
 
-export type KinesisVideoMediaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KinesisVideoMediaClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -167,6 +171,10 @@ export type KinesisVideoMediaClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KinesisVideoMediaClient class. This is resolved and normalized from the {@link KinesisVideoMediaClientConfig | constructor configuration interface}.
+ */
+export interface KinesisVideoMediaClientResolvedConfig extends KinesisVideoMediaClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -177,6 +185,9 @@ export class KinesisVideoMediaClient extends __Client<
   ServiceOutputTypes,
   KinesisVideoMediaClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KinesisVideoMediaClient class. This is resolved and normalized from the {@link KinesisVideoMediaClientConfig | constructor configuration interface}.
+   */
   readonly config: KinesisVideoMediaClientResolvedConfig;
 
   constructor(configuration: KinesisVideoMediaClientConfig) {

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -160,7 +160,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KinesisVideoSignalingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KinesisVideoSignalingClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -168,8 +168,12 @@ export type KinesisVideoSignalingClientConfig = Partial<__SmithyConfiguration<__
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KinesisVideoSignalingClient class constructor that set the region, credentials and other options.
+ */
+export interface KinesisVideoSignalingClientConfig extends KinesisVideoSignalingClientConfigType {}
 
-export type KinesisVideoSignalingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KinesisVideoSignalingClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -177,6 +181,10 @@ export type KinesisVideoSignalingClientResolvedConfig = __SmithyResolvedConfigur
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KinesisVideoSignalingClient class. This is resolved and normalized from the {@link KinesisVideoSignalingClientConfig | constructor configuration interface}.
+ */
+export interface KinesisVideoSignalingClientResolvedConfig extends KinesisVideoSignalingClientResolvedConfigType {}
 
 /**
  * <p>Kinesis Video Streams Signaling Service is a intermediate service that establishes a
@@ -189,6 +197,9 @@ export class KinesisVideoSignalingClient extends __Client<
   ServiceOutputTypes,
   KinesisVideoSignalingClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KinesisVideoSignalingClient class. This is resolved and normalized from the {@link KinesisVideoSignalingClientConfig | constructor configuration interface}.
+   */
   readonly config: KinesisVideoSignalingClientResolvedConfig;
 
   constructor(configuration: KinesisVideoSignalingClientConfig) {

--- a/clients/client-kinesis-video/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/KinesisVideoClient.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KinesisVideoClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KinesisVideoClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -238,8 +238,12 @@ export type KinesisVideoClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KinesisVideoClient class constructor that set the region, credentials and other options.
+ */
+export interface KinesisVideoClientConfig extends KinesisVideoClientConfigType {}
 
-export type KinesisVideoClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KinesisVideoClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -247,6 +251,10 @@ export type KinesisVideoClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KinesisVideoClient class. This is resolved and normalized from the {@link KinesisVideoClientConfig | constructor configuration interface}.
+ */
+export interface KinesisVideoClientResolvedConfig extends KinesisVideoClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -257,6 +265,9 @@ export class KinesisVideoClient extends __Client<
   ServiceOutputTypes,
   KinesisVideoClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KinesisVideoClient class. This is resolved and normalized from the {@link KinesisVideoClientConfig | constructor configuration interface}.
+   */
   readonly config: KinesisVideoClientResolvedConfig;
 
   constructor(configuration: KinesisVideoClientConfig) {

--- a/clients/client-kinesis/KinesisClient.ts
+++ b/clients/client-kinesis/KinesisClient.ts
@@ -280,7 +280,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   eventStreamSerdeProvider?: __EventStreamSerdeProvider;
 }
 
-export type KinesisClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KinesisClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -289,8 +289,12 @@ export type KinesisClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   UserAgentInputConfig &
   EventStreamSerdeInputConfig;
+/**
+ * The configuration interface of KinesisClient class constructor that set the region, credentials and other options.
+ */
+export interface KinesisClientConfig extends KinesisClientConfigType {}
 
-export type KinesisClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KinesisClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -299,6 +303,10 @@ export type KinesisClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig &
   EventStreamSerdeResolvedConfig;
+/**
+ * The resolved configuration interface of KinesisClient class. This is resolved and normalized from the {@link KinesisClientConfig | constructor configuration interface}.
+ */
+export interface KinesisClientResolvedConfig extends KinesisClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Kinesis Data Streams Service API Reference</fullname>
@@ -311,6 +319,9 @@ export class KinesisClient extends __Client<
   ServiceOutputTypes,
   KinesisClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KinesisClient class. This is resolved and normalized from the {@link KinesisClientConfig | constructor configuration interface}.
+   */
   readonly config: KinesisClientResolvedConfig;
 
   constructor(configuration: KinesisClientConfig) {

--- a/clients/client-kms/KMSClient.ts
+++ b/clients/client-kms/KMSClient.ts
@@ -332,7 +332,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type KMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type KMSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -340,8 +340,12 @@ export type KMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of KMSClient class constructor that set the region, credentials and other options.
+ */
+export interface KMSClientConfig extends KMSClientConfigType {}
 
-export type KMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type KMSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -349,6 +353,10 @@ export type KMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of KMSClient class. This is resolved and normalized from the {@link KMSClientConfig | constructor configuration interface}.
+ */
+export interface KMSClientResolvedConfig extends KMSClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Key Management Service</fullname>
@@ -447,6 +455,9 @@ export class KMSClient extends __Client<
   ServiceOutputTypes,
   KMSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of KMSClient class. This is resolved and normalized from the {@link KMSClientConfig | constructor configuration interface}.
+   */
   readonly config: KMSClientResolvedConfig;
 
   constructor(configuration: KMSClientConfig) {

--- a/clients/client-lakeformation/LakeFormationClient.ts
+++ b/clients/client-lakeformation/LakeFormationClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LakeFormationClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LakeFormationClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -211,8 +211,12 @@ export type LakeFormationClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LakeFormationClient class constructor that set the region, credentials and other options.
+ */
+export interface LakeFormationClientConfig extends LakeFormationClientConfigType {}
 
-export type LakeFormationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LakeFormationClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -220,6 +224,10 @@ export type LakeFormationClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LakeFormationClient class. This is resolved and normalized from the {@link LakeFormationClientConfig | constructor configuration interface}.
+ */
+export interface LakeFormationClientResolvedConfig extends LakeFormationClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Lake Formation</fullname>
@@ -231,6 +239,9 @@ export class LakeFormationClient extends __Client<
   ServiceOutputTypes,
   LakeFormationClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LakeFormationClient class. This is resolved and normalized from the {@link LakeFormationClientConfig | constructor configuration interface}.
+   */
   readonly config: LakeFormationClientResolvedConfig;
 
   constructor(configuration: LakeFormationClientConfig) {

--- a/clients/client-lambda/LambdaClient.ts
+++ b/clients/client-lambda/LambdaClient.ts
@@ -425,7 +425,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LambdaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LambdaClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -433,8 +433,12 @@ export type LambdaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LambdaClient class constructor that set the region, credentials and other options.
+ */
+export interface LambdaClientConfig extends LambdaClientConfigType {}
 
-export type LambdaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LambdaClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -442,6 +446,10 @@ export type LambdaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LambdaClient class. This is resolved and normalized from the {@link LambdaClientConfig | constructor configuration interface}.
+ */
+export interface LambdaClientResolvedConfig extends LambdaClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Lambda</fullname>
@@ -458,6 +466,9 @@ export class LambdaClient extends __Client<
   ServiceOutputTypes,
   LambdaClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LambdaClient class. This is resolved and normalized from the {@link LambdaClientConfig | constructor configuration interface}.
+   */
   readonly config: LambdaClientResolvedConfig;
 
   constructor(configuration: LambdaClientConfig) {

--- a/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
@@ -296,7 +296,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LexModelBuildingServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LexModelBuildingServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -304,8 +304,12 @@ export type LexModelBuildingServiceClientConfig = Partial<__SmithyConfiguration<
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LexModelBuildingServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface LexModelBuildingServiceClientConfig extends LexModelBuildingServiceClientConfigType {}
 
-export type LexModelBuildingServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LexModelBuildingServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -313,6 +317,10 @@ export type LexModelBuildingServiceClientResolvedConfig = __SmithyResolvedConfig
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LexModelBuildingServiceClient class. This is resolved and normalized from the {@link LexModelBuildingServiceClientConfig | constructor configuration interface}.
+ */
+export interface LexModelBuildingServiceClientResolvedConfig extends LexModelBuildingServiceClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Lex Build-Time Actions</fullname>
@@ -326,6 +334,9 @@ export class LexModelBuildingServiceClient extends __Client<
   ServiceOutputTypes,
   LexModelBuildingServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LexModelBuildingServiceClient class. This is resolved and normalized from the {@link LexModelBuildingServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: LexModelBuildingServiceClientResolvedConfig;
 
   constructor(configuration: LexModelBuildingServiceClientConfig) {

--- a/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LexRuntimeServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LexRuntimeServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -172,8 +172,12 @@ export type LexRuntimeServiceClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LexRuntimeServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface LexRuntimeServiceClientConfig extends LexRuntimeServiceClientConfigType {}
 
-export type LexRuntimeServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LexRuntimeServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -181,6 +185,10 @@ export type LexRuntimeServiceClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LexRuntimeServiceClient class. This is resolved and normalized from the {@link LexRuntimeServiceClientConfig | constructor configuration interface}.
+ */
+export interface LexRuntimeServiceClientResolvedConfig extends LexRuntimeServiceClientResolvedConfigType {}
 
 /**
  * <p>Amazon Lex provides both build and runtime endpoints. Each endpoint provides a set of
@@ -199,6 +207,9 @@ export class LexRuntimeServiceClient extends __Client<
   ServiceOutputTypes,
   LexRuntimeServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LexRuntimeServiceClient class. This is resolved and normalized from the {@link LexRuntimeServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: LexRuntimeServiceClientResolvedConfig;
 
   constructor(configuration: LexRuntimeServiceClientConfig) {

--- a/clients/client-license-manager/LicenseManagerClient.ts
+++ b/clients/client-license-manager/LicenseManagerClient.ts
@@ -326,7 +326,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LicenseManagerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LicenseManagerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -334,8 +334,12 @@ export type LicenseManagerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LicenseManagerClient class constructor that set the region, credentials and other options.
+ */
+export interface LicenseManagerClientConfig extends LicenseManagerClientConfigType {}
 
-export type LicenseManagerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LicenseManagerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -343,6 +347,10 @@ export type LicenseManagerClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LicenseManagerClient class. This is resolved and normalized from the {@link LicenseManagerClientConfig | constructor configuration interface}.
+ */
+export interface LicenseManagerClientResolvedConfig extends LicenseManagerClientResolvedConfigType {}
 
 /**
  * <fullname> AWS License Manager </fullname>
@@ -355,6 +363,9 @@ export class LicenseManagerClient extends __Client<
   ServiceOutputTypes,
   LicenseManagerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LicenseManagerClient class. This is resolved and normalized from the {@link LicenseManagerClientConfig | constructor configuration interface}.
+   */
   readonly config: LicenseManagerClientResolvedConfig;
 
   constructor(configuration: LicenseManagerClientConfig) {

--- a/clients/client-lightsail/LightsailClient.ts
+++ b/clients/client-lightsail/LightsailClient.ts
@@ -782,7 +782,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LightsailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LightsailClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -790,8 +790,12 @@ export type LightsailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LightsailClient class constructor that set the region, credentials and other options.
+ */
+export interface LightsailClientConfig extends LightsailClientConfigType {}
 
-export type LightsailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LightsailClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -799,6 +803,10 @@ export type LightsailClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LightsailClient class. This is resolved and normalized from the {@link LightsailClientConfig | constructor configuration interface}.
+ */
+export interface LightsailClientResolvedConfig extends LightsailClientResolvedConfigType {}
 
 /**
  * <p>Amazon Lightsail is the easiest way to get started with Amazon Web Services (AWS) for developers
@@ -823,6 +831,9 @@ export class LightsailClient extends __Client<
   ServiceOutputTypes,
   LightsailClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LightsailClient class. This is resolved and normalized from the {@link LightsailClientConfig | constructor configuration interface}.
+   */
   readonly config: LightsailClientResolvedConfig;
 
   constructor(configuration: LightsailClientConfig) {

--- a/clients/client-lookoutvision/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/LookoutVisionClient.ts
@@ -200,7 +200,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LookoutVisionClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LookoutVisionClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -208,8 +208,12 @@ export type LookoutVisionClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LookoutVisionClient class constructor that set the region, credentials and other options.
+ */
+export interface LookoutVisionClientConfig extends LookoutVisionClientConfigType {}
 
-export type LookoutVisionClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LookoutVisionClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -217,6 +221,10 @@ export type LookoutVisionClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LookoutVisionClient class. This is resolved and normalized from the {@link LookoutVisionClientConfig | constructor configuration interface}.
+ */
+export interface LookoutVisionClientResolvedConfig extends LookoutVisionClientResolvedConfigType {}
 
 /**
  * <p>This is the Amazon Lookout for Vision API Reference. It provides descriptions of actions,
@@ -233,6 +241,9 @@ export class LookoutVisionClient extends __Client<
   ServiceOutputTypes,
   LookoutVisionClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LookoutVisionClient class. This is resolved and normalized from the {@link LookoutVisionClientConfig | constructor configuration interface}.
+   */
   readonly config: LookoutVisionClientResolvedConfig;
 
   constructor(configuration: LookoutVisionClientConfig) {

--- a/clients/client-machine-learning/MachineLearningClient.ts
+++ b/clients/client-machine-learning/MachineLearningClient.ts
@@ -266,7 +266,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MachineLearningClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MachineLearningClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -274,8 +274,12 @@ export type MachineLearningClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MachineLearningClient class constructor that set the region, credentials and other options.
+ */
+export interface MachineLearningClientConfig extends MachineLearningClientConfigType {}
 
-export type MachineLearningClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MachineLearningClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -283,6 +287,10 @@ export type MachineLearningClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MachineLearningClient class. This is resolved and normalized from the {@link MachineLearningClientConfig | constructor configuration interface}.
+ */
+export interface MachineLearningClientResolvedConfig extends MachineLearningClientResolvedConfigType {}
 
 /**
  * <p>Definition of the public APIs
@@ -294,6 +302,9 @@ export class MachineLearningClient extends __Client<
   ServiceOutputTypes,
   MachineLearningClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MachineLearningClient class. This is resolved and normalized from the {@link MachineLearningClientConfig | constructor configuration interface}.
+   */
   readonly config: MachineLearningClientResolvedConfig;
 
   constructor(configuration: MachineLearningClientConfig) {

--- a/clients/client-macie/MacieClient.ts
+++ b/clients/client-macie/MacieClient.ts
@@ -182,7 +182,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MacieClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MacieClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -190,8 +190,12 @@ export type MacieClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MacieClient class constructor that set the region, credentials and other options.
+ */
+export interface MacieClientConfig extends MacieClientConfigType {}
 
-export type MacieClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MacieClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -199,6 +203,10 @@ export type MacieClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MacieClient class. This is resolved and normalized from the {@link MacieClientConfig | constructor configuration interface}.
+ */
+export interface MacieClientResolvedConfig extends MacieClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Macie Classic</fullname>
@@ -219,6 +227,9 @@ export class MacieClient extends __Client<
   ServiceOutputTypes,
   MacieClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MacieClient class. This is resolved and normalized from the {@link MacieClientConfig | constructor configuration interface}.
+   */
   readonly config: MacieClientResolvedConfig;
 
   constructor(configuration: MacieClientConfig) {

--- a/clients/client-macie2/Macie2Client.ts
+++ b/clients/client-macie2/Macie2Client.ts
@@ -386,7 +386,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type Macie2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type Macie2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -394,8 +394,12 @@ export type Macie2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of Macie2Client class constructor that set the region, credentials and other options.
+ */
+export interface Macie2ClientConfig extends Macie2ClientConfigType {}
 
-export type Macie2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type Macie2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -403,6 +407,10 @@ export type Macie2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of Macie2Client class. This is resolved and normalized from the {@link Macie2ClientConfig | constructor configuration interface}.
+ */
+export interface Macie2ClientResolvedConfig extends Macie2ClientResolvedConfigType {}
 
 /**
  * <p>Amazon Macie is a fully managed data security and data privacy service that uses machine learning and pattern matching to discover and protect your sensitive data in AWS. Macie automates the discovery of sensitive data, such as PII and intellectual property, to provide you with insight into the data that your organization stores in AWS. Macie also provides an inventory of your Amazon S3 buckets, which it continually monitors for you. If Macie detects sensitive data or potential data access issues, it generates detailed findings for you to review and act upon as necessary.</p>
@@ -413,6 +421,9 @@ export class Macie2Client extends __Client<
   ServiceOutputTypes,
   Macie2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of Macie2Client class. This is resolved and normalized from the {@link Macie2ClientConfig | constructor configuration interface}.
+   */
   readonly config: Macie2ClientResolvedConfig;
 
   constructor(configuration: Macie2ClientConfig) {

--- a/clients/client-managedblockchain/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/ManagedBlockchainClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ManagedBlockchainClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ManagedBlockchainClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -217,8 +217,12 @@ export type ManagedBlockchainClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ManagedBlockchainClient class constructor that set the region, credentials and other options.
+ */
+export interface ManagedBlockchainClientConfig extends ManagedBlockchainClientConfigType {}
 
-export type ManagedBlockchainClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ManagedBlockchainClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -226,6 +230,10 @@ export type ManagedBlockchainClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ManagedBlockchainClient class. This is resolved and normalized from the {@link ManagedBlockchainClientConfig | constructor configuration interface}.
+ */
+export interface ManagedBlockchainClientResolvedConfig extends ManagedBlockchainClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -237,6 +245,9 @@ export class ManagedBlockchainClient extends __Client<
   ServiceOutputTypes,
   ManagedBlockchainClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ManagedBlockchainClient class. This is resolved and normalized from the {@link ManagedBlockchainClientConfig | constructor configuration interface}.
+   */
   readonly config: ManagedBlockchainClientResolvedConfig;
 
   constructor(configuration: ManagedBlockchainClientConfig) {

--- a/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MarketplaceCatalogClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MarketplaceCatalogClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -175,8 +175,12 @@ export type MarketplaceCatalogClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MarketplaceCatalogClient class constructor that set the region, credentials and other options.
+ */
+export interface MarketplaceCatalogClientConfig extends MarketplaceCatalogClientConfigType {}
 
-export type MarketplaceCatalogClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MarketplaceCatalogClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -184,6 +188,10 @@ export type MarketplaceCatalogClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MarketplaceCatalogClient class. This is resolved and normalized from the {@link MarketplaceCatalogClientConfig | constructor configuration interface}.
+ */
+export interface MarketplaceCatalogClientResolvedConfig extends MarketplaceCatalogClientResolvedConfigType {}
 
 /**
  * <p>Catalog API actions allow you to manage your entities through list, describe, and update
@@ -200,6 +208,9 @@ export class MarketplaceCatalogClient extends __Client<
   ServiceOutputTypes,
   MarketplaceCatalogClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MarketplaceCatalogClient class. This is resolved and normalized from the {@link MarketplaceCatalogClientConfig | constructor configuration interface}.
+   */
   readonly config: MarketplaceCatalogClientResolvedConfig;
 
   constructor(configuration: MarketplaceCatalogClientConfig) {

--- a/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
@@ -154,7 +154,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MarketplaceCommerceAnalyticsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MarketplaceCommerceAnalyticsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -162,8 +162,12 @@ export type MarketplaceCommerceAnalyticsClientConfig = Partial<__SmithyConfigura
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MarketplaceCommerceAnalyticsClient class constructor that set the region, credentials and other options.
+ */
+export interface MarketplaceCommerceAnalyticsClientConfig extends MarketplaceCommerceAnalyticsClientConfigType {}
 
-export type MarketplaceCommerceAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MarketplaceCommerceAnalyticsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -171,6 +175,11 @@ export type MarketplaceCommerceAnalyticsClientResolvedConfig = __SmithyResolvedC
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MarketplaceCommerceAnalyticsClient class. This is resolved and normalized from the {@link MarketplaceCommerceAnalyticsClientConfig | constructor configuration interface}.
+ */
+export interface MarketplaceCommerceAnalyticsClientResolvedConfig
+  extends MarketplaceCommerceAnalyticsClientResolvedConfigType {}
 
 /**
  * Provides AWS Marketplace business intelligence data on-demand.
@@ -181,6 +190,9 @@ export class MarketplaceCommerceAnalyticsClient extends __Client<
   ServiceOutputTypes,
   MarketplaceCommerceAnalyticsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MarketplaceCommerceAnalyticsClient class. This is resolved and normalized from the {@link MarketplaceCommerceAnalyticsClientConfig | constructor configuration interface}.
+   */
   readonly config: MarketplaceCommerceAnalyticsClientResolvedConfig;
 
   constructor(configuration: MarketplaceCommerceAnalyticsClientConfig) {

--- a/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
@@ -150,7 +150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MarketplaceEntitlementServiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MarketplaceEntitlementServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -158,8 +158,12 @@ export type MarketplaceEntitlementServiceClientConfig = Partial<__SmithyConfigur
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MarketplaceEntitlementServiceClient class constructor that set the region, credentials and other options.
+ */
+export interface MarketplaceEntitlementServiceClientConfig extends MarketplaceEntitlementServiceClientConfigType {}
 
-export type MarketplaceEntitlementServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MarketplaceEntitlementServiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -167,6 +171,11 @@ export type MarketplaceEntitlementServiceClientResolvedConfig = __SmithyResolved
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MarketplaceEntitlementServiceClient class. This is resolved and normalized from the {@link MarketplaceEntitlementServiceClientConfig | constructor configuration interface}.
+ */
+export interface MarketplaceEntitlementServiceClientResolvedConfig
+  extends MarketplaceEntitlementServiceClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Marketplace Entitlement Service</fullname>
@@ -193,6 +202,9 @@ export class MarketplaceEntitlementServiceClient extends __Client<
   ServiceOutputTypes,
   MarketplaceEntitlementServiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MarketplaceEntitlementServiceClient class. This is resolved and normalized from the {@link MarketplaceEntitlementServiceClientConfig | constructor configuration interface}.
+   */
   readonly config: MarketplaceEntitlementServiceClientResolvedConfig;
 
   constructor(configuration: MarketplaceEntitlementServiceClientConfig) {

--- a/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
@@ -161,7 +161,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MarketplaceMeteringClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MarketplaceMeteringClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -169,8 +169,12 @@ export type MarketplaceMeteringClientConfig = Partial<__SmithyConfiguration<__Ht
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MarketplaceMeteringClient class constructor that set the region, credentials and other options.
+ */
+export interface MarketplaceMeteringClientConfig extends MarketplaceMeteringClientConfigType {}
 
-export type MarketplaceMeteringClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MarketplaceMeteringClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -178,6 +182,10 @@ export type MarketplaceMeteringClientResolvedConfig = __SmithyResolvedConfigurat
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MarketplaceMeteringClient class. This is resolved and normalized from the {@link MarketplaceMeteringClientConfig | constructor configuration interface}.
+ */
+export interface MarketplaceMeteringClientResolvedConfig extends MarketplaceMeteringClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Marketplace Metering Service</fullname>
@@ -244,6 +252,9 @@ export class MarketplaceMeteringClient extends __Client<
   ServiceOutputTypes,
   MarketplaceMeteringClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MarketplaceMeteringClient class. This is resolved and normalized from the {@link MarketplaceMeteringClientConfig | constructor configuration interface}.
+   */
   readonly config: MarketplaceMeteringClientResolvedConfig;
 
   constructor(configuration: MarketplaceMeteringClientConfig) {

--- a/clients/client-mediaconnect/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/MediaConnectClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaConnectClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -259,8 +259,12 @@ export type MediaConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaConnectClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaConnectClientConfig extends MediaConnectClientConfigType {}
 
-export type MediaConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaConnectClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -268,6 +272,10 @@ export type MediaConnectClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaConnectClient class. This is resolved and normalized from the {@link MediaConnectClientConfig | constructor configuration interface}.
+ */
+export interface MediaConnectClientResolvedConfig extends MediaConnectClientResolvedConfigType {}
 
 /**
  * API for AWS Elemental MediaConnect
@@ -278,6 +286,9 @@ export class MediaConnectClient extends __Client<
   ServiceOutputTypes,
   MediaConnectClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaConnectClient class. This is resolved and normalized from the {@link MediaConnectClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaConnectClientResolvedConfig;
 
   constructor(configuration: MediaConnectClientConfig) {

--- a/clients/client-mediaconvert/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/MediaConvertClient.ts
@@ -233,7 +233,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaConvertClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaConvertClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -241,8 +241,12 @@ export type MediaConvertClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaConvertClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaConvertClientConfig extends MediaConvertClientConfigType {}
 
-export type MediaConvertClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaConvertClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -250,6 +254,10 @@ export type MediaConvertClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaConvertClient class. This is resolved and normalized from the {@link MediaConvertClientConfig | constructor configuration interface}.
+ */
+export interface MediaConvertClientResolvedConfig extends MediaConvertClientResolvedConfigType {}
 
 /**
  * AWS Elemental MediaConvert
@@ -260,6 +268,9 @@ export class MediaConvertClient extends __Client<
   ServiceOutputTypes,
   MediaConvertClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaConvertClient class. This is resolved and normalized from the {@link MediaConvertClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaConvertClientResolvedConfig;
 
   constructor(configuration: MediaConvertClientConfig) {

--- a/clients/client-medialive/MediaLiveClient.ts
+++ b/clients/client-medialive/MediaLiveClient.ts
@@ -374,7 +374,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaLiveClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaLiveClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -382,8 +382,12 @@ export type MediaLiveClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaLiveClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaLiveClientConfig extends MediaLiveClientConfigType {}
 
-export type MediaLiveClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaLiveClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -391,6 +395,10 @@ export type MediaLiveClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaLiveClient class. This is resolved and normalized from the {@link MediaLiveClientConfig | constructor configuration interface}.
+ */
+export interface MediaLiveClientResolvedConfig extends MediaLiveClientResolvedConfigType {}
 
 /**
  * API for AWS Elemental MediaLive
@@ -401,6 +409,9 @@ export class MediaLiveClient extends __Client<
   ServiceOutputTypes,
   MediaLiveClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaLiveClient class. This is resolved and normalized from the {@link MediaLiveClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaLiveClientResolvedConfig;
 
   constructor(configuration: MediaLiveClientConfig) {

--- a/clients/client-mediapackage-vod/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/MediaPackageVodClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaPackageVodClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaPackageVodClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -235,8 +235,12 @@ export type MediaPackageVodClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaPackageVodClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaPackageVodClientConfig extends MediaPackageVodClientConfigType {}
 
-export type MediaPackageVodClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaPackageVodClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -244,6 +248,10 @@ export type MediaPackageVodClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaPackageVodClient class. This is resolved and normalized from the {@link MediaPackageVodClientConfig | constructor configuration interface}.
+ */
+export interface MediaPackageVodClientResolvedConfig extends MediaPackageVodClientResolvedConfigType {}
 
 /**
  * AWS Elemental MediaPackage VOD
@@ -254,6 +262,9 @@ export class MediaPackageVodClient extends __Client<
   ServiceOutputTypes,
   MediaPackageVodClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaPackageVodClient class. This is resolved and normalized from the {@link MediaPackageVodClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaPackageVodClientResolvedConfig;
 
   constructor(configuration: MediaPackageVodClientConfig) {

--- a/clients/client-mediapackage/MediaPackageClient.ts
+++ b/clients/client-mediapackage/MediaPackageClient.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaPackageClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaPackageClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -238,8 +238,12 @@ export type MediaPackageClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaPackageClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaPackageClientConfig extends MediaPackageClientConfigType {}
 
-export type MediaPackageClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaPackageClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -247,6 +251,10 @@ export type MediaPackageClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaPackageClient class. This is resolved and normalized from the {@link MediaPackageClientConfig | constructor configuration interface}.
+ */
+export interface MediaPackageClientResolvedConfig extends MediaPackageClientResolvedConfigType {}
 
 /**
  * AWS Elemental MediaPackage
@@ -257,6 +265,9 @@ export class MediaPackageClient extends __Client<
   ServiceOutputTypes,
   MediaPackageClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaPackageClient class. This is resolved and normalized from the {@link MediaPackageClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaPackageClientResolvedConfig;
 
   constructor(configuration: MediaPackageClientConfig) {

--- a/clients/client-mediastore-data/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/MediaStoreDataClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaStoreDataClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaStoreDataClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -172,8 +172,12 @@ export type MediaStoreDataClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaStoreDataClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaStoreDataClientConfig extends MediaStoreDataClientConfigType {}
 
-export type MediaStoreDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaStoreDataClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -181,6 +185,10 @@ export type MediaStoreDataClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaStoreDataClient class. This is resolved and normalized from the {@link MediaStoreDataClientConfig | constructor configuration interface}.
+ */
+export interface MediaStoreDataClientResolvedConfig extends MediaStoreDataClientResolvedConfigType {}
 
 /**
  * <p>An AWS Elemental MediaStore asset is an object, similar to an object in the Amazon S3
@@ -193,6 +201,9 @@ export class MediaStoreDataClient extends __Client<
   ServiceOutputTypes,
   MediaStoreDataClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaStoreDataClient class. This is resolved and normalized from the {@link MediaStoreDataClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaStoreDataClientResolvedConfig;
 
   constructor(configuration: MediaStoreDataClientConfig) {

--- a/clients/client-mediastore/MediaStoreClient.ts
+++ b/clients/client-mediastore/MediaStoreClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaStoreClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaStoreClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -229,8 +229,12 @@ export type MediaStoreClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaStoreClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaStoreClientConfig extends MediaStoreClientConfigType {}
 
-export type MediaStoreClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaStoreClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -238,6 +242,10 @@ export type MediaStoreClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaStoreClient class. This is resolved and normalized from the {@link MediaStoreClientConfig | constructor configuration interface}.
+ */
+export interface MediaStoreClientResolvedConfig extends MediaStoreClientResolvedConfigType {}
 
 /**
  * <p>An AWS Elemental MediaStore container is a namespace that holds folders and objects.
@@ -249,6 +257,9 @@ export class MediaStoreClient extends __Client<
   ServiceOutputTypes,
   MediaStoreClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaStoreClient class. This is resolved and normalized from the {@link MediaStoreClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaStoreClientResolvedConfig;
 
   constructor(configuration: MediaStoreClientConfig) {

--- a/clients/client-mediatailor/MediaTailorClient.ts
+++ b/clients/client-mediatailor/MediaTailorClient.ts
@@ -185,7 +185,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MediaTailorClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MediaTailorClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -193,8 +193,12 @@ export type MediaTailorClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MediaTailorClient class constructor that set the region, credentials and other options.
+ */
+export interface MediaTailorClientConfig extends MediaTailorClientConfigType {}
 
-export type MediaTailorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MediaTailorClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -202,6 +206,10 @@ export type MediaTailorClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MediaTailorClient class. This is resolved and normalized from the {@link MediaTailorClientConfig | constructor configuration interface}.
+ */
+export interface MediaTailorClientResolvedConfig extends MediaTailorClientResolvedConfigType {}
 
 /**
  * <p>Use the AWS Elemental MediaTailor SDK to configure scalable ad insertion for your live and VOD content. With AWS Elemental MediaTailor, you can serve targeted ads to viewers while maintaining broadcast quality in over-the-top (OTT) video applications. For information about using the service, including detailed information about the settings covered in this guide, see the AWS Elemental MediaTailor User Guide.<p>Through the SDK, you manage AWS Elemental MediaTailor configurations the same as you do through the console. For example, you specify ad insertion behavior and mapping information for the origin server and the ad decision server (ADS).</p>
@@ -212,6 +220,9 @@ export class MediaTailorClient extends __Client<
   ServiceOutputTypes,
   MediaTailorClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MediaTailorClient class. This is resolved and normalized from the {@link MediaTailorClientConfig | constructor configuration interface}.
+   */
   readonly config: MediaTailorClientResolvedConfig;
 
   constructor(configuration: MediaTailorClientConfig) {

--- a/clients/client-migration-hub/MigrationHubClient.ts
+++ b/clients/client-migration-hub/MigrationHubClient.ts
@@ -248,7 +248,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MigrationHubClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MigrationHubClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -256,8 +256,12 @@ export type MigrationHubClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MigrationHubClient class constructor that set the region, credentials and other options.
+ */
+export interface MigrationHubClientConfig extends MigrationHubClientConfigType {}
 
-export type MigrationHubClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MigrationHubClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -265,6 +269,10 @@ export type MigrationHubClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MigrationHubClient class. This is resolved and normalized from the {@link MigrationHubClientConfig | constructor configuration interface}.
+ */
+export interface MigrationHubClientResolvedConfig extends MigrationHubClientResolvedConfigType {}
 
 /**
  * <p>The AWS Migration Hub API methods help to obtain server and application migration status
@@ -280,6 +288,9 @@ export class MigrationHubClient extends __Client<
   ServiceOutputTypes,
   MigrationHubClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MigrationHubClient class. This is resolved and normalized from the {@link MigrationHubClientConfig | constructor configuration interface}.
+   */
   readonly config: MigrationHubClientResolvedConfig;
 
   constructor(configuration: MigrationHubClientConfig) {

--- a/clients/client-migrationhub-config/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/MigrationHubConfigClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MigrationHubConfigClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MigrationHubConfigClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -172,8 +172,12 @@ export type MigrationHubConfigClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MigrationHubConfigClient class constructor that set the region, credentials and other options.
+ */
+export interface MigrationHubConfigClientConfig extends MigrationHubConfigClientConfigType {}
 
-export type MigrationHubConfigClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MigrationHubConfigClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -181,6 +185,10 @@ export type MigrationHubConfigClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MigrationHubConfigClient class. This is resolved and normalized from the {@link MigrationHubConfigClientConfig | constructor configuration interface}.
+ */
+export interface MigrationHubConfigClientResolvedConfig extends MigrationHubConfigClientResolvedConfigType {}
 
 /**
  * <p>The AWS Migration Hub home region APIs are available specifically for working with your
@@ -216,6 +224,9 @@ export class MigrationHubConfigClient extends __Client<
   ServiceOutputTypes,
   MigrationHubConfigClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MigrationHubConfigClient class. This is resolved and normalized from the {@link MigrationHubConfigClientConfig | constructor configuration interface}.
+   */
   readonly config: MigrationHubConfigClientResolvedConfig;
 
   constructor(configuration: MigrationHubConfigClientConfig) {

--- a/clients/client-mobile/MobileClient.ts
+++ b/clients/client-mobile/MobileClient.ts
@@ -176,7 +176,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MobileClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MobileClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -184,8 +184,12 @@ export type MobileClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MobileClient class constructor that set the region, credentials and other options.
+ */
+export interface MobileClientConfig extends MobileClientConfigType {}
 
-export type MobileClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MobileClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -193,6 +197,10 @@ export type MobileClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MobileClient class. This is resolved and normalized from the {@link MobileClientConfig | constructor configuration interface}.
+ */
+export interface MobileClientResolvedConfig extends MobileClientResolvedConfigType {}
 
 /**
  * <p>
@@ -207,6 +215,9 @@ export class MobileClient extends __Client<
   ServiceOutputTypes,
   MobileClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MobileClient class. This is resolved and normalized from the {@link MobileClientConfig | constructor configuration interface}.
+   */
   readonly config: MobileClientResolvedConfig;
 
   constructor(configuration: MobileClientConfig) {

--- a/clients/client-mq/MqClient.ts
+++ b/clients/client-mq/MqClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MqClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MqClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -244,8 +244,12 @@ export type MqClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MqClient class constructor that set the region, credentials and other options.
+ */
+export interface MqClientConfig extends MqClientConfigType {}
 
-export type MqClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MqClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -253,6 +257,10 @@ export type MqClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandler
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MqClient class. This is resolved and normalized from the {@link MqClientConfig | constructor configuration interface}.
+ */
+export interface MqClientResolvedConfig extends MqClientResolvedConfigType {}
 
 /**
  * Amazon MQ is a managed message broker service for Apache ActiveMQ and RabbitMQ that makes it easy to set up and operate message brokers in the cloud. A message broker allows software applications and components to communicate using various programming languages, operating systems, and formal messaging protocols.
@@ -263,6 +271,9 @@ export class MqClient extends __Client<
   ServiceOutputTypes,
   MqClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MqClient class. This is resolved and normalized from the {@link MqClientConfig | constructor configuration interface}.
+   */
   readonly config: MqClientResolvedConfig;
 
   constructor(configuration: MqClientConfig) {

--- a/clients/client-mturk/MTurkClient.ts
+++ b/clients/client-mturk/MTurkClient.ts
@@ -329,7 +329,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MTurkClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MTurkClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -337,8 +337,12 @@ export type MTurkClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MTurkClient class constructor that set the region, credentials and other options.
+ */
+export interface MTurkClientConfig extends MTurkClientConfigType {}
 
-export type MTurkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MTurkClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -346,6 +350,10 @@ export type MTurkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MTurkClient class. This is resolved and normalized from the {@link MTurkClientConfig | constructor configuration interface}.
+ */
+export interface MTurkClientResolvedConfig extends MTurkClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Mechanical Turk API Reference</fullname>
@@ -356,6 +364,9 @@ export class MTurkClient extends __Client<
   ServiceOutputTypes,
   MTurkClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MTurkClient class. This is resolved and normalized from the {@link MTurkClientConfig | constructor configuration interface}.
+   */
   readonly config: MTurkClientResolvedConfig;
 
   constructor(configuration: MTurkClientConfig) {

--- a/clients/client-neptune/NeptuneClient.ts
+++ b/clients/client-neptune/NeptuneClient.ts
@@ -485,7 +485,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type NeptuneClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type NeptuneClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -493,8 +493,12 @@ export type NeptuneClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of NeptuneClient class constructor that set the region, credentials and other options.
+ */
+export interface NeptuneClientConfig extends NeptuneClientConfigType {}
 
-export type NeptuneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type NeptuneClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -502,6 +506,10 @@ export type NeptuneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of NeptuneClient class. This is resolved and normalized from the {@link NeptuneClientConfig | constructor configuration interface}.
+ */
+export interface NeptuneClientResolvedConfig extends NeptuneClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Neptune</fullname>
@@ -529,6 +537,9 @@ export class NeptuneClient extends __Client<
   ServiceOutputTypes,
   NeptuneClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of NeptuneClient class. This is resolved and normalized from the {@link NeptuneClientConfig | constructor configuration interface}.
+   */
   readonly config: NeptuneClientResolvedConfig;
 
   constructor(configuration: NeptuneClientConfig) {

--- a/clients/client-network-firewall/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/NetworkFirewallClient.ts
@@ -284,7 +284,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type NetworkFirewallClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type NetworkFirewallClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -292,8 +292,12 @@ export type NetworkFirewallClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of NetworkFirewallClient class constructor that set the region, credentials and other options.
+ */
+export interface NetworkFirewallClientConfig extends NetworkFirewallClientConfigType {}
 
-export type NetworkFirewallClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type NetworkFirewallClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -301,6 +305,10 @@ export type NetworkFirewallClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of NetworkFirewallClient class. This is resolved and normalized from the {@link NetworkFirewallClientConfig | constructor configuration interface}.
+ */
+export interface NetworkFirewallClientResolvedConfig extends NetworkFirewallClientResolvedConfigType {}
 
 /**
  * <p>This is the API Reference for AWS Network Firewall. This guide is for developers who need
@@ -390,6 +398,9 @@ export class NetworkFirewallClient extends __Client<
   ServiceOutputTypes,
   NetworkFirewallClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of NetworkFirewallClient class. This is resolved and normalized from the {@link NetworkFirewallClientConfig | constructor configuration interface}.
+   */
   readonly config: NetworkFirewallClientResolvedConfig;
 
   constructor(configuration: NetworkFirewallClientConfig) {

--- a/clients/client-networkmanager/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/NetworkManagerClient.ts
@@ -299,7 +299,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type NetworkManagerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type NetworkManagerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -307,8 +307,12 @@ export type NetworkManagerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of NetworkManagerClient class constructor that set the region, credentials and other options.
+ */
+export interface NetworkManagerClientConfig extends NetworkManagerClientConfigType {}
 
-export type NetworkManagerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type NetworkManagerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -316,6 +320,10 @@ export type NetworkManagerClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of NetworkManagerClient class. This is resolved and normalized from the {@link NetworkManagerClientConfig | constructor configuration interface}.
+ */
+export interface NetworkManagerClientResolvedConfig extends NetworkManagerClientResolvedConfigType {}
 
 /**
  * <p>Transit Gateway Network Manager (Network Manager) enables you to create a global network, in which you can monitor your
@@ -328,6 +336,9 @@ export class NetworkManagerClient extends __Client<
   ServiceOutputTypes,
   NetworkManagerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of NetworkManagerClient class. This is resolved and normalized from the {@link NetworkManagerClientConfig | constructor configuration interface}.
+   */
   readonly config: NetworkManagerClientResolvedConfig;
 
   constructor(configuration: NetworkManagerClientConfig) {

--- a/clients/client-opsworks/OpsWorksClient.ts
+++ b/clients/client-opsworks/OpsWorksClient.ts
@@ -449,7 +449,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type OpsWorksClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type OpsWorksClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -457,8 +457,12 @@ export type OpsWorksClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of OpsWorksClient class constructor that set the region, credentials and other options.
+ */
+export interface OpsWorksClientConfig extends OpsWorksClientConfigType {}
 
-export type OpsWorksClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type OpsWorksClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -466,6 +470,10 @@ export type OpsWorksClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of OpsWorksClient class. This is resolved and normalized from the {@link OpsWorksClientConfig | constructor configuration interface}.
+ */
+export interface OpsWorksClientResolvedConfig extends OpsWorksClientResolvedConfigType {}
 
 /**
  * <fullname>AWS OpsWorks</fullname>
@@ -590,6 +598,9 @@ export class OpsWorksClient extends __Client<
   ServiceOutputTypes,
   OpsWorksClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of OpsWorksClient class. This is resolved and normalized from the {@link OpsWorksClientConfig | constructor configuration interface}.
+   */
   readonly config: OpsWorksClientResolvedConfig;
 
   constructor(configuration: OpsWorksClientConfig) {

--- a/clients/client-opsworkscm/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/OpsWorksCMClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type OpsWorksCMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type OpsWorksCMClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -229,8 +229,12 @@ export type OpsWorksCMClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of OpsWorksCMClient class constructor that set the region, credentials and other options.
+ */
+export interface OpsWorksCMClientConfig extends OpsWorksCMClientConfigType {}
 
-export type OpsWorksCMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type OpsWorksCMClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -238,6 +242,10 @@ export type OpsWorksCMClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of OpsWorksCMClient class. This is resolved and normalized from the {@link OpsWorksCMClientConfig | constructor configuration interface}.
+ */
+export interface OpsWorksCMClientResolvedConfig extends OpsWorksCMClientResolvedConfigType {}
 
 /**
  * <fullname>AWS OpsWorks CM</fullname>
@@ -335,6 +343,9 @@ export class OpsWorksCMClient extends __Client<
   ServiceOutputTypes,
   OpsWorksCMClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of OpsWorksCMClient class. This is resolved and normalized from the {@link OpsWorksCMClientConfig | constructor configuration interface}.
+   */
   readonly config: OpsWorksCMClientResolvedConfig;
 
   constructor(configuration: OpsWorksCMClientConfig) {

--- a/clients/client-organizations/OrganizationsClient.ts
+++ b/clients/client-organizations/OrganizationsClient.ts
@@ -377,7 +377,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type OrganizationsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type OrganizationsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -385,8 +385,12 @@ export type OrganizationsClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of OrganizationsClient class constructor that set the region, credentials and other options.
+ */
+export interface OrganizationsClientConfig extends OrganizationsClientConfigType {}
 
-export type OrganizationsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type OrganizationsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -394,6 +398,10 @@ export type OrganizationsClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of OrganizationsClient class. This is resolved and normalized from the {@link OrganizationsClientConfig | constructor configuration interface}.
+ */
+export interface OrganizationsClientResolvedConfig extends OrganizationsClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Organizations</fullname>
@@ -404,6 +412,9 @@ export class OrganizationsClient extends __Client<
   ServiceOutputTypes,
   OrganizationsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of OrganizationsClient class. This is resolved and normalized from the {@link OrganizationsClientConfig | constructor configuration interface}.
+   */
   readonly config: OrganizationsClientResolvedConfig;
 
   constructor(configuration: OrganizationsClientConfig) {

--- a/clients/client-outposts/OutpostsClient.ts
+++ b/clients/client-outposts/OutpostsClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type OutpostsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type OutpostsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -181,8 +181,12 @@ export type OutpostsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of OutpostsClient class constructor that set the region, credentials and other options.
+ */
+export interface OutpostsClientConfig extends OutpostsClientConfigType {}
 
-export type OutpostsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type OutpostsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -190,6 +194,10 @@ export type OutpostsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of OutpostsClient class. This is resolved and normalized from the {@link OutpostsClientConfig | constructor configuration interface}.
+ */
+export interface OutpostsClientResolvedConfig extends OutpostsClientResolvedConfigType {}
 
 /**
  * <p>AWS Outposts is a fully-managed service that extends AWS infrastructure,
@@ -205,6 +213,9 @@ export class OutpostsClient extends __Client<
   ServiceOutputTypes,
   OutpostsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of OutpostsClient class. This is resolved and normalized from the {@link OutpostsClientConfig | constructor configuration interface}.
+   */
   readonly config: OutpostsClientResolvedConfig;
 
   constructor(configuration: OutpostsClientConfig) {

--- a/clients/client-personalize-events/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/PersonalizeEventsClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PersonalizeEventsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PersonalizeEventsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -160,8 +160,12 @@ export type PersonalizeEventsClientConfig = Partial<__SmithyConfiguration<__Http
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PersonalizeEventsClient class constructor that set the region, credentials and other options.
+ */
+export interface PersonalizeEventsClientConfig extends PersonalizeEventsClientConfigType {}
 
-export type PersonalizeEventsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PersonalizeEventsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -169,6 +173,10 @@ export type PersonalizeEventsClientResolvedConfig = __SmithyResolvedConfiguratio
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PersonalizeEventsClient class. This is resolved and normalized from the {@link PersonalizeEventsClientConfig | constructor configuration interface}.
+ */
+export interface PersonalizeEventsClientResolvedConfig extends PersonalizeEventsClientResolvedConfigType {}
 
 /**
  * <p>Amazon Personalize can consume real-time user event data, such as <i>stream</i> or <i>click</i> data, and use
@@ -180,6 +188,9 @@ export class PersonalizeEventsClient extends __Client<
   ServiceOutputTypes,
   PersonalizeEventsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PersonalizeEventsClient class. This is resolved and normalized from the {@link PersonalizeEventsClientConfig | constructor configuration interface}.
+   */
   readonly config: PersonalizeEventsClientResolvedConfig;
 
   constructor(configuration: PersonalizeEventsClientConfig) {

--- a/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
@@ -154,7 +154,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PersonalizeRuntimeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PersonalizeRuntimeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -162,8 +162,12 @@ export type PersonalizeRuntimeClientConfig = Partial<__SmithyConfiguration<__Htt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PersonalizeRuntimeClient class constructor that set the region, credentials and other options.
+ */
+export interface PersonalizeRuntimeClientConfig extends PersonalizeRuntimeClientConfigType {}
 
-export type PersonalizeRuntimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PersonalizeRuntimeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -171,6 +175,10 @@ export type PersonalizeRuntimeClientResolvedConfig = __SmithyResolvedConfigurati
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PersonalizeRuntimeClient class. This is resolved and normalized from the {@link PersonalizeRuntimeClientConfig | constructor configuration interface}.
+ */
+export interface PersonalizeRuntimeClientResolvedConfig extends PersonalizeRuntimeClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -181,6 +189,9 @@ export class PersonalizeRuntimeClient extends __Client<
   ServiceOutputTypes,
   PersonalizeRuntimeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PersonalizeRuntimeClient class. This is resolved and normalized from the {@link PersonalizeRuntimeClientConfig | constructor configuration interface}.
+   */
   readonly config: PersonalizeRuntimeClientResolvedConfig;
 
   constructor(configuration: PersonalizeRuntimeClientConfig) {

--- a/clients/client-personalize/PersonalizeClient.ts
+++ b/clients/client-personalize/PersonalizeClient.ts
@@ -314,7 +314,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PersonalizeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PersonalizeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -322,8 +322,12 @@ export type PersonalizeClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PersonalizeClient class constructor that set the region, credentials and other options.
+ */
+export interface PersonalizeClientConfig extends PersonalizeClientConfigType {}
 
-export type PersonalizeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PersonalizeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -331,6 +335,10 @@ export type PersonalizeClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PersonalizeClient class. This is resolved and normalized from the {@link PersonalizeClientConfig | constructor configuration interface}.
+ */
+export interface PersonalizeClientResolvedConfig extends PersonalizeClientResolvedConfigType {}
 
 /**
  * <p>Amazon Personalize is a machine learning service that makes it easy to add individualized
@@ -342,6 +350,9 @@ export class PersonalizeClient extends __Client<
   ServiceOutputTypes,
   PersonalizeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PersonalizeClient class. This is resolved and normalized from the {@link PersonalizeClientConfig | constructor configuration interface}.
+   */
   readonly config: PersonalizeClientResolvedConfig;
 
   constructor(configuration: PersonalizeClientConfig) {

--- a/clients/client-pi/PIClient.ts
+++ b/clients/client-pi/PIClient.ts
@@ -154,7 +154,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PIClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PIClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -162,8 +162,12 @@ export type PIClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PIClient class constructor that set the region, credentials and other options.
+ */
+export interface PIClientConfig extends PIClientConfigType {}
 
-export type PIClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PIClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -171,6 +175,10 @@ export type PIClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandler
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PIClient class. This is resolved and normalized from the {@link PIClientConfig | constructor configuration interface}.
+ */
+export interface PIClientResolvedConfig extends PIClientResolvedConfigType {}
 
 /**
  * <p>AWS Performance Insights enables you to monitor and explore different dimensions of
@@ -194,6 +202,9 @@ export class PIClient extends __Client<
   ServiceOutputTypes,
   PIClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PIClient class. This is resolved and normalized from the {@link PIClientConfig | constructor configuration interface}.
+   */
   readonly config: PIClientResolvedConfig;
 
   constructor(configuration: PIClientConfig) {

--- a/clients/client-pinpoint-email/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/PinpointEmailClient.ts
@@ -380,7 +380,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PinpointEmailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PinpointEmailClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -388,8 +388,12 @@ export type PinpointEmailClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PinpointEmailClient class constructor that set the region, credentials and other options.
+ */
+export interface PinpointEmailClientConfig extends PinpointEmailClientConfigType {}
 
-export type PinpointEmailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PinpointEmailClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -397,6 +401,10 @@ export type PinpointEmailClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PinpointEmailClient class. This is resolved and normalized from the {@link PinpointEmailClientConfig | constructor configuration interface}.
+ */
+export interface PinpointEmailClientResolvedConfig extends PinpointEmailClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Pinpoint Email Service</fullname>
@@ -435,6 +443,9 @@ export class PinpointEmailClient extends __Client<
   ServiceOutputTypes,
   PinpointEmailClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PinpointEmailClient class. This is resolved and normalized from the {@link PinpointEmailClientConfig | constructor configuration interface}.
+   */
   readonly config: PinpointEmailClientResolvedConfig;
 
   constructor(configuration: PinpointEmailClientConfig) {

--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PinpointSMSVoiceClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PinpointSMSVoiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -202,8 +202,12 @@ export type PinpointSMSVoiceClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PinpointSMSVoiceClient class constructor that set the region, credentials and other options.
+ */
+export interface PinpointSMSVoiceClientConfig extends PinpointSMSVoiceClientConfigType {}
 
-export type PinpointSMSVoiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PinpointSMSVoiceClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -211,6 +215,10 @@ export type PinpointSMSVoiceClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PinpointSMSVoiceClient class. This is resolved and normalized from the {@link PinpointSMSVoiceClientConfig | constructor configuration interface}.
+ */
+export interface PinpointSMSVoiceClientResolvedConfig extends PinpointSMSVoiceClientResolvedConfigType {}
 
 /**
  * Pinpoint SMS and Voice Messaging public facing APIs
@@ -221,6 +229,9 @@ export class PinpointSMSVoiceClient extends __Client<
   ServiceOutputTypes,
   PinpointSMSVoiceClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PinpointSMSVoiceClient class. This is resolved and normalized from the {@link PinpointSMSVoiceClientConfig | constructor configuration interface}.
+   */
   readonly config: PinpointSMSVoiceClientResolvedConfig;
 
   constructor(configuration: PinpointSMSVoiceClientConfig) {

--- a/clients/client-pinpoint/PinpointClient.ts
+++ b/clients/client-pinpoint/PinpointClient.ts
@@ -593,7 +593,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PinpointClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PinpointClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -601,8 +601,12 @@ export type PinpointClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PinpointClient class constructor that set the region, credentials and other options.
+ */
+export interface PinpointClientConfig extends PinpointClientConfigType {}
 
-export type PinpointClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PinpointClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -610,6 +614,10 @@ export type PinpointClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PinpointClient class. This is resolved and normalized from the {@link PinpointClientConfig | constructor configuration interface}.
+ */
+export interface PinpointClientResolvedConfig extends PinpointClientResolvedConfigType {}
 
 /**
  * <p>Doc Engage API - Amazon Pinpoint API</p>
@@ -620,6 +628,9 @@ export class PinpointClient extends __Client<
   ServiceOutputTypes,
   PinpointClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PinpointClient class. This is resolved and normalized from the {@link PinpointClientConfig | constructor configuration interface}.
+   */
   readonly config: PinpointClientResolvedConfig;
 
   constructor(configuration: PinpointClientConfig) {

--- a/clients/client-polly/PollyClient.ts
+++ b/clients/client-polly/PollyClient.ts
@@ -185,7 +185,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PollyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PollyClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -193,8 +193,12 @@ export type PollyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PollyClient class constructor that set the region, credentials and other options.
+ */
+export interface PollyClientConfig extends PollyClientConfigType {}
 
-export type PollyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PollyClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -202,6 +206,10 @@ export type PollyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PollyClient class. This is resolved and normalized from the {@link PollyClientConfig | constructor configuration interface}.
+ */
+export interface PollyClientResolvedConfig extends PollyClientResolvedConfigType {}
 
 /**
  * <p>Amazon Polly is a web service that makes it easy to synthesize speech from
@@ -217,6 +225,9 @@ export class PollyClient extends __Client<
   ServiceOutputTypes,
   PollyClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PollyClient class. This is resolved and normalized from the {@link PollyClientConfig | constructor configuration interface}.
+   */
   readonly config: PollyClientResolvedConfig;
 
   constructor(configuration: PollyClientConfig) {

--- a/clients/client-pricing/PricingClient.ts
+++ b/clients/client-pricing/PricingClient.ts
@@ -155,7 +155,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type PricingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type PricingClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -163,8 +163,12 @@ export type PricingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of PricingClient class constructor that set the region, credentials and other options.
+ */
+export interface PricingClientConfig extends PricingClientConfigType {}
 
-export type PricingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type PricingClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -172,6 +176,10 @@ export type PricingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of PricingClient class. This is resolved and normalized from the {@link PricingClientConfig | constructor configuration interface}.
+ */
+export interface PricingClientResolvedConfig extends PricingClientResolvedConfigType {}
 
 /**
  * <p>AWS Price List Service API (AWS Price List Service) is a centralized and convenient way to
@@ -205,6 +213,9 @@ export class PricingClient extends __Client<
   ServiceOutputTypes,
   PricingClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of PricingClient class. This is resolved and normalized from the {@link PricingClientConfig | constructor configuration interface}.
+   */
   readonly config: PricingClientResolvedConfig;
 
   constructor(configuration: PricingClientConfig) {

--- a/clients/client-qldb-session/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/QLDBSessionClient.ts
@@ -150,7 +150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type QLDBSessionClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type QLDBSessionClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -158,8 +158,12 @@ export type QLDBSessionClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of QLDBSessionClient class constructor that set the region, credentials and other options.
+ */
+export interface QLDBSessionClientConfig extends QLDBSessionClientConfigType {}
 
-export type QLDBSessionClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type QLDBSessionClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -167,6 +171,10 @@ export type QLDBSessionClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of QLDBSessionClient class. This is resolved and normalized from the {@link QLDBSessionClientConfig | constructor configuration interface}.
+ */
+export interface QLDBSessionClientResolvedConfig extends QLDBSessionClientResolvedConfigType {}
 
 /**
  * <p>The transactional data APIs for Amazon QLDB</p>
@@ -197,6 +205,9 @@ export class QLDBSessionClient extends __Client<
   ServiceOutputTypes,
   QLDBSessionClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of QLDBSessionClient class. This is resolved and normalized from the {@link QLDBSessionClientConfig | constructor configuration interface}.
+   */
   readonly config: QLDBSessionClientResolvedConfig;
 
   constructor(configuration: QLDBSessionClientConfig) {

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type QLDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type QLDBClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -238,8 +238,12 @@ export type QLDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOption
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of QLDBClient class constructor that set the region, credentials and other options.
+ */
+export interface QLDBClientConfig extends QLDBClientConfigType {}
 
-export type QLDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type QLDBClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -247,6 +251,10 @@ export type QLDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandl
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of QLDBClient class. This is resolved and normalized from the {@link QLDBClientConfig | constructor configuration interface}.
+ */
+export interface QLDBClientResolvedConfig extends QLDBClientResolvedConfigType {}
 
 /**
  * <p>The control plane for Amazon QLDB</p>
@@ -257,6 +265,9 @@ export class QLDBClient extends __Client<
   ServiceOutputTypes,
   QLDBClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of QLDBClient class. This is resolved and normalized from the {@link QLDBClientConfig | constructor configuration interface}.
+   */
   readonly config: QLDBClientResolvedConfig;
 
   constructor(configuration: QLDBClientConfig) {

--- a/clients/client-quicksight/QuickSightClient.ts
+++ b/clients/client-quicksight/QuickSightClient.ts
@@ -560,7 +560,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type QuickSightClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type QuickSightClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -568,8 +568,12 @@ export type QuickSightClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of QuickSightClient class constructor that set the region, credentials and other options.
+ */
+export interface QuickSightClientConfig extends QuickSightClientConfigType {}
 
-export type QuickSightClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type QuickSightClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -577,6 +581,10 @@ export type QuickSightClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of QuickSightClient class. This is resolved and normalized from the {@link QuickSightClientConfig | constructor configuration interface}.
+ */
+export interface QuickSightClientResolvedConfig extends QuickSightClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon QuickSight API Reference</fullname>
@@ -591,6 +599,9 @@ export class QuickSightClient extends __Client<
   ServiceOutputTypes,
   QuickSightClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of QuickSightClient class. This is resolved and normalized from the {@link QuickSightClientConfig | constructor configuration interface}.
+   */
   readonly config: QuickSightClientResolvedConfig;
 
   constructor(configuration: QuickSightClientConfig) {

--- a/clients/client-ram/RAMClient.ts
+++ b/clients/client-ram/RAMClient.ts
@@ -269,7 +269,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RAMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RAMClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -277,8 +277,12 @@ export type RAMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RAMClient class constructor that set the region, credentials and other options.
+ */
+export interface RAMClientConfig extends RAMClientConfigType {}
 
-export type RAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RAMClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -286,6 +290,10 @@ export type RAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RAMClient class. This is resolved and normalized from the {@link RAMClientConfig | constructor configuration interface}.
+ */
+export interface RAMClientResolvedConfig extends RAMClientResolvedConfigType {}
 
 /**
  * <p>Use AWS Resource Access Manager to share AWS resources between AWS accounts. To share a resource, you
@@ -301,6 +309,9 @@ export class RAMClient extends __Client<
   ServiceOutputTypes,
   RAMClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RAMClient class. This is resolved and normalized from the {@link RAMClientConfig | constructor configuration interface}.
+   */
   readonly config: RAMClientResolvedConfig;
 
   constructor(configuration: RAMClientConfig) {

--- a/clients/client-rds-data/RDSDataClient.ts
+++ b/clients/client-rds-data/RDSDataClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RDSDataClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RDSDataClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -181,8 +181,12 @@ export type RDSDataClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RDSDataClient class constructor that set the region, credentials and other options.
+ */
+export interface RDSDataClientConfig extends RDSDataClientConfigType {}
 
-export type RDSDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RDSDataClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -190,6 +194,10 @@ export type RDSDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RDSDataClient class. This is resolved and normalized from the {@link RDSDataClientConfig | constructor configuration interface}.
+ */
+export interface RDSDataClientResolvedConfig extends RDSDataClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon RDS Data Service</fullname>
@@ -209,6 +217,9 @@ export class RDSDataClient extends __Client<
   ServiceOutputTypes,
   RDSDataClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RDSDataClient class. This is resolved and normalized from the {@link RDSDataClientConfig | constructor configuration interface}.
+   */
   readonly config: RDSDataClientResolvedConfig;
 
   constructor(configuration: RDSDataClientConfig) {

--- a/clients/client-rds/RDSClient.ts
+++ b/clients/client-rds/RDSClient.ts
@@ -836,7 +836,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RDSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RDSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -844,8 +844,12 @@ export type RDSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RDSClient class constructor that set the region, credentials and other options.
+ */
+export interface RDSClientConfig extends RDSClientConfigType {}
 
-export type RDSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RDSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -853,6 +857,10 @@ export type RDSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RDSClient class. This is resolved and normalized from the {@link RDSClientConfig | constructor configuration interface}.
+ */
+export interface RDSClientResolvedConfig extends RDSClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Relational Database Service</fullname>
@@ -919,6 +927,9 @@ export class RDSClient extends __Client<
   ServiceOutputTypes,
   RDSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RDSClient class. This is resolved and normalized from the {@link RDSClientConfig | constructor configuration interface}.
+   */
   readonly config: RDSClientResolvedConfig;
 
   constructor(configuration: RDSClientConfig) {

--- a/clients/client-redshift-data/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/RedshiftDataClient.ts
@@ -176,7 +176,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RedshiftDataClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RedshiftDataClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -184,8 +184,12 @@ export type RedshiftDataClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RedshiftDataClient class constructor that set the region, credentials and other options.
+ */
+export interface RedshiftDataClientConfig extends RedshiftDataClientConfigType {}
 
-export type RedshiftDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RedshiftDataClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -193,6 +197,10 @@ export type RedshiftDataClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RedshiftDataClient class. This is resolved and normalized from the {@link RedshiftDataClientConfig | constructor configuration interface}.
+ */
+export interface RedshiftDataClientResolvedConfig extends RedshiftDataClientResolvedConfigType {}
 
 /**
  * <p>You can use the Amazon Redshift Data API to run queries on Amazon Redshift tables. You
@@ -204,6 +212,9 @@ export class RedshiftDataClient extends __Client<
   ServiceOutputTypes,
   RedshiftDataClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RedshiftDataClient class. This is resolved and normalized from the {@link RedshiftDataClientConfig | constructor configuration interface}.
+   */
   readonly config: RedshiftDataClientResolvedConfig;
 
   constructor(configuration: RedshiftDataClientConfig) {

--- a/clients/client-redshift/RedshiftClient.ts
+++ b/clients/client-redshift/RedshiftClient.ts
@@ -638,7 +638,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RedshiftClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RedshiftClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -646,8 +646,12 @@ export type RedshiftClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RedshiftClient class constructor that set the region, credentials and other options.
+ */
+export interface RedshiftClientConfig extends RedshiftClientConfigType {}
 
-export type RedshiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RedshiftClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -655,6 +659,10 @@ export type RedshiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RedshiftClient class. This is resolved and normalized from the {@link RedshiftClientConfig | constructor configuration interface}.
+ */
+export interface RedshiftClientResolvedConfig extends RedshiftClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Redshift</fullname>
@@ -686,6 +694,9 @@ export class RedshiftClient extends __Client<
   ServiceOutputTypes,
   RedshiftClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RedshiftClient class. This is resolved and normalized from the {@link RedshiftClientConfig | constructor configuration interface}.
+   */
   readonly config: RedshiftClientResolvedConfig;
 
   constructor(configuration: RedshiftClientConfig) {

--- a/clients/client-rekognition/RekognitionClient.ts
+++ b/clients/client-rekognition/RekognitionClient.ts
@@ -356,7 +356,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RekognitionClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RekognitionClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -364,8 +364,12 @@ export type RekognitionClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RekognitionClient class constructor that set the region, credentials and other options.
+ */
+export interface RekognitionClientConfig extends RekognitionClientConfigType {}
 
-export type RekognitionClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RekognitionClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -373,6 +377,10 @@ export type RekognitionClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RekognitionClient class. This is resolved and normalized from the {@link RekognitionClientConfig | constructor configuration interface}.
+ */
+export interface RekognitionClientResolvedConfig extends RekognitionClientResolvedConfigType {}
 
 /**
  * <p>This is the Amazon Rekognition API reference.</p>
@@ -383,6 +391,9 @@ export class RekognitionClient extends __Client<
   ServiceOutputTypes,
   RekognitionClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RekognitionClient class. This is resolved and normalized from the {@link RekognitionClientConfig | constructor configuration interface}.
+   */
   readonly config: RekognitionClientResolvedConfig;
 
   constructor(configuration: RekognitionClientConfig) {

--- a/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
@@ -182,7 +182,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ResourceGroupsTaggingAPIClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ResourceGroupsTaggingAPIClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -190,8 +190,12 @@ export type ResourceGroupsTaggingAPIClientConfig = Partial<__SmithyConfiguration
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ResourceGroupsTaggingAPIClient class constructor that set the region, credentials and other options.
+ */
+export interface ResourceGroupsTaggingAPIClientConfig extends ResourceGroupsTaggingAPIClientConfigType {}
 
-export type ResourceGroupsTaggingAPIClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ResourceGroupsTaggingAPIClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -199,6 +203,11 @@ export type ResourceGroupsTaggingAPIClientResolvedConfig = __SmithyResolvedConfi
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ResourceGroupsTaggingAPIClient class. This is resolved and normalized from the {@link ResourceGroupsTaggingAPIClientConfig | constructor configuration interface}.
+ */
+export interface ResourceGroupsTaggingAPIClientResolvedConfig
+  extends ResourceGroupsTaggingAPIClientResolvedConfigType {}
 
 /**
  * <fullname>Resource Groups Tagging API</fullname>
@@ -965,6 +974,9 @@ export class ResourceGroupsTaggingAPIClient extends __Client<
   ServiceOutputTypes,
   ResourceGroupsTaggingAPIClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ResourceGroupsTaggingAPIClient class. This is resolved and normalized from the {@link ResourceGroupsTaggingAPIClientConfig | constructor configuration interface}.
+   */
   readonly config: ResourceGroupsTaggingAPIClientResolvedConfig;
 
   constructor(configuration: ResourceGroupsTaggingAPIClientConfig) {

--- a/clients/client-resource-groups/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/ResourceGroupsClient.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ResourceGroupsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ResourceGroupsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -205,8 +205,12 @@ export type ResourceGroupsClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ResourceGroupsClient class constructor that set the region, credentials and other options.
+ */
+export interface ResourceGroupsClientConfig extends ResourceGroupsClientConfigType {}
 
-export type ResourceGroupsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ResourceGroupsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -214,6 +218,10 @@ export type ResourceGroupsClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ResourceGroupsClient class. This is resolved and normalized from the {@link ResourceGroupsClientConfig | constructor configuration interface}.
+ */
+export interface ResourceGroupsClientResolvedConfig extends ResourceGroupsClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Resource Groups</fullname>
@@ -259,6 +267,9 @@ export class ResourceGroupsClient extends __Client<
   ServiceOutputTypes,
   ResourceGroupsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ResourceGroupsClient class. This is resolved and normalized from the {@link ResourceGroupsClientConfig | constructor configuration interface}.
+   */
   readonly config: ResourceGroupsClientResolvedConfig;
 
   constructor(configuration: ResourceGroupsClientConfig) {

--- a/clients/client-robomaker/RoboMakerClient.ts
+++ b/clients/client-robomaker/RoboMakerClient.ts
@@ -434,7 +434,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RoboMakerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RoboMakerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -442,8 +442,12 @@ export type RoboMakerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RoboMakerClient class constructor that set the region, credentials and other options.
+ */
+export interface RoboMakerClientConfig extends RoboMakerClientConfigType {}
 
-export type RoboMakerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RoboMakerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -451,6 +455,10 @@ export type RoboMakerClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RoboMakerClient class. This is resolved and normalized from the {@link RoboMakerClientConfig | constructor configuration interface}.
+ */
+export interface RoboMakerClientResolvedConfig extends RoboMakerClientResolvedConfigType {}
 
 /**
  * <p>This section provides documentation for the AWS RoboMaker API operations.</p>
@@ -461,6 +469,9 @@ export class RoboMakerClient extends __Client<
   ServiceOutputTypes,
   RoboMakerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RoboMakerClient class. This is resolved and normalized from the {@link RoboMakerClientConfig | constructor configuration interface}.
+   */
   readonly config: RoboMakerClientResolvedConfig;
 
   constructor(configuration: RoboMakerClientConfig) {

--- a/clients/client-route-53-domains/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/Route53DomainsClient.ts
@@ -290,7 +290,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type Route53DomainsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type Route53DomainsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -298,8 +298,12 @@ export type Route53DomainsClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of Route53DomainsClient class constructor that set the region, credentials and other options.
+ */
+export interface Route53DomainsClientConfig extends Route53DomainsClientConfigType {}
 
-export type Route53DomainsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type Route53DomainsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -307,6 +311,10 @@ export type Route53DomainsClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of Route53DomainsClient class. This is resolved and normalized from the {@link Route53DomainsClientConfig | constructor configuration interface}.
+ */
+export interface Route53DomainsClientResolvedConfig extends Route53DomainsClientResolvedConfigType {}
 
 /**
  * <p>Amazon Route 53 API actions let you register domain names and perform related operations.</p>
@@ -317,6 +325,9 @@ export class Route53DomainsClient extends __Client<
   ServiceOutputTypes,
   Route53DomainsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of Route53DomainsClient class. This is resolved and normalized from the {@link Route53DomainsClientConfig | constructor configuration interface}.
+   */
   readonly config: Route53DomainsClientResolvedConfig;
 
   constructor(configuration: Route53DomainsClientConfig) {

--- a/clients/client-route-53/Route53Client.ts
+++ b/clients/client-route-53/Route53Client.ts
@@ -437,7 +437,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type Route53ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type Route53ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -445,8 +445,12 @@ export type Route53ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of Route53Client class constructor that set the region, credentials and other options.
+ */
+export interface Route53ClientConfig extends Route53ClientConfigType {}
 
-export type Route53ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type Route53ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -454,6 +458,10 @@ export type Route53ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of Route53Client class. This is resolved and normalized from the {@link Route53ClientConfig | constructor configuration interface}.
+ */
+export interface Route53ClientResolvedConfig extends Route53ClientResolvedConfigType {}
 
 /**
  * <p>Amazon Route 53 is a highly available and scalable Domain Name System (DNS) web service.</p>
@@ -464,6 +472,9 @@ export class Route53Client extends __Client<
   ServiceOutputTypes,
   Route53ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of Route53Client class. This is resolved and normalized from the {@link Route53ClientConfig | constructor configuration interface}.
+   */
   readonly config: Route53ClientResolvedConfig;
 
   constructor(configuration: Route53ClientConfig) {

--- a/clients/client-route53resolver/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/Route53ResolverClient.ts
@@ -320,7 +320,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type Route53ResolverClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type Route53ResolverClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -328,8 +328,12 @@ export type Route53ResolverClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of Route53ResolverClient class constructor that set the region, credentials and other options.
+ */
+export interface Route53ResolverClientConfig extends Route53ResolverClientConfigType {}
 
-export type Route53ResolverClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type Route53ResolverClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -337,6 +341,10 @@ export type Route53ResolverClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of Route53ResolverClient class. This is resolved and normalized from the {@link Route53ResolverClientConfig | constructor configuration interface}.
+ */
+export interface Route53ResolverClientResolvedConfig extends Route53ResolverClientResolvedConfigType {}
 
 /**
  * <p>When you create a VPC using Amazon VPC, you automatically get DNS resolution within the VPC from Route 53 Resolver.
@@ -376,6 +384,9 @@ export class Route53ResolverClient extends __Client<
   ServiceOutputTypes,
   Route53ResolverClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of Route53ResolverClient class. This is resolved and normalized from the {@link Route53ResolverClientConfig | constructor configuration interface}.
+   */
   readonly config: Route53ResolverClientResolvedConfig;
 
   constructor(configuration: Route53ResolverClientConfig) {

--- a/clients/client-s3-control/S3ControlClient.ts
+++ b/clients/client-s3-control/S3ControlClient.ts
@@ -328,7 +328,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type S3ControlClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type S3ControlClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -337,8 +337,12 @@ export type S3ControlClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   S3ControlInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of S3ControlClient class constructor that set the region, credentials and other options.
+ */
+export interface S3ControlClientConfig extends S3ControlClientConfigType {}
 
-export type S3ControlClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type S3ControlClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -347,6 +351,10 @@ export type S3ControlClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   S3ControlResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of S3ControlClient class. This is resolved and normalized from the {@link S3ControlClientConfig | constructor configuration interface}.
+ */
+export interface S3ControlClientResolvedConfig extends S3ControlClientResolvedConfigType {}
 
 /**
  * <p>
@@ -360,6 +368,9 @@ export class S3ControlClient extends __Client<
   ServiceOutputTypes,
   S3ControlClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of S3ControlClient class. This is resolved and normalized from the {@link S3ControlClientConfig | constructor configuration interface}.
+   */
   readonly config: S3ControlClientResolvedConfig;
 
   constructor(configuration: S3ControlClientConfig) {

--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -613,7 +613,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   eventStreamSerdeProvider?: __EventStreamSerdeProvider;
 }
 
-export type S3ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type S3ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -623,8 +623,12 @@ export type S3ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>
   BucketEndpointInputConfig &
   UserAgentInputConfig &
   EventStreamSerdeInputConfig;
+/**
+ * The configuration interface of S3Client class constructor that set the region, credentials and other options.
+ */
+export interface S3ClientConfig extends S3ClientConfigType {}
 
-export type S3ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type S3ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -634,6 +638,10 @@ export type S3ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandler
   BucketEndpointResolvedConfig &
   UserAgentResolvedConfig &
   EventStreamSerdeResolvedConfig;
+/**
+ * The resolved configuration interface of S3Client class. This is resolved and normalized from the {@link S3ClientConfig | constructor configuration interface}.
+ */
+export interface S3ClientResolvedConfig extends S3ClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -644,6 +652,9 @@ export class S3Client extends __Client<
   ServiceOutputTypes,
   S3ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of S3Client class. This is resolved and normalized from the {@link S3ClientConfig | constructor configuration interface}.
+   */
   readonly config: S3ClientResolvedConfig;
 
   constructor(configuration: S3ClientConfig) {

--- a/clients/client-s3outposts/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/S3OutpostsClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type S3OutpostsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type S3OutpostsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -160,8 +160,12 @@ export type S3OutpostsClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of S3OutpostsClient class constructor that set the region, credentials and other options.
+ */
+export interface S3OutpostsClientConfig extends S3OutpostsClientConfigType {}
 
-export type S3OutpostsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type S3OutpostsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -169,6 +173,10 @@ export type S3OutpostsClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of S3OutpostsClient class. This is resolved and normalized from the {@link S3OutpostsClientConfig | constructor configuration interface}.
+ */
+export interface S3OutpostsClientResolvedConfig extends S3OutpostsClientResolvedConfigType {}
 
 /**
  * <p>Amazon S3 on Outposts provides access to S3 on Outposts operations.</p>
@@ -179,6 +187,9 @@ export class S3OutpostsClient extends __Client<
   ServiceOutputTypes,
   S3OutpostsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of S3OutpostsClient class. This is resolved and normalized from the {@link S3OutpostsClientConfig | constructor configuration interface}.
+   */
   readonly config: S3OutpostsClientResolvedConfig;
 
   constructor(configuration: S3OutpostsClientConfig) {

--- a/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SageMakerA2IRuntimeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SageMakerA2IRuntimeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -172,8 +172,12 @@ export type SageMakerA2IRuntimeClientConfig = Partial<__SmithyConfiguration<__Ht
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SageMakerA2IRuntimeClient class constructor that set the region, credentials and other options.
+ */
+export interface SageMakerA2IRuntimeClientConfig extends SageMakerA2IRuntimeClientConfigType {}
 
-export type SageMakerA2IRuntimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SageMakerA2IRuntimeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -181,6 +185,10 @@ export type SageMakerA2IRuntimeClientResolvedConfig = __SmithyResolvedConfigurat
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SageMakerA2IRuntimeClient class. This is resolved and normalized from the {@link SageMakerA2IRuntimeClientConfig | constructor configuration interface}.
+ */
+export interface SageMakerA2IRuntimeClientResolvedConfig extends SageMakerA2IRuntimeClientResolvedConfigType {}
 
 /**
  * <important>
@@ -220,6 +228,9 @@ export class SageMakerA2IRuntimeClient extends __Client<
   ServiceOutputTypes,
   SageMakerA2IRuntimeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SageMakerA2IRuntimeClient class. This is resolved and normalized from the {@link SageMakerA2IRuntimeClientConfig | constructor configuration interface}.
+   */
   readonly config: SageMakerA2IRuntimeClientResolvedConfig;
 
   constructor(configuration: SageMakerA2IRuntimeClientConfig) {

--- a/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
@@ -154,7 +154,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SagemakerEdgeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SagemakerEdgeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -162,8 +162,12 @@ export type SagemakerEdgeClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SagemakerEdgeClient class constructor that set the region, credentials and other options.
+ */
+export interface SagemakerEdgeClientConfig extends SagemakerEdgeClientConfigType {}
 
-export type SagemakerEdgeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SagemakerEdgeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -171,6 +175,10 @@ export type SagemakerEdgeClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SagemakerEdgeClient class. This is resolved and normalized from the {@link SagemakerEdgeClientConfig | constructor configuration interface}.
+ */
+export interface SagemakerEdgeClientResolvedConfig extends SagemakerEdgeClientResolvedConfigType {}
 
 /**
  * <p>SageMaker Edge Manager dataplane service for communicating with active agents.</p>
@@ -181,6 +189,9 @@ export class SagemakerEdgeClient extends __Client<
   ServiceOutputTypes,
   SagemakerEdgeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SagemakerEdgeClient class. This is resolved and normalized from the {@link SagemakerEdgeClientConfig | constructor configuration interface}.
+   */
   readonly config: SagemakerEdgeClientResolvedConfig;
 
   constructor(configuration: SagemakerEdgeClientConfig) {

--- a/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SageMakerFeatureStoreRuntimeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SageMakerFeatureStoreRuntimeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -160,8 +160,12 @@ export type SageMakerFeatureStoreRuntimeClientConfig = Partial<__SmithyConfigura
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SageMakerFeatureStoreRuntimeClient class constructor that set the region, credentials and other options.
+ */
+export interface SageMakerFeatureStoreRuntimeClientConfig extends SageMakerFeatureStoreRuntimeClientConfigType {}
 
-export type SageMakerFeatureStoreRuntimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SageMakerFeatureStoreRuntimeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -169,6 +173,11 @@ export type SageMakerFeatureStoreRuntimeClientResolvedConfig = __SmithyResolvedC
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SageMakerFeatureStoreRuntimeClient class. This is resolved and normalized from the {@link SageMakerFeatureStoreRuntimeClientConfig | constructor configuration interface}.
+ */
+export interface SageMakerFeatureStoreRuntimeClientResolvedConfig
+  extends SageMakerFeatureStoreRuntimeClientResolvedConfigType {}
 
 /**
  * <p>Contains all data plane API operations and data types for the Amazon SageMaker Feature
@@ -205,6 +214,9 @@ export class SageMakerFeatureStoreRuntimeClient extends __Client<
   ServiceOutputTypes,
   SageMakerFeatureStoreRuntimeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SageMakerFeatureStoreRuntimeClient class. This is resolved and normalized from the {@link SageMakerFeatureStoreRuntimeClientConfig | constructor configuration interface}.
+   */
   readonly config: SageMakerFeatureStoreRuntimeClientResolvedConfig;
 
   constructor(configuration: SageMakerFeatureStoreRuntimeClientConfig) {

--- a/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
@@ -150,7 +150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SageMakerRuntimeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SageMakerRuntimeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -158,8 +158,12 @@ export type SageMakerRuntimeClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SageMakerRuntimeClient class constructor that set the region, credentials and other options.
+ */
+export interface SageMakerRuntimeClientConfig extends SageMakerRuntimeClientConfigType {}
 
-export type SageMakerRuntimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SageMakerRuntimeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -167,6 +171,10 @@ export type SageMakerRuntimeClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SageMakerRuntimeClient class. This is resolved and normalized from the {@link SageMakerRuntimeClientConfig | constructor configuration interface}.
+ */
+export interface SageMakerRuntimeClientResolvedConfig extends SageMakerRuntimeClientResolvedConfigType {}
 
 /**
  * <p> The Amazon SageMaker runtime API. </p>
@@ -177,6 +185,9 @@ export class SageMakerRuntimeClient extends __Client<
   ServiceOutputTypes,
   SageMakerRuntimeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SageMakerRuntimeClient class. This is resolved and normalized from the {@link SageMakerRuntimeClientConfig | constructor configuration interface}.
+   */
   readonly config: SageMakerRuntimeClientResolvedConfig;
 
   constructor(configuration: SageMakerRuntimeClientConfig) {

--- a/clients/client-sagemaker/SageMakerClient.ts
+++ b/clients/client-sagemaker/SageMakerClient.ts
@@ -1181,7 +1181,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SageMakerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SageMakerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -1189,8 +1189,12 @@ export type SageMakerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SageMakerClient class constructor that set the region, credentials and other options.
+ */
+export interface SageMakerClientConfig extends SageMakerClientConfigType {}
 
-export type SageMakerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SageMakerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -1198,6 +1202,10 @@ export type SageMakerClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SageMakerClient class. This is resolved and normalized from the {@link SageMakerClientConfig | constructor configuration interface}.
+ */
+export interface SageMakerClientResolvedConfig extends SageMakerClientResolvedConfigType {}
 
 /**
  * <p>Provides APIs for creating and managing Amazon SageMaker resources. </p>
@@ -1223,6 +1231,9 @@ export class SageMakerClient extends __Client<
   ServiceOutputTypes,
   SageMakerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SageMakerClient class. This is resolved and normalized from the {@link SageMakerClientConfig | constructor configuration interface}.
+   */
   readonly config: SageMakerClientResolvedConfig;
 
   constructor(configuration: SageMakerClientConfig) {

--- a/clients/client-savingsplans/SavingsplansClient.ts
+++ b/clients/client-savingsplans/SavingsplansClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SavingsplansClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SavingsplansClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -202,8 +202,12 @@ export type SavingsplansClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SavingsplansClient class constructor that set the region, credentials and other options.
+ */
+export interface SavingsplansClientConfig extends SavingsplansClientConfigType {}
 
-export type SavingsplansClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SavingsplansClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -211,6 +215,10 @@ export type SavingsplansClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SavingsplansClient class. This is resolved and normalized from the {@link SavingsplansClientConfig | constructor configuration interface}.
+ */
+export interface SavingsplansClientResolvedConfig extends SavingsplansClientResolvedConfigType {}
 
 /**
  * <p>Savings Plans are a pricing model that offer significant savings on AWS usage (for
@@ -224,6 +232,9 @@ export class SavingsplansClient extends __Client<
   ServiceOutputTypes,
   SavingsplansClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SavingsplansClient class. This is resolved and normalized from the {@link SavingsplansClientConfig | constructor configuration interface}.
+   */
   readonly config: SavingsplansClientResolvedConfig;
 
   constructor(configuration: SavingsplansClientConfig) {

--- a/clients/client-schemas/SchemasClient.ts
+++ b/clients/client-schemas/SchemasClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SchemasClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SchemasClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -268,8 +268,12 @@ export type SchemasClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SchemasClient class constructor that set the region, credentials and other options.
+ */
+export interface SchemasClientConfig extends SchemasClientConfigType {}
 
-export type SchemasClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SchemasClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -277,6 +281,10 @@ export type SchemasClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SchemasClient class. This is resolved and normalized from the {@link SchemasClientConfig | constructor configuration interface}.
+ */
+export interface SchemasClientResolvedConfig extends SchemasClientResolvedConfigType {}
 
 /**
  * <p>Amazon EventBridge Schema Registry</p>
@@ -287,6 +295,9 @@ export class SchemasClient extends __Client<
   ServiceOutputTypes,
   SchemasClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SchemasClient class. This is resolved and normalized from the {@link SchemasClientConfig | constructor configuration interface}.
+   */
   readonly config: SchemasClientResolvedConfig;
 
   constructor(configuration: SchemasClientConfig) {

--- a/clients/client-secrets-manager/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/SecretsManagerClient.ts
@@ -218,7 +218,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SecretsManagerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SecretsManagerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -226,8 +226,12 @@ export type SecretsManagerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SecretsManagerClient class constructor that set the region, credentials and other options.
+ */
+export interface SecretsManagerClientConfig extends SecretsManagerClientConfigType {}
 
-export type SecretsManagerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SecretsManagerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -235,6 +239,10 @@ export type SecretsManagerClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SecretsManagerClient class. This is resolved and normalized from the {@link SecretsManagerClientConfig | constructor configuration interface}.
+ */
+export interface SecretsManagerClientResolvedConfig extends SecretsManagerClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Secrets Manager API Reference</fullname>
@@ -307,6 +315,9 @@ export class SecretsManagerClient extends __Client<
   ServiceOutputTypes,
   SecretsManagerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SecretsManagerClient class. This is resolved and normalized from the {@link SecretsManagerClientConfig | constructor configuration interface}.
+   */
   readonly config: SecretsManagerClientResolvedConfig;
 
   constructor(configuration: SecretsManagerClientConfig) {

--- a/clients/client-securityhub/SecurityHubClient.ts
+++ b/clients/client-securityhub/SecurityHubClient.ts
@@ -356,7 +356,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SecurityHubClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SecurityHubClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -364,8 +364,12 @@ export type SecurityHubClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SecurityHubClient class constructor that set the region, credentials and other options.
+ */
+export interface SecurityHubClientConfig extends SecurityHubClientConfigType {}
 
-export type SecurityHubClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SecurityHubClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -373,6 +377,10 @@ export type SecurityHubClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SecurityHubClient class. This is resolved and normalized from the {@link SecurityHubClientConfig | constructor configuration interface}.
+ */
+export interface SecurityHubClientResolvedConfig extends SecurityHubClientResolvedConfigType {}
 
 /**
  * <p>Security Hub provides you with a comprehensive view of the security state of your AWS
@@ -437,6 +445,9 @@ export class SecurityHubClient extends __Client<
   ServiceOutputTypes,
   SecurityHubClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SecurityHubClient class. This is resolved and normalized from the {@link SecurityHubClientConfig | constructor configuration interface}.
+   */
   readonly config: SecurityHubClientResolvedConfig;
 
   constructor(configuration: SecurityHubClientConfig) {

--- a/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
@@ -215,7 +215,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ServerlessApplicationRepositoryClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ServerlessApplicationRepositoryClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -223,8 +223,12 @@ export type ServerlessApplicationRepositoryClientConfig = Partial<__SmithyConfig
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ServerlessApplicationRepositoryClient class constructor that set the region, credentials and other options.
+ */
+export interface ServerlessApplicationRepositoryClientConfig extends ServerlessApplicationRepositoryClientConfigType {}
 
-export type ServerlessApplicationRepositoryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ServerlessApplicationRepositoryClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -232,6 +236,11 @@ export type ServerlessApplicationRepositoryClientResolvedConfig = __SmithyResolv
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ServerlessApplicationRepositoryClient class. This is resolved and normalized from the {@link ServerlessApplicationRepositoryClientConfig | constructor configuration interface}.
+ */
+export interface ServerlessApplicationRepositoryClientResolvedConfig
+  extends ServerlessApplicationRepositoryClientResolvedConfigType {}
 
 /**
  * <p>The AWS Serverless Application Repository makes it easy for developers and enterprises to quickly find
@@ -261,6 +270,9 @@ export class ServerlessApplicationRepositoryClient extends __Client<
   ServiceOutputTypes,
   ServerlessApplicationRepositoryClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ServerlessApplicationRepositoryClient class. This is resolved and normalized from the {@link ServerlessApplicationRepositoryClientConfig | constructor configuration interface}.
+   */
   readonly config: ServerlessApplicationRepositoryClientResolvedConfig;
 
   constructor(configuration: ServerlessApplicationRepositoryClientConfig) {

--- a/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
@@ -242,7 +242,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ServiceCatalogAppRegistryClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ServiceCatalogAppRegistryClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -250,8 +250,12 @@ export type ServiceCatalogAppRegistryClientConfig = Partial<__SmithyConfiguratio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ServiceCatalogAppRegistryClient class constructor that set the region, credentials and other options.
+ */
+export interface ServiceCatalogAppRegistryClientConfig extends ServiceCatalogAppRegistryClientConfigType {}
 
-export type ServiceCatalogAppRegistryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ServiceCatalogAppRegistryClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -259,6 +263,11 @@ export type ServiceCatalogAppRegistryClientResolvedConfig = __SmithyResolvedConf
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ServiceCatalogAppRegistryClient class. This is resolved and normalized from the {@link ServiceCatalogAppRegistryClientConfig | constructor configuration interface}.
+ */
+export interface ServiceCatalogAppRegistryClientResolvedConfig
+  extends ServiceCatalogAppRegistryClientResolvedConfigType {}
 
 /**
  * <p> AWS Service Catalog AppRegistry enables organizations to understand the application context of their AWS resources. AppRegistry provides a repository of your applications, their resources, and the application metadata that you use within your enterprise.</p>
@@ -269,6 +278,9 @@ export class ServiceCatalogAppRegistryClient extends __Client<
   ServiceOutputTypes,
   ServiceCatalogAppRegistryClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ServiceCatalogAppRegistryClient class. This is resolved and normalized from the {@link ServiceCatalogAppRegistryClientConfig | constructor configuration interface}.
+   */
   readonly config: ServiceCatalogAppRegistryClientResolvedConfig;
 
   constructor(configuration: ServiceCatalogAppRegistryClientConfig) {

--- a/clients/client-service-catalog/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/ServiceCatalogClient.ts
@@ -584,7 +584,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ServiceCatalogClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ServiceCatalogClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -592,8 +592,12 @@ export type ServiceCatalogClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ServiceCatalogClient class constructor that set the region, credentials and other options.
+ */
+export interface ServiceCatalogClientConfig extends ServiceCatalogClientConfigType {}
 
-export type ServiceCatalogClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ServiceCatalogClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -601,6 +605,10 @@ export type ServiceCatalogClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ServiceCatalogClient class. This is resolved and normalized from the {@link ServiceCatalogClientConfig | constructor configuration interface}.
+ */
+export interface ServiceCatalogClientResolvedConfig extends ServiceCatalogClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Service Catalog</fullname>
@@ -617,6 +625,9 @@ export class ServiceCatalogClient extends __Client<
   ServiceOutputTypes,
   ServiceCatalogClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ServiceCatalogClient class. This is resolved and normalized from the {@link ServiceCatalogClientConfig | constructor configuration interface}.
+   */
   readonly config: ServiceCatalogClientResolvedConfig;
 
   constructor(configuration: ServiceCatalogClientConfig) {

--- a/clients/client-service-quotas/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/ServiceQuotasClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ServiceQuotasClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ServiceQuotasClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -244,8 +244,12 @@ export type ServiceQuotasClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ServiceQuotasClient class constructor that set the region, credentials and other options.
+ */
+export interface ServiceQuotasClientConfig extends ServiceQuotasClientConfigType {}
 
-export type ServiceQuotasClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ServiceQuotasClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -253,6 +257,10 @@ export type ServiceQuotasClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ServiceQuotasClient class. This is resolved and normalized from the {@link ServiceQuotasClientConfig | constructor configuration interface}.
+ */
+export interface ServiceQuotasClientResolvedConfig extends ServiceQuotasClientResolvedConfigType {}
 
 /**
  * <p> Service Quotas is a web service that you can use to manage many of your AWS service
@@ -274,6 +282,9 @@ export class ServiceQuotasClient extends __Client<
   ServiceOutputTypes,
   ServiceQuotasClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ServiceQuotasClient class. This is resolved and normalized from the {@link ServiceQuotasClientConfig | constructor configuration interface}.
+   */
   readonly config: ServiceQuotasClientResolvedConfig;
 
   constructor(configuration: ServiceQuotasClientConfig) {

--- a/clients/client-servicediscovery/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/ServiceDiscoveryClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ServiceDiscoveryClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ServiceDiscoveryClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -244,8 +244,12 @@ export type ServiceDiscoveryClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ServiceDiscoveryClient class constructor that set the region, credentials and other options.
+ */
+export interface ServiceDiscoveryClientConfig extends ServiceDiscoveryClientConfigType {}
 
-export type ServiceDiscoveryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ServiceDiscoveryClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -253,6 +257,10 @@ export type ServiceDiscoveryClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ServiceDiscoveryClient class. This is resolved and normalized from the {@link ServiceDiscoveryClientConfig | constructor configuration interface}.
+ */
+export interface ServiceDiscoveryClientResolvedConfig extends ServiceDiscoveryClientResolvedConfigType {}
 
 /**
  * <p>AWS Cloud Map lets you configure public DNS, private DNS, or HTTP namespaces that your microservice applications
@@ -267,6 +275,9 @@ export class ServiceDiscoveryClient extends __Client<
   ServiceOutputTypes,
   ServiceDiscoveryClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ServiceDiscoveryClient class. This is resolved and normalized from the {@link ServiceDiscoveryClientConfig | constructor configuration interface}.
+   */
   readonly config: ServiceDiscoveryClientResolvedConfig;
 
   constructor(configuration: ServiceDiscoveryClientConfig) {

--- a/clients/client-ses/SESClient.ts
+++ b/clients/client-ses/SESClient.ts
@@ -512,7 +512,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SESClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SESClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -520,8 +520,12 @@ export type SESClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SESClient class constructor that set the region, credentials and other options.
+ */
+export interface SESClientConfig extends SESClientConfigType {}
 
-export type SESClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SESClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -529,6 +533,10 @@ export type SESClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SESClient class. This is resolved and normalized from the {@link SESClientConfig | constructor configuration interface}.
+ */
+export interface SESClientResolvedConfig extends SESClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Simple Email Service</fullname>
@@ -547,6 +555,9 @@ export class SESClient extends __Client<
   ServiceOutputTypes,
   SESClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SESClient class. This is resolved and normalized from the {@link SESClientConfig | constructor configuration interface}.
+   */
   readonly config: SESClientResolvedConfig;
 
   constructor(configuration: SESClientConfig) {

--- a/clients/client-sesv2/SESv2Client.ts
+++ b/clients/client-sesv2/SESv2Client.ts
@@ -557,7 +557,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SESv2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SESv2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -565,8 +565,12 @@ export type SESv2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SESv2Client class constructor that set the region, credentials and other options.
+ */
+export interface SESv2ClientConfig extends SESv2ClientConfigType {}
 
-export type SESv2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SESv2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -574,6 +578,10 @@ export type SESv2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SESv2Client class. This is resolved and normalized from the {@link SESv2ClientConfig | constructor configuration interface}.
+ */
+export interface SESv2ClientResolvedConfig extends SESv2ClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon SES API v2</fullname>
@@ -603,6 +611,9 @@ export class SESv2Client extends __Client<
   ServiceOutputTypes,
   SESv2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SESv2Client class. This is resolved and normalized from the {@link SESv2ClientConfig | constructor configuration interface}.
+   */
   readonly config: SESv2ClientResolvedConfig;
 
   constructor(configuration: SESv2ClientConfig) {

--- a/clients/client-sfn/SFNClient.ts
+++ b/clients/client-sfn/SFNClient.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SFNClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SFNClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -238,8 +238,12 @@ export type SFNClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SFNClient class constructor that set the region, credentials and other options.
+ */
+export interface SFNClientConfig extends SFNClientConfigType {}
 
-export type SFNClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SFNClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -247,6 +251,10 @@ export type SFNClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SFNClient class. This is resolved and normalized from the {@link SFNClientConfig | constructor configuration interface}.
+ */
+export interface SFNClientResolvedConfig extends SFNClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Step Functions</fullname>
@@ -272,6 +280,9 @@ export class SFNClient extends __Client<
   ServiceOutputTypes,
   SFNClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SFNClient class. This is resolved and normalized from the {@link SFNClientConfig | constructor configuration interface}.
+   */
   readonly config: SFNClientResolvedConfig;
 
   constructor(configuration: SFNClientConfig) {

--- a/clients/client-shield/ShieldClient.ts
+++ b/clients/client-shield/ShieldClient.ts
@@ -296,7 +296,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type ShieldClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type ShieldClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -304,8 +304,12 @@ export type ShieldClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of ShieldClient class constructor that set the region, credentials and other options.
+ */
+export interface ShieldClientConfig extends ShieldClientConfigType {}
 
-export type ShieldClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type ShieldClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -313,6 +317,10 @@ export type ShieldClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of ShieldClient class. This is resolved and normalized from the {@link ShieldClientConfig | constructor configuration interface}.
+ */
+export interface ShieldClientResolvedConfig extends ShieldClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Shield Advanced</fullname>
@@ -326,6 +334,9 @@ export class ShieldClient extends __Client<
   ServiceOutputTypes,
   ShieldClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of ShieldClient class. This is resolved and normalized from the {@link ShieldClientConfig | constructor configuration interface}.
+   */
   readonly config: ShieldClientResolvedConfig;
 
   constructor(configuration: ShieldClientConfig) {

--- a/clients/client-signer/SignerClient.ts
+++ b/clients/client-signer/SignerClient.ts
@@ -224,7 +224,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SignerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SignerClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -232,8 +232,12 @@ export type SignerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SignerClient class constructor that set the region, credentials and other options.
+ */
+export interface SignerClientConfig extends SignerClientConfigType {}
 
-export type SignerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SignerClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -241,6 +245,10 @@ export type SignerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SignerClient class. This is resolved and normalized from the {@link SignerClientConfig | constructor configuration interface}.
+ */
+export interface SignerClientResolvedConfig extends SignerClientResolvedConfigType {}
 
 /**
  * <p>AWS Signer is a fully managed code signing service to help you ensure the trust and
@@ -267,6 +275,9 @@ export class SignerClient extends __Client<
   ServiceOutputTypes,
   SignerClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SignerClient class. This is resolved and normalized from the {@link SignerClientConfig | constructor configuration interface}.
+   */
   readonly config: SignerClientResolvedConfig;
 
   constructor(configuration: SignerClientConfig) {

--- a/clients/client-sms/SMSClient.ts
+++ b/clients/client-sms/SMSClient.ts
@@ -314,7 +314,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SMSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -322,8 +322,12 @@ export type SMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SMSClient class constructor that set the region, credentials and other options.
+ */
+export interface SMSClientConfig extends SMSClientConfigType {}
 
-export type SMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SMSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -331,6 +335,10 @@ export type SMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SMSClient class. This is resolved and normalized from the {@link SMSClientConfig | constructor configuration interface}.
+ */
+export interface SMSClientResolvedConfig extends SMSClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Server Migration Service</fullname>
@@ -357,6 +365,9 @@ export class SMSClient extends __Client<
   ServiceOutputTypes,
   SMSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SMSClient class. This is resolved and normalized from the {@link SMSClientConfig | constructor configuration interface}.
+   */
   readonly config: SMSClientResolvedConfig;
 
   constructor(configuration: SMSClientConfig) {

--- a/clients/client-snowball/SnowballClient.ts
+++ b/clients/client-snowball/SnowballClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SnowballClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SnowballClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -235,8 +235,12 @@ export type SnowballClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SnowballClient class constructor that set the region, credentials and other options.
+ */
+export interface SnowballClientConfig extends SnowballClientConfigType {}
 
-export type SnowballClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SnowballClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -244,6 +248,10 @@ export type SnowballClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SnowballClient class. This is resolved and normalized from the {@link SnowballClientConfig | constructor configuration interface}.
+ */
+export interface SnowballClientResolvedConfig extends SnowballClientResolvedConfigType {}
 
 /**
  * <p>AWS Snow Family is a petabyte-scale data transport solution that uses secure devices to
@@ -260,6 +268,9 @@ export class SnowballClient extends __Client<
   ServiceOutputTypes,
   SnowballClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SnowballClient class. This is resolved and normalized from the {@link SnowballClientConfig | constructor configuration interface}.
+   */
   readonly config: SnowballClientResolvedConfig;
 
   constructor(configuration: SnowballClientConfig) {

--- a/clients/client-sns/SNSClient.ts
+++ b/clients/client-sns/SNSClient.ts
@@ -296,7 +296,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SNSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SNSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -304,8 +304,12 @@ export type SNSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SNSClient class constructor that set the region, credentials and other options.
+ */
+export interface SNSClientConfig extends SNSClientConfigType {}
 
-export type SNSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SNSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -313,6 +317,10 @@ export type SNSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SNSClient class. This is resolved and normalized from the {@link SNSClientConfig | constructor configuration interface}.
+ */
+export interface SNSClientResolvedConfig extends SNSClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Simple Notification Service</fullname>
@@ -336,6 +344,9 @@ export class SNSClient extends __Client<
   ServiceOutputTypes,
   SNSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SNSClient class. This is resolved and normalized from the {@link SNSClientConfig | constructor configuration interface}.
+   */
   readonly config: SNSClientResolvedConfig;
 
   constructor(configuration: SNSClientConfig) {

--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -224,7 +224,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SQSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SQSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -232,8 +232,12 @@ export type SQSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SQSClient class constructor that set the region, credentials and other options.
+ */
+export interface SQSClientConfig extends SQSClientConfigType {}
 
-export type SQSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SQSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -241,6 +245,10 @@ export type SQSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SQSClient class. This is resolved and normalized from the {@link SQSClientConfig | constructor configuration interface}.
+ */
+export interface SQSClientResolvedConfig extends SQSClientResolvedConfigType {}
 
 /**
  * <p>Welcome to the <i>Amazon Simple Queue Service API Reference</i>.</p>
@@ -319,6 +327,9 @@ export class SQSClient extends __Client<
   ServiceOutputTypes,
   SQSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SQSClient class. This is resolved and normalized from the {@link SQSClientConfig | constructor configuration interface}.
+   */
   readonly config: SQSClientResolvedConfig;
 
   constructor(configuration: SQSClientConfig) {

--- a/clients/client-ssm/SSMClient.ts
+++ b/clients/client-ssm/SSMClient.ts
@@ -779,7 +779,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SSMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SSMClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -787,8 +787,12 @@ export type SSMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SSMClient class constructor that set the region, credentials and other options.
+ */
+export interface SSMClientConfig extends SSMClientConfigType {}
 
-export type SSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SSMClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -796,6 +800,10 @@ export type SSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SSMClient class. This is resolved and normalized from the {@link SSMClientConfig | constructor configuration interface}.
+ */
+export interface SSMClientResolvedConfig extends SSMClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Systems Manager</fullname>
@@ -819,6 +827,9 @@ export class SSMClient extends __Client<
   ServiceOutputTypes,
   SSMClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SSMClient class. This is resolved and normalized from the {@link SSMClientConfig | constructor configuration interface}.
+   */
   readonly config: SSMClientResolvedConfig;
 
   constructor(configuration: SSMClientConfig) {

--- a/clients/client-sso-admin/SSOAdminClient.ts
+++ b/clients/client-sso-admin/SSOAdminClient.ts
@@ -323,7 +323,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SSOAdminClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SSOAdminClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -331,8 +331,12 @@ export type SSOAdminClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SSOAdminClient class constructor that set the region, credentials and other options.
+ */
+export interface SSOAdminClientConfig extends SSOAdminClientConfigType {}
 
-export type SSOAdminClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SSOAdminClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -340,6 +344,10 @@ export type SSOAdminClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SSOAdminClient class. This is resolved and normalized from the {@link SSOAdminClientConfig | constructor configuration interface}.
+ */
+export interface SSOAdminClientResolvedConfig extends SSOAdminClientResolvedConfigType {}
 
 export class SSOAdminClient extends __Client<
   __HttpHandlerOptions,
@@ -347,6 +355,9 @@ export class SSOAdminClient extends __Client<
   ServiceOutputTypes,
   SSOAdminClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SSOAdminClient class. This is resolved and normalized from the {@link SSOAdminClientConfig | constructor configuration interface}.
+   */
   readonly config: SSOAdminClientResolvedConfig;
 
   constructor(configuration: SSOAdminClientConfig) {

--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -149,21 +149,29 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SSOOIDCClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SSOOIDCClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SSOOIDCClient class constructor that set the region, credentials and other options.
+ */
+export interface SSOOIDCClientConfig extends SSOOIDCClientConfigType {}
 
-export type SSOOIDCClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SSOOIDCClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SSOOIDCClient class. This is resolved and normalized from the {@link SSOOIDCClientConfig | constructor configuration interface}.
+ */
+export interface SSOOIDCClientResolvedConfig extends SSOOIDCClientResolvedConfigType {}
 
 /**
  * <p>AWS Single Sign-On (SSO) OpenID Connect (OIDC) is a web service that enables a client
@@ -191,6 +199,9 @@ export class SSOOIDCClient extends __Client<
   ServiceOutputTypes,
   SSOOIDCClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SSOOIDCClient class. This is resolved and normalized from the {@link SSOOIDCClientConfig | constructor configuration interface}.
+   */
   readonly config: SSOOIDCClientResolvedConfig;
 
   constructor(configuration: SSOOIDCClientConfig) {

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -149,21 +149,29 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SSOClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SSOClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
   RetryInputConfig &
   HostHeaderInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SSOClient class constructor that set the region, credentials and other options.
+ */
+export interface SSOClientConfig extends SSOClientConfigType {}
 
-export type SSOClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SSOClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SSOClient class. This is resolved and normalized from the {@link SSOClientConfig | constructor configuration interface}.
+ */
+export interface SSOClientResolvedConfig extends SSOClientResolvedConfigType {}
 
 /**
  * <p>AWS Single Sign-On Portal is a web service that makes it easy for you to assign user
@@ -189,6 +197,9 @@ export class SSOClient extends __Client<
   ServiceOutputTypes,
   SSOClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SSOClient class. This is resolved and normalized from the {@link SSOClientConfig | constructor configuration interface}.
+   */
   readonly config: SSOClientResolvedConfig;
 
   constructor(configuration: SSOClientConfig) {

--- a/clients/client-storage-gateway/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/StorageGatewayClient.ts
@@ -536,7 +536,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type StorageGatewayClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type StorageGatewayClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -544,8 +544,12 @@ export type StorageGatewayClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of StorageGatewayClient class constructor that set the region, credentials and other options.
+ */
+export interface StorageGatewayClientConfig extends StorageGatewayClientConfigType {}
 
-export type StorageGatewayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type StorageGatewayClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -553,6 +557,10 @@ export type StorageGatewayClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of StorageGatewayClient class. This is resolved and normalized from the {@link StorageGatewayClientConfig | constructor configuration interface}.
+ */
+export interface StorageGatewayClientResolvedConfig extends StorageGatewayClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Storage Gateway Service</fullname>
@@ -634,6 +642,9 @@ export class StorageGatewayClient extends __Client<
   ServiceOutputTypes,
   StorageGatewayClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of StorageGatewayClient class. This is resolved and normalized from the {@link StorageGatewayClientConfig | constructor configuration interface}.
+   */
   readonly config: StorageGatewayClientResolvedConfig;
 
   constructor(configuration: StorageGatewayClientConfig) {

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -174,7 +174,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type STSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type STSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -182,8 +182,12 @@ export type STSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   StsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of STSClient class constructor that set the region, credentials and other options.
+ */
+export interface STSClientConfig extends STSClientConfigType {}
 
-export type STSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type STSClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -191,6 +195,10 @@ export type STSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   StsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of STSClient class. This is resolved and normalized from the {@link STSClientConfig | constructor configuration interface}.
+ */
+export interface STSClientResolvedConfig extends STSClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Security Token Service</fullname>
@@ -205,6 +213,9 @@ export class STSClient extends __Client<
   ServiceOutputTypes,
   STSClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of STSClient class. This is resolved and normalized from the {@link STSClientConfig | constructor configuration interface}.
+   */
   readonly config: STSClientResolvedConfig;
 
   constructor(configuration: STSClientConfig) {

--- a/clients/client-support/SupportClient.ts
+++ b/clients/client-support/SupportClient.ts
@@ -218,7 +218,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SupportClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SupportClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -226,8 +226,12 @@ export type SupportClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SupportClient class constructor that set the region, credentials and other options.
+ */
+export interface SupportClientConfig extends SupportClientConfigType {}
 
-export type SupportClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SupportClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -235,6 +239,10 @@ export type SupportClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SupportClient class. This is resolved and normalized from the {@link SupportClientConfig | constructor configuration interface}.
+ */
+export interface SupportClientResolvedConfig extends SupportClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Support</fullname>
@@ -321,6 +329,9 @@ export class SupportClient extends __Client<
   ServiceOutputTypes,
   SupportClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SupportClient class. This is resolved and normalized from the {@link SupportClientConfig | constructor configuration interface}.
+   */
   readonly config: SupportClientResolvedConfig;
 
   constructor(configuration: SupportClientConfig) {

--- a/clients/client-swf/SWFClient.ts
+++ b/clients/client-swf/SWFClient.ts
@@ -344,7 +344,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SWFClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SWFClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -352,8 +352,12 @@ export type SWFClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SWFClient class constructor that set the region, credentials and other options.
+ */
+export interface SWFClientConfig extends SWFClientConfigType {}
 
-export type SWFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SWFClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -361,6 +365,10 @@ export type SWFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SWFClient class. This is resolved and normalized from the {@link SWFClientConfig | constructor configuration interface}.
+ */
+export interface SWFClientResolvedConfig extends SWFClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Simple Workflow Service</fullname>
@@ -386,6 +394,9 @@ export class SWFClient extends __Client<
   ServiceOutputTypes,
   SWFClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SWFClient class. This is resolved and normalized from the {@link SWFClientConfig | constructor configuration interface}.
+   */
   readonly config: SWFClientResolvedConfig;
 
   constructor(configuration: SWFClientConfig) {

--- a/clients/client-synthetics/SyntheticsClient.ts
+++ b/clients/client-synthetics/SyntheticsClient.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type SyntheticsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type SyntheticsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -205,8 +205,12 @@ export type SyntheticsClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of SyntheticsClient class constructor that set the region, credentials and other options.
+ */
+export interface SyntheticsClientConfig extends SyntheticsClientConfigType {}
 
-export type SyntheticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type SyntheticsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -214,6 +218,10 @@ export type SyntheticsClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of SyntheticsClient class. This is resolved and normalized from the {@link SyntheticsClientConfig | constructor configuration interface}.
+ */
+export interface SyntheticsClientResolvedConfig extends SyntheticsClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon CloudWatch Synthetics</fullname>
@@ -239,6 +247,9 @@ export class SyntheticsClient extends __Client<
   ServiceOutputTypes,
   SyntheticsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of SyntheticsClient class. This is resolved and normalized from the {@link SyntheticsClientConfig | constructor configuration interface}.
+   */
   readonly config: SyntheticsClientResolvedConfig;
 
   constructor(configuration: SyntheticsClientConfig) {

--- a/clients/client-textract/TextractClient.ts
+++ b/clients/client-textract/TextractClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type TextractClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type TextractClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -187,8 +187,12 @@ export type TextractClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of TextractClient class constructor that set the region, credentials and other options.
+ */
+export interface TextractClientConfig extends TextractClientConfigType {}
 
-export type TextractClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type TextractClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -196,6 +200,10 @@ export type TextractClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of TextractClient class. This is resolved and normalized from the {@link TextractClientConfig | constructor configuration interface}.
+ */
+export interface TextractClientResolvedConfig extends TextractClientResolvedConfigType {}
 
 /**
  * <p>Amazon Textract detects and analyzes text in documents and converts it
@@ -208,6 +216,9 @@ export class TextractClient extends __Client<
   ServiceOutputTypes,
   TextractClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of TextractClient class. This is resolved and normalized from the {@link TextractClientConfig | constructor configuration interface}.
+   */
   readonly config: TextractClientResolvedConfig;
 
   constructor(configuration: TextractClientConfig) {

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type TimestreamQueryClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type TimestreamQueryClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -160,8 +160,12 @@ export type TimestreamQueryClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of TimestreamQueryClient class constructor that set the region, credentials and other options.
+ */
+export interface TimestreamQueryClientConfig extends TimestreamQueryClientConfigType {}
 
-export type TimestreamQueryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type TimestreamQueryClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -169,6 +173,10 @@ export type TimestreamQueryClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of TimestreamQueryClient class. This is resolved and normalized from the {@link TimestreamQueryClientConfig | constructor configuration interface}.
+ */
+export interface TimestreamQueryClientResolvedConfig extends TimestreamQueryClientResolvedConfigType {}
 
 /**
  * <p>
@@ -181,6 +189,9 @@ export class TimestreamQueryClient extends __Client<
   ServiceOutputTypes,
   TimestreamQueryClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of TimestreamQueryClient class. This is resolved and normalized from the {@link TimestreamQueryClientConfig | constructor configuration interface}.
+   */
   readonly config: TimestreamQueryClientResolvedConfig;
 
   constructor(configuration: TimestreamQueryClientConfig) {

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type TimestreamWriteClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type TimestreamWriteClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -205,8 +205,12 @@ export type TimestreamWriteClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of TimestreamWriteClient class constructor that set the region, credentials and other options.
+ */
+export interface TimestreamWriteClientConfig extends TimestreamWriteClientConfigType {}
 
-export type TimestreamWriteClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type TimestreamWriteClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -214,6 +218,10 @@ export type TimestreamWriteClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of TimestreamWriteClient class. This is resolved and normalized from the {@link TimestreamWriteClientConfig | constructor configuration interface}.
+ */
+export interface TimestreamWriteClientResolvedConfig extends TimestreamWriteClientResolvedConfigType {}
 
 /**
  * <p>Amazon Timestream is a fast, scalable, fully managed time series database service that makes it easy to store and analyze trillions of time series data points per day. With Timestream, you can easily store and analyze IoT sensor data to derive insights from your IoT applications. You can analyze industrial telemetry to streamline equipment management and maintenance. You can also store and analyze log data and metrics to improve the performance and availability of your applications. Timestream is built from the ground up to effectively ingest, process, and store time series data. It organizes data to optimize query processing. It automatically scales based on the volume of data ingested and on the query volume to ensure you receive optimal performance while inserting and querying data. As your data grows over time, Timestream’s adaptive query processing engine spans across storage tiers to provide fast analysis while reducing costs.</p>
@@ -224,6 +232,9 @@ export class TimestreamWriteClient extends __Client<
   ServiceOutputTypes,
   TimestreamWriteClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of TimestreamWriteClient class. This is resolved and normalized from the {@link TimestreamWriteClientConfig | constructor configuration interface}.
+   */
   readonly config: TimestreamWriteClientResolvedConfig;
 
   constructor(configuration: TimestreamWriteClientConfig) {

--- a/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
@@ -185,7 +185,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   eventStreamSerdeProvider?: __EventStreamSerdeProvider;
 }
 
-export type TranscribeStreamingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type TranscribeStreamingClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -196,8 +196,12 @@ export type TranscribeStreamingClientConfig = Partial<__SmithyConfiguration<__Ht
   WebSocketInputConfig &
   UserAgentInputConfig &
   EventStreamSerdeInputConfig;
+/**
+ * The configuration interface of TranscribeStreamingClient class constructor that set the region, credentials and other options.
+ */
+export interface TranscribeStreamingClientConfig extends TranscribeStreamingClientConfigType {}
 
-export type TranscribeStreamingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type TranscribeStreamingClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -208,6 +212,10 @@ export type TranscribeStreamingClientResolvedConfig = __SmithyResolvedConfigurat
   WebSocketResolvedConfig &
   UserAgentResolvedConfig &
   EventStreamSerdeResolvedConfig;
+/**
+ * The resolved configuration interface of TranscribeStreamingClient class. This is resolved and normalized from the {@link TranscribeStreamingClientConfig | constructor configuration interface}.
+ */
+export interface TranscribeStreamingClientResolvedConfig extends TranscribeStreamingClientResolvedConfigType {}
 
 /**
  * <p>Operations and objects for transcribing streaming speech to text.</p>
@@ -218,6 +226,9 @@ export class TranscribeStreamingClient extends __Client<
   ServiceOutputTypes,
   TranscribeStreamingClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of TranscribeStreamingClient class. This is resolved and normalized from the {@link TranscribeStreamingClientConfig | constructor configuration interface}.
+   */
   readonly config: TranscribeStreamingClientResolvedConfig;
 
   constructor(configuration: TranscribeStreamingClientConfig) {

--- a/clients/client-transcribe/TranscribeClient.ts
+++ b/clients/client-transcribe/TranscribeClient.ts
@@ -293,7 +293,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type TranscribeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type TranscribeClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -301,8 +301,12 @@ export type TranscribeClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of TranscribeClient class constructor that set the region, credentials and other options.
+ */
+export interface TranscribeClientConfig extends TranscribeClientConfigType {}
 
-export type TranscribeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type TranscribeClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -310,6 +314,10 @@ export type TranscribeClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of TranscribeClient class. This is resolved and normalized from the {@link TranscribeClientConfig | constructor configuration interface}.
+ */
+export interface TranscribeClientResolvedConfig extends TranscribeClientResolvedConfigType {}
 
 /**
  * <p>Operations and objects for transcribing speech to text.</p>
@@ -320,6 +328,9 @@ export class TranscribeClient extends __Client<
   ServiceOutputTypes,
   TranscribeClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of TranscribeClient class. This is resolved and normalized from the {@link TranscribeClientConfig | constructor configuration interface}.
+   */
   readonly config: TranscribeClientResolvedConfig;
 
   constructor(configuration: TranscribeClientConfig) {

--- a/clients/client-transfer/TransferClient.ts
+++ b/clients/client-transfer/TransferClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type TransferClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type TransferClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -229,8 +229,12 @@ export type TransferClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of TransferClient class constructor that set the region, credentials and other options.
+ */
+export interface TransferClientConfig extends TransferClientConfigType {}
 
-export type TransferClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type TransferClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -238,6 +242,10 @@ export type TransferClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of TransferClient class. This is resolved and normalized from the {@link TransferClientConfig | constructor configuration interface}.
+ */
+export interface TransferClientResolvedConfig extends TransferClientResolvedConfigType {}
 
 /**
  * <p>AWS Transfer Family is a fully managed service that enables the transfer of files over the
@@ -256,6 +264,9 @@ export class TransferClient extends __Client<
   ServiceOutputTypes,
   TransferClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of TransferClient class. This is resolved and normalized from the {@link TransferClientConfig | constructor configuration interface}.
+   */
   readonly config: TransferClientResolvedConfig;
 
   constructor(configuration: TransferClientConfig) {

--- a/clients/client-translate/TranslateClient.ts
+++ b/clients/client-translate/TranslateClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type TranslateClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type TranslateClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -211,8 +211,12 @@ export type TranslateClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of TranslateClient class constructor that set the region, credentials and other options.
+ */
+export interface TranslateClientConfig extends TranslateClientConfigType {}
 
-export type TranslateClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type TranslateClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -220,6 +224,10 @@ export type TranslateClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of TranslateClient class. This is resolved and normalized from the {@link TranslateClientConfig | constructor configuration interface}.
+ */
+export interface TranslateClientResolvedConfig extends TranslateClientResolvedConfigType {}
 
 /**
  * <p>Provides translation between one source language and another of the same set of
@@ -231,6 +239,9 @@ export class TranslateClient extends __Client<
   ServiceOutputTypes,
   TranslateClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of TranslateClient class. This is resolved and normalized from the {@link TranslateClientConfig | constructor configuration interface}.
+   */
   readonly config: TranslateClientResolvedConfig;
 
   constructor(configuration: TranslateClientConfig) {

--- a/clients/client-waf-regional/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/WAFRegionalClient.ts
@@ -497,7 +497,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WAFRegionalClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WAFRegionalClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -505,8 +505,12 @@ export type WAFRegionalClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WAFRegionalClient class constructor that set the region, credentials and other options.
+ */
+export interface WAFRegionalClientConfig extends WAFRegionalClientConfigType {}
 
-export type WAFRegionalClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WAFRegionalClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -514,6 +518,10 @@ export type WAFRegionalClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WAFRegionalClient class. This is resolved and normalized from the {@link WAFRegionalClientConfig | constructor configuration interface}.
+ */
+export interface WAFRegionalClientResolvedConfig extends WAFRegionalClientResolvedConfigType {}
 
 /**
  * <note>
@@ -534,6 +542,9 @@ export class WAFRegionalClient extends __Client<
   ServiceOutputTypes,
   WAFRegionalClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WAFRegionalClient class. This is resolved and normalized from the {@link WAFRegionalClientConfig | constructor configuration interface}.
+   */
   readonly config: WAFRegionalClientResolvedConfig;
 
   constructor(configuration: WAFRegionalClientConfig) {

--- a/clients/client-waf/WAFClient.ts
+++ b/clients/client-waf/WAFClient.ts
@@ -479,7 +479,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WAFClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WAFClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -487,8 +487,12 @@ export type WAFClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WAFClient class constructor that set the region, credentials and other options.
+ */
+export interface WAFClientConfig extends WAFClientConfigType {}
 
-export type WAFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WAFClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -496,6 +500,10 @@ export type WAFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WAFClient class. This is resolved and normalized from the {@link WAFClientConfig | constructor configuration interface}.
+ */
+export interface WAFClientResolvedConfig extends WAFClientResolvedConfigType {}
 
 /**
  * <note>
@@ -516,6 +524,9 @@ export class WAFClient extends __Client<
   ServiceOutputTypes,
   WAFClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WAFClient class. This is resolved and normalized from the {@link WAFClientConfig | constructor configuration interface}.
+   */
   readonly config: WAFClientResolvedConfig;
 
   constructor(configuration: WAFClientConfig) {

--- a/clients/client-wafv2/WAFV2Client.ts
+++ b/clients/client-wafv2/WAFV2Client.ts
@@ -323,7 +323,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WAFV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WAFV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -331,8 +331,12 @@ export type WAFV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WAFV2Client class constructor that set the region, credentials and other options.
+ */
+export interface WAFV2ClientConfig extends WAFV2ClientConfigType {}
 
-export type WAFV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WAFV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -340,6 +344,10 @@ export type WAFV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WAFV2Client class. This is resolved and normalized from the {@link WAFV2ClientConfig | constructor configuration interface}.
+ */
+export interface WAFV2ClientResolvedConfig extends WAFV2ClientResolvedConfigType {}
 
 /**
  * <note>
@@ -406,6 +414,9 @@ export class WAFV2Client extends __Client<
   ServiceOutputTypes,
   WAFV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WAFV2Client class. This is resolved and normalized from the {@link WAFV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: WAFV2ClientResolvedConfig;
 
   constructor(configuration: WAFV2ClientConfig) {

--- a/clients/client-workdocs/WorkDocsClient.ts
+++ b/clients/client-workdocs/WorkDocsClient.ts
@@ -320,7 +320,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WorkDocsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WorkDocsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -328,8 +328,12 @@ export type WorkDocsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WorkDocsClient class constructor that set the region, credentials and other options.
+ */
+export interface WorkDocsClientConfig extends WorkDocsClientConfigType {}
 
-export type WorkDocsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WorkDocsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -337,6 +341,10 @@ export type WorkDocsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WorkDocsClient class. This is resolved and normalized from the {@link WorkDocsClientConfig | constructor configuration interface}.
+ */
+export interface WorkDocsClientResolvedConfig extends WorkDocsClientResolvedConfigType {}
 
 /**
  * <p>The WorkDocs API is designed for the following use cases:</p>
@@ -379,6 +387,9 @@ export class WorkDocsClient extends __Client<
   ServiceOutputTypes,
   WorkDocsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WorkDocsClient class. This is resolved and normalized from the {@link WorkDocsClientConfig | constructor configuration interface}.
+   */
   readonly config: WorkDocsClientResolvedConfig;
 
   constructor(configuration: WorkDocsClientConfig) {

--- a/clients/client-worklink/WorkLinkClient.ts
+++ b/clients/client-worklink/WorkLinkClient.ts
@@ -308,7 +308,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WorkLinkClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WorkLinkClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -316,8 +316,12 @@ export type WorkLinkClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WorkLinkClient class constructor that set the region, credentials and other options.
+ */
+export interface WorkLinkClientConfig extends WorkLinkClientConfigType {}
 
-export type WorkLinkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WorkLinkClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -325,6 +329,10 @@ export type WorkLinkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WorkLinkClient class. This is resolved and normalized from the {@link WorkLinkClientConfig | constructor configuration interface}.
+ */
+export interface WorkLinkClientResolvedConfig extends WorkLinkClientResolvedConfigType {}
 
 /**
  * <p>Amazon WorkLink is a cloud-based service that provides secure access
@@ -341,6 +349,9 @@ export class WorkLinkClient extends __Client<
   ServiceOutputTypes,
   WorkLinkClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WorkLinkClient class. This is resolved and normalized from the {@link WorkLinkClientConfig | constructor configuration interface}.
+   */
   readonly config: WorkLinkClientResolvedConfig;
 
   constructor(configuration: WorkLinkClientConfig) {

--- a/clients/client-workmail/WorkMailClient.ts
+++ b/clients/client-workmail/WorkMailClient.ts
@@ -281,7 +281,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WorkMailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WorkMailClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -289,8 +289,12 @@ export type WorkMailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WorkMailClient class constructor that set the region, credentials and other options.
+ */
+export interface WorkMailClientConfig extends WorkMailClientConfigType {}
 
-export type WorkMailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WorkMailClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -298,6 +302,10 @@ export type WorkMailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WorkMailClient class. This is resolved and normalized from the {@link WorkMailClientConfig | constructor configuration interface}.
+ */
+export interface WorkMailClientResolvedConfig extends WorkMailClientResolvedConfigType {}
 
 /**
  * <p>Amazon WorkMail is a secure, managed business email and calendaring service with support for
@@ -342,6 +350,9 @@ export class WorkMailClient extends __Client<
   ServiceOutputTypes,
   WorkMailClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WorkMailClient class. This is resolved and normalized from the {@link WorkMailClientConfig | constructor configuration interface}.
+   */
   readonly config: WorkMailClientResolvedConfig;
 
   constructor(configuration: WorkMailClientConfig) {

--- a/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
@@ -153,7 +153,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WorkMailMessageFlowClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WorkMailMessageFlowClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -161,8 +161,12 @@ export type WorkMailMessageFlowClientConfig = Partial<__SmithyConfiguration<__Ht
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WorkMailMessageFlowClient class constructor that set the region, credentials and other options.
+ */
+export interface WorkMailMessageFlowClientConfig extends WorkMailMessageFlowClientConfigType {}
 
-export type WorkMailMessageFlowClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WorkMailMessageFlowClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -170,6 +174,10 @@ export type WorkMailMessageFlowClientResolvedConfig = __SmithyResolvedConfigurat
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WorkMailMessageFlowClient class. This is resolved and normalized from the {@link WorkMailMessageFlowClientConfig | constructor configuration interface}.
+ */
+export interface WorkMailMessageFlowClientResolvedConfig extends WorkMailMessageFlowClientResolvedConfigType {}
 
 /**
  * <p>The WorkMail Message Flow API provides access to email messages as they are
@@ -184,6 +192,9 @@ export class WorkMailMessageFlowClient extends __Client<
   ServiceOutputTypes,
   WorkMailMessageFlowClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WorkMailMessageFlowClient class. This is resolved and normalized from the {@link WorkMailMessageFlowClientConfig | constructor configuration interface}.
+   */
   readonly config: WorkMailMessageFlowClientResolvedConfig;
 
   constructor(configuration: WorkMailMessageFlowClientConfig) {

--- a/clients/client-workspaces/WorkSpacesClient.ts
+++ b/clients/client-workspaces/WorkSpacesClient.ts
@@ -389,7 +389,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WorkSpacesClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WorkSpacesClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -397,8 +397,12 @@ export type WorkSpacesClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WorkSpacesClient class constructor that set the region, credentials and other options.
+ */
+export interface WorkSpacesClientConfig extends WorkSpacesClientConfigType {}
 
-export type WorkSpacesClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WorkSpacesClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -406,6 +410,10 @@ export type WorkSpacesClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WorkSpacesClient class. This is resolved and normalized from the {@link WorkSpacesClientConfig | constructor configuration interface}.
+ */
+export interface WorkSpacesClientResolvedConfig extends WorkSpacesClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon WorkSpaces Service</fullname>
@@ -418,6 +426,9 @@ export class WorkSpacesClient extends __Client<
   ServiceOutputTypes,
   WorkSpacesClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WorkSpacesClient class. This is resolved and normalized from the {@link WorkSpacesClientConfig | constructor configuration interface}.
+   */
   readonly config: WorkSpacesClientResolvedConfig;
 
   constructor(configuration: WorkSpacesClientConfig) {

--- a/clients/client-xray/XRayClient.ts
+++ b/clients/client-xray/XRayClient.ts
@@ -254,7 +254,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type XRayClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type XRayClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -262,8 +262,12 @@ export type XRayClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOption
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of XRayClient class constructor that set the region, credentials and other options.
+ */
+export interface XRayClientConfig extends XRayClientConfigType {}
 
-export type XRayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type XRayClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -271,6 +275,10 @@ export type XRayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandl
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of XRayClient class. This is resolved and normalized from the {@link XRayClientConfig | constructor configuration interface}.
+ */
+export interface XRayClientResolvedConfig extends XRayClientResolvedConfigType {}
 
 /**
  * <p>AWS X-Ray provides APIs for managing debug traces and retrieving service maps
@@ -282,6 +290,9 @@ export class XRayClient extends __Client<
   ServiceOutputTypes,
   XRayClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of XRayClient class. This is resolved and normalized from the {@link XRayClientConfig | constructor configuration interface}.
+   */
   readonly config: XRayClientResolvedConfig;
 
   constructor(configuration: XRayClientConfig) {

--- a/protocol_tests/aws-ec2/EC2ProtocolClient.ts
+++ b/protocol_tests/aws-ec2/EC2ProtocolClient.ts
@@ -224,7 +224,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type EC2ProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type EC2ProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -232,8 +232,12 @@ export type EC2ProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of EC2ProtocolClient class constructor that set the region, credentials and other options.
+ */
+export interface EC2ProtocolClientConfig extends EC2ProtocolClientConfigType {}
 
-export type EC2ProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type EC2ProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -241,6 +245,10 @@ export type EC2ProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of EC2ProtocolClient class. This is resolved and normalized from the {@link EC2ProtocolClientConfig | constructor configuration interface}.
+ */
+export interface EC2ProtocolClientResolvedConfig extends EC2ProtocolClientResolvedConfigType {}
 
 /**
  * An EC2 query service that sends query requests and XML responses.
@@ -251,6 +259,9 @@ export class EC2ProtocolClient extends __Client<
   ServiceOutputTypes,
   EC2ProtocolClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of EC2ProtocolClient class. This is resolved and normalized from the {@link EC2ProtocolClientConfig | constructor configuration interface}.
+   */
   readonly config: EC2ProtocolClientResolvedConfig;
 
   constructor(configuration: EC2ProtocolClientConfig) {

--- a/protocol_tests/aws-json/JsonProtocolClient.ts
+++ b/protocol_tests/aws-json/JsonProtocolClient.ts
@@ -191,7 +191,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type JsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type JsonProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -199,8 +199,12 @@ export type JsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of JsonProtocolClient class constructor that set the region, credentials and other options.
+ */
+export interface JsonProtocolClientConfig extends JsonProtocolClientConfigType {}
 
-export type JsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type JsonProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -208,6 +212,10 @@ export type JsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of JsonProtocolClient class. This is resolved and normalized from the {@link JsonProtocolClientConfig | constructor configuration interface}.
+ */
+export interface JsonProtocolClientResolvedConfig extends JsonProtocolClientResolvedConfigType {}
 
 export class JsonProtocolClient extends __Client<
   __HttpHandlerOptions,
@@ -215,6 +223,9 @@ export class JsonProtocolClient extends __Client<
   ServiceOutputTypes,
   JsonProtocolClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of JsonProtocolClient class. This is resolved and normalized from the {@link JsonProtocolClientConfig | constructor configuration interface}.
+   */
   readonly config: JsonProtocolClientResolvedConfig;
 
   constructor(configuration: JsonProtocolClientConfig) {

--- a/protocol_tests/aws-query/QueryProtocolClient.ts
+++ b/protocol_tests/aws-query/QueryProtocolClient.ts
@@ -254,7 +254,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type QueryProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type QueryProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -262,8 +262,12 @@ export type QueryProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHand
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of QueryProtocolClient class constructor that set the region, credentials and other options.
+ */
+export interface QueryProtocolClientConfig extends QueryProtocolClientConfigType {}
 
-export type QueryProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type QueryProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -271,6 +275,10 @@ export type QueryProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of QueryProtocolClient class. This is resolved and normalized from the {@link QueryProtocolClientConfig | constructor configuration interface}.
+ */
+export interface QueryProtocolClientResolvedConfig extends QueryProtocolClientResolvedConfigType {}
 
 /**
  * A query service that sends query requests and XML responses.
@@ -281,6 +289,9 @@ export class QueryProtocolClient extends __Client<
   ServiceOutputTypes,
   QueryProtocolClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of QueryProtocolClient class. This is resolved and normalized from the {@link QueryProtocolClientConfig | constructor configuration interface}.
+   */
   readonly config: QueryProtocolClientResolvedConfig;
 
   constructor(configuration: QueryProtocolClientConfig) {

--- a/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
+++ b/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
@@ -332,7 +332,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RestJsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RestJsonProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -340,8 +340,12 @@ export type RestJsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RestJsonProtocolClient class constructor that set the region, credentials and other options.
+ */
+export interface RestJsonProtocolClientConfig extends RestJsonProtocolClientConfigType {}
 
-export type RestJsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RestJsonProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -349,6 +353,10 @@ export type RestJsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RestJsonProtocolClient class. This is resolved and normalized from the {@link RestJsonProtocolClientConfig | constructor configuration interface}.
+ */
+export interface RestJsonProtocolClientResolvedConfig extends RestJsonProtocolClientResolvedConfigType {}
 
 /**
  * A REST JSON service that sends JSON requests and responses.
@@ -359,6 +367,9 @@ export class RestJsonProtocolClient extends __Client<
   ServiceOutputTypes,
   RestJsonProtocolClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RestJsonProtocolClient class. This is resolved and normalized from the {@link RestJsonProtocolClientConfig | constructor configuration interface}.
+   */
   readonly config: RestJsonProtocolClientResolvedConfig;
 
   constructor(configuration: RestJsonProtocolClientConfig) {

--- a/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
@@ -365,7 +365,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type RestXmlProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type RestXmlProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -373,8 +373,12 @@ export type RestXmlProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of RestXmlProtocolClient class constructor that set the region, credentials and other options.
+ */
+export interface RestXmlProtocolClientConfig extends RestXmlProtocolClientConfigType {}
 
-export type RestXmlProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type RestXmlProtocolClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -382,6 +386,10 @@ export type RestXmlProtocolClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of RestXmlProtocolClient class. This is resolved and normalized from the {@link RestXmlProtocolClientConfig | constructor configuration interface}.
+ */
+export interface RestXmlProtocolClientResolvedConfig extends RestXmlProtocolClientResolvedConfigType {}
 
 /**
  * A REST XML service that sends XML requests and responses.
@@ -392,6 +400,9 @@ export class RestXmlProtocolClient extends __Client<
   ServiceOutputTypes,
   RestXmlProtocolClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of RestXmlProtocolClient class. This is resolved and normalized from the {@link RestXmlProtocolClientConfig | constructor configuration interface}.
+   */
   readonly config: RestXmlProtocolClientResolvedConfig;
 
   constructor(configuration: RestXmlProtocolClientConfig) {


### PR DESCRIPTION
### Description
This change improves the readability of client constructor interface.

Currently there's no way to get full list of client constructor parameter, because the options split into different modularized packages:
![beforeInterface](https://user-images.githubusercontent.com/7614947/115075690-54425c80-9eb0-11eb-95a1-47aa446b4acb.gif)

After the change, we will have full list of available options for client constructor and resolved config:
![afterInterface](https://user-images.githubusercontent.com/7614947/115075809-83f16480-9eb0-11eb-8c73-4d1a671c3f9f.gif)


### Testing
Tested locally

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
