### PR TITLE
docs(clients): remove unexpected STS commands

### DIFF
--- a/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -18,6 +18,7 @@ export class SdkClientTocPlugin extends RendererComponent {
   private commandsNavigationItem?: NavigationItem;
   private clientsNavigationItem?: NavigationItem;
   private paginatorsNavigationItem?: NavigationItem;
+  private waitersNavigationItem?: NavigationItem;
   private clientDir?: string;
 
   initialize() {
@@ -53,9 +54,15 @@ export class SdkClientTocPlugin extends RendererComponent {
       this.clientsNavigationItem = new NavigationItem("Clients", void 0, page.toc);
       this.commandsNavigationItem = new NavigationItem("Commands", void 0, page.toc);
       this.paginatorsNavigationItem = new NavigationItem("Paginators", void 0, page.toc);
+      this.waitersNavigationItem = new NavigationItem("Waiters", void 0, page.toc);
     }
 
     this.buildToc(model, trail, page.toc, tocRestriction);
+  }
+
+  // Confirm declaration comes from the same folder as the client class
+  private belongsToClientPackage(model: DeclarationReflection): boolean {
+    return this.clientDir && model.sources?.[0].file?.fullFileName.indexOf(this.clientDir) === 0;
   }
 
   private isClient(model: DeclarationReflection): boolean {
@@ -66,28 +73,36 @@ export class SdkClientTocPlugin extends RendererComponent {
       (model.name.endsWith("Client") /* Modular client like S3Client */ ||
         extendedTypes.filter((reference) => (reference as ReferenceType).name === `${model.name}Client`).length > 0) &&
       /* Filter out other client classes that not sourced from the same directory as current client. e.g. STS, SSO */
-      this.clientDir &&
-      dirname(model.sources[0]?.file.fullFileName) === this.clientDir
+      this.belongsToClientPackage(model)
     );
   }
 
   private isCommand(model: DeclarationReflection): boolean {
     return (
       model.kindOf(ReflectionKind.Class) &&
-      model.getFullName() !== "Command" && // Exclude the Smithy Command class.
       model.name.endsWith("Command") &&
-      model.children?.some((child) => child.name === "resolveMiddleware")
+      model.children?.some((child) => child.name === "resolveMiddleware") &&
+      this.belongsToClientPackage(model)
     );
   }
 
   private isPaginator(model: DeclarationReflection): boolean {
-    return model.name.startsWith("paginate") && model.kindOf(ReflectionKind.Function);
+    return (
+      model.name.startsWith("paginate") && model.kindOf(ReflectionKind.Function) && this.belongsToClientPackage(model)
+    );
   }
 
   private isInputOrOutput(model: DeclarationReflection): boolean {
     return (
       model.kindOf(ReflectionKind.Interface) &&
-      (model.name.endsWith("CommandInput") || model.name.endsWith("CommandOutput"))
+      (model.name.endsWith("CommandInput") || model.name.endsWith("CommandOutput")) &&
+      this.belongsToClientPackage(model)
+    );
+  }
+
+  private isWaiter(model: DeclarationReflection): boolean {
+    return (
+      model.name.startsWith("waitFor") && model.kindOf(ReflectionKind.Function) && this.belongsToClientPackage(model)
     );
   }
 
@@ -128,6 +143,8 @@ export class SdkClientTocPlugin extends RendererComponent {
           NavigationItem.create(child, this.paginatorsNavigationItem, true);
         } else if (this.isInputOrOutput(child)) {
           NavigationItem.create(child, this.commandsNavigationItem, true);
+        } else if (this.isWaiter(child)) {
+          NavigationItem.create(child, this.waitersNavigationItem, true);
         } else {
           const item = NavigationItem.create(child, parent, true);
           if (trail.includes(child)) {


### PR DESCRIPTION
### Descriptions
The current client reference contains unwanted commands from STS & SSO because they are pulled from the dependencies: like `AssumeRoleCommand` and `AssumeRoleWithSAMLCommand` in the screen shot bellow:
<details><summary>Current ToC screenshot</summary>
<p>

![Screen Shot 2021-04-21 at 9 58 14 AM](https://user-images.githubusercontent.com/7614947/115592685-5e85a180-a288-11eb-8f17-e69492e050e6.png)

</p>
</details>


This change moves these unwanted commands to the bottom:
<details><summary>New ToC screenshot</summary>
<p>

![Screen Shot 2021-04-21 at 9 57 53 AM](https://user-images.githubusercontent.com/7614947/115592670-5a598400-a288-11eb-999f-af6055d1f0d9.png)

</p>
</details>

This change also provide aggregation of the waiters.
<details><summary>Aggregation of Waiters</summary>
<p>

![Screen Shot 2021-04-21 at 9 58 34 AM](https://user-images.githubusercontent.com/7614947/115592694-62192880-a288-11eb-8382-62065d87afad.png)

</p>
</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
