### PR TITLE
chore(codegen,config-resolver): refactor how endpoint is resolved for non-AWS client

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -47,8 +47,14 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
                         .servicePredicate((m, s) -> isAwsService(s))
                         .build(),
+                // Only one of Endpoints or CustomEndpoints should be used
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Endpoints", HAS_CONFIG)
+                        .servicePredicate((m, s) -> isAwsService(s))
+                        .build(),
+                RuntimeClientPlugin.builder()
+                        .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "CustomEndpoints", HAS_CONFIG)
+                        .servicePredicate((m, s) -> !isAwsService(s))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "Retry")

--- a/packages/config-resolver/src/CustomEndpointsConfig.ts
+++ b/packages/config-resolver/src/CustomEndpointsConfig.ts
@@ -1,0 +1,45 @@
+// TODO: Create a .spec.ts for this
+import { Endpoint, Provider, UrlParser } from "@aws-sdk/types";
+
+export interface CustomEndpointsInputConfig {
+  /**
+   * The fully qualified endpoint of the webservice.
+   */
+  endpoint: string | Endpoint | Provider<Endpoint>;
+
+  /**
+   * Whether TLS is enabled for requests.
+   */
+  tls?: boolean;
+}
+
+interface PreviouslyResolved {
+  urlParser: UrlParser;
+}
+
+export interface CustomEndpointsResolvedConfig extends Required<CustomEndpointsInputConfig> {
+  endpoint: Provider<Endpoint>;
+  isCustomEndpoint: true; // TODO: Can this be removed or some other logic depends on this?
+}
+
+export const resolveCustomEndpointsConfig = <T>(
+  input: T & CustomEndpointsInputConfig & PreviouslyResolved
+): T & CustomEndpointsResolvedConfig => ({
+  ...input,
+  tls: input.tls ?? true,
+  endpoint: normalizeEndpoint(input),
+  isCustomEndpoint: true,
+});
+
+// TODO: can this be shared with EndpointsConfig.ts
+const normalizeEndpoint = (input: CustomEndpointsInputConfig & PreviouslyResolved): Provider<Endpoint> => {
+  const { endpoint, urlParser } = input;
+  if (typeof endpoint === "string") {
+    const promisified = Promise.resolve(urlParser(endpoint));
+    return () => promisified;
+  } else if (typeof endpoint === "object") {
+    const promisified = Promise.resolve(endpoint);
+    return () => promisified;
+  }
+  return endpoint;
+};

--- a/packages/config-resolver/src/EndpointsConfig.ts
+++ b/packages/config-resolver/src/EndpointsConfig.ts
@@ -13,9 +13,9 @@ export interface EndpointsInputConfig {
 }
 
 interface PreviouslyResolved {
-  regionInfoProvider?: RegionInfoProvider;
+  regionInfoProvider: RegionInfoProvider;
   urlParser: UrlParser;
-  region?: Provider<string>;
+  region: Provider<string>;
 }
 
 export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> {
@@ -45,10 +45,6 @@ const normalizeEndpoint = (input: EndpointsInputConfig & PreviouslyResolved): Pr
 };
 
 const getEndPointFromRegion = async (input: EndpointsInputConfig & PreviouslyResolved) => {
-  if (input.region === undefined || input.regionInfoProvider === undefined) {
-    throw new Error("No endpoint specified and region is not defined");
-  }
-
   const { tls = true } = input;
   const region = await input.region();
 

--- a/packages/config-resolver/src/index.ts
+++ b/packages/config-resolver/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./CustomEndpointsConfig";
 export * from "./EndpointsConfig";
 export * from "./RegionConfig";


### PR DESCRIPTION
### Description
This is a refactoring of my earlier attempt at getting a non-AWS client working wrt endpoint resolution. This addresses the concern in https://github.com/aws/aws-sdk-js-v3/pull/2279#discussion_r617402875 by separating out the logic used by AWS client v/s non-AWS client. Also makes endpoint required for non-AWS client, addressing https://github.com/adamthom-amzn/aws-sdk-js-v3/pull/1#issuecomment-804665638.

This approach adds some duplication. But seems to fit within the current plugin model in the codegen. Trying to use the same EndpointsConfig.ts but different methods/types would not fit easily into the ServiceGenerator logic. I thought it is better to have some minimal duplication in config-resolver than bigger restructing in codegen.

### Testing
I generated the client used in our smithy-typescript-ssdk-demo package and it worked with these changes.

### Questions:
* Let me know if `chore(codegen,config-resolver): refactor how endpoint is resolved for non-AWS client` matches the expectation of git commit titles for when this is squashed and merged. Or is `chore: refactor how endpoint is resolved for non-AWS client` better?
* EndpointsConfig and AwsEndpointsConfig may be better than NonAwsEndpointsConfig and EndpointsConfig. Is it fine to rename these? Or other suggestions on names. (edit): Using EndpointsConfig (for AWS) and CustomEndpointsConfig (for non-AWS) now. Let me know if other suggestions.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
