### PR TITLE
feat(clients): adding throwable waiters WaitUntil[operationState]

### DIFF
--- a/clients/client-acm-pca/waiters/waitForAuditReportCreated.ts
+++ b/clients/client-acm-pca/waiters/waitForAuditReportCreated.ts
@@ -36,9 +36,7 @@ const checkState = async (
 };
 /**
  * Wait until a Audit Report is created
- *  @deprecated In favor of waitUntilAuditReportCreated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeCertificateAuthorityAuditReportCommand for polling.
+ *  @deprecated Use waitUntilAuditReportCreated instead. waitForAuditReportCreated does not throw error in non-success cases.
  */
 export const waitForAuditReportCreated = async (
   params: WaiterConfiguration<ACMPCAClient>,

--- a/clients/client-acm-pca/waiters/waitForAuditReportCreated.ts
+++ b/clients/client-acm-pca/waiters/waitForAuditReportCreated.ts
@@ -36,9 +36,9 @@ const checkState = async (
 };
 /**
  * Wait until a Audit Report is created
- *  @deprecated in favor of waitUntilAuditReportCreated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCertificateAuthorityAuditReportCommand for polling.
+ *  @deprecated In favor of waitUntilAuditReportCreated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCertificateAuthorityAuditReportCommand for polling.
  */
 export const waitForAuditReportCreated = async (
   params: WaiterConfiguration<ACMPCAClient>,
@@ -49,8 +49,8 @@ export const waitForAuditReportCreated = async (
 };
 /**
  * Wait until a Audit Report is created
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCertificateAuthorityAuditReportCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCertificateAuthorityAuditReportCommand for polling.
  */
 export const waitUntilAuditReportCreated = async (
   params: WaiterConfiguration<ACMPCAClient>,

--- a/clients/client-acm-pca/waiters/waitForAuditReportCreated.ts
+++ b/clients/client-acm-pca/waiters/waitForAuditReportCreated.ts
@@ -3,20 +3,22 @@ import {
   DescribeCertificateAuthorityAuditReportCommand,
   DescribeCertificateAuthorityAuditReportCommandInput,
 } from "../commands/DescribeCertificateAuthorityAuditReportCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ACMPCAClient,
   input: DescribeCertificateAuthorityAuditReportCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeCertificateAuthorityAuditReportCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.AuditReportStatus;
       };
       if (returnComparator() === "SUCCESS") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -24,14 +26,17 @@ const checkState = async (
         return result.AuditReportStatus;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a Audit Report is created
+ *  @deprecated in favor of waitUntilAuditReportCreated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeCertificateAuthorityAuditReportCommand for polling.
  */
@@ -41,4 +46,17 @@ export const waitForAuditReportCreated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a Audit Report is created
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeCertificateAuthorityAuditReportCommand for polling.
+ */
+export const waitUntilAuditReportCreated = async (
+  params: WaiterConfiguration<ACMPCAClient>,
+  input: DescribeCertificateAuthorityAuditReportCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-acm-pca/waiters/waitForCertificateAuthorityCSRCreated.ts
+++ b/clients/client-acm-pca/waiters/waitForCertificateAuthorityCSRCreated.ts
@@ -24,9 +24,9 @@ const checkState = async (
 };
 /**
  * Wait until a Certificate Authority CSR is created
- *  @deprecated in favor of waitUntilCertificateAuthorityCSRCreated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetCertificateAuthorityCsrCommand for polling.
+ *  @deprecated In favor of waitUntilCertificateAuthorityCSRCreated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetCertificateAuthorityCsrCommand for polling.
  */
 export const waitForCertificateAuthorityCSRCreated = async (
   params: WaiterConfiguration<ACMPCAClient>,
@@ -37,8 +37,8 @@ export const waitForCertificateAuthorityCSRCreated = async (
 };
 /**
  * Wait until a Certificate Authority CSR is created
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetCertificateAuthorityCsrCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetCertificateAuthorityCsrCommand for polling.
  */
 export const waitUntilCertificateAuthorityCSRCreated = async (
   params: WaiterConfiguration<ACMPCAClient>,

--- a/clients/client-acm-pca/waiters/waitForCertificateAuthorityCSRCreated.ts
+++ b/clients/client-acm-pca/waiters/waitForCertificateAuthorityCSRCreated.ts
@@ -24,9 +24,7 @@ const checkState = async (
 };
 /**
  * Wait until a Certificate Authority CSR is created
- *  @deprecated In favor of waitUntilCertificateAuthorityCSRCreated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetCertificateAuthorityCsrCommand for polling.
+ *  @deprecated Use waitUntilCertificateAuthorityCSRCreated instead. waitForCertificateAuthorityCSRCreated does not throw error in non-success cases.
  */
 export const waitForCertificateAuthorityCSRCreated = async (
   params: WaiterConfiguration<ACMPCAClient>,

--- a/clients/client-acm-pca/waiters/waitForCertificateAuthorityCSRCreated.ts
+++ b/clients/client-acm-pca/waiters/waitForCertificateAuthorityCSRCreated.ts
@@ -3,24 +3,28 @@ import {
   GetCertificateAuthorityCsrCommand,
   GetCertificateAuthorityCsrCommandInput,
 } from "../commands/GetCertificateAuthorityCsrCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ACMPCAClient,
   input: GetCertificateAuthorityCsrCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetCertificateAuthorityCsrCommand(input));
-    return { state: WaiterState.SUCCESS };
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "RequestInProgressException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a Certificate Authority CSR is created
+ *  @deprecated in favor of waitUntilCertificateAuthorityCSRCreated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetCertificateAuthorityCsrCommand for polling.
  */
@@ -30,4 +34,17 @@ export const waitForCertificateAuthorityCSRCreated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a Certificate Authority CSR is created
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetCertificateAuthorityCsrCommand for polling.
+ */
+export const waitUntilCertificateAuthorityCSRCreated = async (
+  params: WaiterConfiguration<ACMPCAClient>,
+  input: GetCertificateAuthorityCsrCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-acm-pca/waiters/waitForCertificateIssued.ts
+++ b/clients/client-acm-pca/waiters/waitForCertificateIssued.ts
@@ -18,9 +18,9 @@ const checkState = async (client: ACMPCAClient, input: GetCertificateCommandInpu
 };
 /**
  * Wait until a certificate is issued
- *  @deprecated in favor of waitUntilCertificateIssued. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetCertificateCommand for polling.
+ *  @deprecated In favor of waitUntilCertificateIssued. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetCertificateCommand for polling.
  */
 export const waitForCertificateIssued = async (
   params: WaiterConfiguration<ACMPCAClient>,
@@ -31,8 +31,8 @@ export const waitForCertificateIssued = async (
 };
 /**
  * Wait until a certificate is issued
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetCertificateCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetCertificateCommand for polling.
  */
 export const waitUntilCertificateIssued = async (
   params: WaiterConfiguration<ACMPCAClient>,

--- a/clients/client-acm-pca/waiters/waitForCertificateIssued.ts
+++ b/clients/client-acm-pca/waiters/waitForCertificateIssued.ts
@@ -1,20 +1,24 @@
 import { ACMPCAClient } from "../ACMPCAClient";
 import { GetCertificateCommand, GetCertificateCommandInput } from "../commands/GetCertificateCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: ACMPCAClient, input: GetCertificateCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetCertificateCommand(input));
-    return { state: WaiterState.SUCCESS };
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "RequestInProgressException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a certificate is issued
+ *  @deprecated in favor of waitUntilCertificateIssued. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetCertificateCommand for polling.
  */
@@ -24,4 +28,17 @@ export const waitForCertificateIssued = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a certificate is issued
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetCertificateCommand for polling.
+ */
+export const waitUntilCertificateIssued = async (
+  params: WaiterConfiguration<ACMPCAClient>,
+  input: GetCertificateCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-acm-pca/waiters/waitForCertificateIssued.ts
+++ b/clients/client-acm-pca/waiters/waitForCertificateIssued.ts
@@ -18,9 +18,7 @@ const checkState = async (client: ACMPCAClient, input: GetCertificateCommandInpu
 };
 /**
  * Wait until a certificate is issued
- *  @deprecated In favor of waitUntilCertificateIssued. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetCertificateCommand for polling.
+ *  @deprecated Use waitUntilCertificateIssued instead. waitForCertificateIssued does not throw error in non-success cases.
  */
 export const waitForCertificateIssued = async (
   params: WaiterConfiguration<ACMPCAClient>,

--- a/clients/client-acm/waiters/waitForCertificateValidated.ts
+++ b/clients/client-acm/waiters/waitForCertificateValidated.ts
@@ -55,9 +55,9 @@ const checkState = async (client: ACMClient, input: DescribeCertificateCommandIn
 };
 /**
  *
- *  @deprecated in favor of waitUntilCertificateValidated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCertificateCommand for polling.
+ *  @deprecated In favor of waitUntilCertificateValidated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCertificateCommand for polling.
  */
 export const waitForCertificateValidated = async (
   params: WaiterConfiguration<ACMClient>,
@@ -68,8 +68,8 @@ export const waitForCertificateValidated = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCertificateCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCertificateCommand for polling.
  */
 export const waitUntilCertificateValidated = async (
   params: WaiterConfiguration<ACMClient>,

--- a/clients/client-acm/waiters/waitForCertificateValidated.ts
+++ b/clients/client-acm/waiters/waitForCertificateValidated.ts
@@ -1,10 +1,12 @@
 import { ACMClient } from "../ACMClient";
 import { DescribeCertificateCommand, DescribeCertificateCommandInput } from "../commands/DescribeCertificateCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: ACMClient, input: DescribeCertificateCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeCertificateCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Certificate.DomainValidationOptions);
@@ -18,7 +20,7 @@ const checkState = async (client: ACMClient, input: DescribeCertificateCommandIn
         allStringEq_5 = allStringEq_5 && element_4 == "SUCCESS";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: ACMClient, input: DescribeCertificateCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "PENDING_VALIDATION") {
-          return { state: WaiterState.RETRY };
+          return { state: WaiterState.RETRY, reason };
         }
       }
     } catch (e) {}
@@ -40,18 +42,20 @@ const checkState = async (client: ACMClient, input: DescribeCertificateCommandIn
         return result.Certificate.Status;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.FAILURE };
+      return { state: WaiterState.FAILURE, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilCertificateValidated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeCertificateCommand for polling.
  */
@@ -61,4 +65,17 @@ export const waitForCertificateValidated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 60, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeCertificateCommand for polling.
+ */
+export const waitUntilCertificateValidated = async (
+  params: WaiterConfiguration<ACMClient>,
+  input: DescribeCertificateCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 60, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-acm/waiters/waitForCertificateValidated.ts
+++ b/clients/client-acm/waiters/waitForCertificateValidated.ts
@@ -55,9 +55,7 @@ const checkState = async (client: ACMClient, input: DescribeCertificateCommandIn
 };
 /**
  *
- *  @deprecated In favor of waitUntilCertificateValidated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeCertificateCommand for polling.
+ *  @deprecated Use waitUntilCertificateValidated instead. waitForCertificateValidated does not throw error in non-success cases.
  */
 export const waitForCertificateValidated = async (
   params: WaiterConfiguration<ACMClient>,

--- a/clients/client-appstream/waiters/waitForFleetStarted.ts
+++ b/clients/client-appstream/waiters/waitForFleetStarted.ts
@@ -58,9 +58,9 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
 };
 /**
  *
- *  @deprecated in favor of waitUntilFleetStarted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFleetsCommand for polling.
+ *  @deprecated In favor of waitUntilFleetStarted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFleetsCommand for polling.
  */
 export const waitForFleetStarted = async (
   params: WaiterConfiguration<AppStreamClient>,
@@ -71,8 +71,8 @@ export const waitForFleetStarted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFleetsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFleetsCommand for polling.
  */
 export const waitUntilFleetStarted = async (
   params: WaiterConfiguration<AppStreamClient>,

--- a/clients/client-appstream/waiters/waitForFleetStarted.ts
+++ b/clients/client-appstream/waiters/waitForFleetStarted.ts
@@ -58,9 +58,7 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
 };
 /**
  *
- *  @deprecated In favor of waitUntilFleetStarted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeFleetsCommand for polling.
+ *  @deprecated Use waitUntilFleetStarted instead. waitForFleetStarted does not throw error in non-success cases.
  */
 export const waitForFleetStarted = async (
   params: WaiterConfiguration<AppStreamClient>,

--- a/clients/client-appstream/waiters/waitForFleetStarted.ts
+++ b/clients/client-appstream/waiters/waitForFleetStarted.ts
@@ -1,10 +1,12 @@
 import { AppStreamClient } from "../AppStreamClient";
 import { DescribeFleetsCommand, DescribeFleetsCommandInput } from "../commands/DescribeFleetsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeFleetsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Fleets);
@@ -18,7 +20,7 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
         allStringEq_5 = allStringEq_5 && element_4 == "ACTIVE";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "PENDING_DEACTIVATE") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,15 +47,18 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "INACTIVE") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilFleetStarted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeFleetsCommand for polling.
  */
@@ -63,4 +68,17 @@ export const waitForFleetStarted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeFleetsCommand for polling.
+ */
+export const waitUntilFleetStarted = async (
+  params: WaiterConfiguration<AppStreamClient>,
+  input: DescribeFleetsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-appstream/waiters/waitForFleetStopped.ts
+++ b/clients/client-appstream/waiters/waitForFleetStopped.ts
@@ -58,9 +58,9 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
 };
 /**
  *
- *  @deprecated in favor of waitUntilFleetStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFleetsCommand for polling.
+ *  @deprecated In favor of waitUntilFleetStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFleetsCommand for polling.
  */
 export const waitForFleetStopped = async (
   params: WaiterConfiguration<AppStreamClient>,
@@ -71,8 +71,8 @@ export const waitForFleetStopped = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFleetsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFleetsCommand for polling.
  */
 export const waitUntilFleetStopped = async (
   params: WaiterConfiguration<AppStreamClient>,

--- a/clients/client-appstream/waiters/waitForFleetStopped.ts
+++ b/clients/client-appstream/waiters/waitForFleetStopped.ts
@@ -1,10 +1,12 @@
 import { AppStreamClient } from "../AppStreamClient";
 import { DescribeFleetsCommand, DescribeFleetsCommandInput } from "../commands/DescribeFleetsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeFleetsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Fleets);
@@ -18,7 +20,7 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
         allStringEq_5 = allStringEq_5 && element_4 == "INACTIVE";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "PENDING_ACTIVATE") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,15 +47,18 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "ACTIVE") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilFleetStopped. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeFleetsCommand for polling.
  */
@@ -63,4 +68,17 @@ export const waitForFleetStopped = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeFleetsCommand for polling.
+ */
+export const waitUntilFleetStopped = async (
+  params: WaiterConfiguration<AppStreamClient>,
+  input: DescribeFleetsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-appstream/waiters/waitForFleetStopped.ts
+++ b/clients/client-appstream/waiters/waitForFleetStopped.ts
@@ -58,9 +58,7 @@ const checkState = async (client: AppStreamClient, input: DescribeFleetsCommandI
 };
 /**
  *
- *  @deprecated In favor of waitUntilFleetStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeFleetsCommand for polling.
+ *  @deprecated Use waitUntilFleetStopped instead. waitForFleetStopped does not throw error in non-success cases.
  */
 export const waitForFleetStopped = async (
   params: WaiterConfiguration<AppStreamClient>,

--- a/clients/client-auto-scaling/waiters/waitForGroupExists.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupExists.ts
@@ -36,9 +36,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilGroupExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
+ *  @deprecated Use waitUntilGroupExists instead. waitForGroupExists does not throw error in non-success cases.
  */
 export const waitForGroupExists = async (
   params: WaiterConfiguration<AutoScalingClient>,

--- a/clients/client-auto-scaling/waiters/waitForGroupExists.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupExists.ts
@@ -36,9 +36,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilGroupExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ *  @deprecated In favor of waitUntilGroupExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
  */
 export const waitForGroupExists = async (
   params: WaiterConfiguration<AutoScalingClient>,
@@ -49,8 +49,8 @@ export const waitForGroupExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
  */
 export const waitUntilGroupExists = async (
   params: WaiterConfiguration<AutoScalingClient>,

--- a/clients/client-auto-scaling/waiters/waitForGroupExists.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupExists.ts
@@ -3,20 +3,22 @@ import {
   DescribeAutoScalingGroupsCommand,
   DescribeAutoScalingGroupsCommandInput,
 } from "../commands/DescribeAutoScalingGroupsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: AutoScalingClient,
   input: DescribeAutoScalingGroupsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAutoScalingGroupsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.AutoScalingGroups.length > 0.0;
       };
       if (returnComparator() == true) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -24,14 +26,17 @@ const checkState = async (
         return result.AutoScalingGroups.length > 0.0;
       };
       if (returnComparator() == false) {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilGroupExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
  */
@@ -41,4 +46,17 @@ export const waitForGroupExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ */
+export const waitUntilGroupExists = async (
+  params: WaiterConfiguration<AutoScalingClient>,
+  input: DescribeAutoScalingGroupsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-auto-scaling/waiters/waitForGroupInService.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupInService.ts
@@ -58,9 +58,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilGroupInService. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
+ *  @deprecated Use waitUntilGroupInService instead. waitForGroupInService does not throw error in non-success cases.
  */
 export const waitForGroupInService = async (
   params: WaiterConfiguration<AutoScalingClient>,

--- a/clients/client-auto-scaling/waiters/waitForGroupInService.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupInService.ts
@@ -58,9 +58,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilGroupInService. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ *  @deprecated In favor of waitUntilGroupInService. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
  */
 export const waitForGroupInService = async (
   params: WaiterConfiguration<AutoScalingClient>,
@@ -71,8 +71,8 @@ export const waitForGroupInService = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
  */
 export const waitUntilGroupInService = async (
   params: WaiterConfiguration<AutoScalingClient>,

--- a/clients/client-auto-scaling/waiters/waitForGroupInService.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupInService.ts
@@ -3,14 +3,16 @@ import {
   DescribeAutoScalingGroupsCommand,
   DescribeAutoScalingGroupsCommandInput,
 } from "../commands/DescribeAutoScalingGroupsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: AutoScalingClient,
   input: DescribeAutoScalingGroupsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAutoScalingGroupsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.AutoScalingGroups);
@@ -27,7 +29,7 @@ const checkState = async (
         return flat_7.includes(false);
       };
       if (returnComparator() == false) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -46,14 +48,17 @@ const checkState = async (
         return flat_7.includes(false);
       };
       if (returnComparator() == true) {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilGroupInService. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
  */
@@ -63,4 +68,17 @@ export const waitForGroupInService = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ */
+export const waitUntilGroupInService = async (
+  params: WaiterConfiguration<AutoScalingClient>,
+  input: DescribeAutoScalingGroupsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-auto-scaling/waiters/waitForGroupNotExists.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupNotExists.ts
@@ -36,9 +36,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilGroupNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ *  @deprecated In favor of waitUntilGroupNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
  */
 export const waitForGroupNotExists = async (
   params: WaiterConfiguration<AutoScalingClient>,
@@ -49,8 +49,8 @@ export const waitForGroupNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAutoScalingGroupsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
  */
 export const waitUntilGroupNotExists = async (
   params: WaiterConfiguration<AutoScalingClient>,

--- a/clients/client-auto-scaling/waiters/waitForGroupNotExists.ts
+++ b/clients/client-auto-scaling/waiters/waitForGroupNotExists.ts
@@ -36,9 +36,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilGroupNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAutoScalingGroupsCommand for polling.
+ *  @deprecated Use waitUntilGroupNotExists instead. waitForGroupNotExists does not throw error in non-success cases.
  */
 export const waitForGroupNotExists = async (
   params: WaiterConfiguration<AutoScalingClient>,

--- a/clients/client-cloudformation/waiters/waitForTypeRegistrationComplete.ts
+++ b/clients/client-cloudformation/waiters/waitForTypeRegistrationComplete.ts
@@ -36,9 +36,9 @@ const checkState = async (
 };
 /**
  * Wait until type registration is COMPLETE.
- *  @deprecated in favor of waitUntilTypeRegistrationComplete. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTypeRegistrationCommand for polling.
+ *  @deprecated In favor of waitUntilTypeRegistrationComplete. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTypeRegistrationCommand for polling.
  */
 export const waitForTypeRegistrationComplete = async (
   params: WaiterConfiguration<CloudFormationClient>,
@@ -49,8 +49,8 @@ export const waitForTypeRegistrationComplete = async (
 };
 /**
  * Wait until type registration is COMPLETE.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTypeRegistrationCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTypeRegistrationCommand for polling.
  */
 export const waitUntilTypeRegistrationComplete = async (
   params: WaiterConfiguration<CloudFormationClient>,

--- a/clients/client-cloudformation/waiters/waitForTypeRegistrationComplete.ts
+++ b/clients/client-cloudformation/waiters/waitForTypeRegistrationComplete.ts
@@ -36,9 +36,7 @@ const checkState = async (
 };
 /**
  * Wait until type registration is COMPLETE.
- *  @deprecated In favor of waitUntilTypeRegistrationComplete. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeTypeRegistrationCommand for polling.
+ *  @deprecated Use waitUntilTypeRegistrationComplete instead. waitForTypeRegistrationComplete does not throw error in non-success cases.
  */
 export const waitForTypeRegistrationComplete = async (
   params: WaiterConfiguration<CloudFormationClient>,

--- a/clients/client-cloudformation/waiters/waitForTypeRegistrationComplete.ts
+++ b/clients/client-cloudformation/waiters/waitForTypeRegistrationComplete.ts
@@ -3,20 +3,22 @@ import {
   DescribeTypeRegistrationCommand,
   DescribeTypeRegistrationCommandInput,
 } from "../commands/DescribeTypeRegistrationCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: CloudFormationClient,
   input: DescribeTypeRegistrationCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeTypeRegistrationCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.ProgressStatus;
       };
       if (returnComparator() === "COMPLETE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -24,14 +26,17 @@ const checkState = async (
         return result.ProgressStatus;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until type registration is COMPLETE.
+ *  @deprecated in favor of waitUntilTypeRegistrationComplete. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeTypeRegistrationCommand for polling.
  */
@@ -41,4 +46,17 @@ export const waitForTypeRegistrationComplete = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until type registration is COMPLETE.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeTypeRegistrationCommand for polling.
+ */
+export const waitUntilTypeRegistrationComplete = async (
+  params: WaiterConfiguration<CloudFormationClient>,
+  input: DescribeTypeRegistrationCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-cloudfront/waiters/waitForDistributionDeployed.ts
+++ b/clients/client-cloudfront/waiters/waitForDistributionDeployed.ts
@@ -22,9 +22,9 @@ const checkState = async (client: CloudFrontClient, input: GetDistributionComman
 };
 /**
  * Wait until a distribution is deployed.
- *  @deprecated in favor of waitUntilDistributionDeployed. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetDistributionCommand for polling.
+ *  @deprecated In favor of waitUntilDistributionDeployed. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetDistributionCommand for polling.
  */
 export const waitForDistributionDeployed = async (
   params: WaiterConfiguration<CloudFrontClient>,
@@ -35,8 +35,8 @@ export const waitForDistributionDeployed = async (
 };
 /**
  * Wait until a distribution is deployed.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetDistributionCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetDistributionCommand for polling.
  */
 export const waitUntilDistributionDeployed = async (
   params: WaiterConfiguration<CloudFrontClient>,

--- a/clients/client-cloudfront/waiters/waitForDistributionDeployed.ts
+++ b/clients/client-cloudfront/waiters/waitForDistributionDeployed.ts
@@ -1,23 +1,28 @@
 import { CloudFrontClient } from "../CloudFrontClient";
 import { GetDistributionCommand, GetDistributionCommandInput } from "../commands/GetDistributionCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: CloudFrontClient, input: GetDistributionCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetDistributionCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Distribution.Status;
       };
       if (returnComparator() === "Deployed") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a distribution is deployed.
+ *  @deprecated in favor of waitUntilDistributionDeployed. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetDistributionCommand for polling.
  */
@@ -27,4 +32,17 @@ export const waitForDistributionDeployed = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 60, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a distribution is deployed.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetDistributionCommand for polling.
+ */
+export const waitUntilDistributionDeployed = async (
+  params: WaiterConfiguration<CloudFrontClient>,
+  input: GetDistributionCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 60, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-cloudfront/waiters/waitForDistributionDeployed.ts
+++ b/clients/client-cloudfront/waiters/waitForDistributionDeployed.ts
@@ -22,9 +22,7 @@ const checkState = async (client: CloudFrontClient, input: GetDistributionComman
 };
 /**
  * Wait until a distribution is deployed.
- *  @deprecated In favor of waitUntilDistributionDeployed. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetDistributionCommand for polling.
+ *  @deprecated Use waitUntilDistributionDeployed instead. waitForDistributionDeployed does not throw error in non-success cases.
  */
 export const waitForDistributionDeployed = async (
   params: WaiterConfiguration<CloudFrontClient>,

--- a/clients/client-cloudfront/waiters/waitForInvalidationCompleted.ts
+++ b/clients/client-cloudfront/waiters/waitForInvalidationCompleted.ts
@@ -1,23 +1,28 @@
 import { CloudFrontClient } from "../CloudFrontClient";
 import { GetInvalidationCommand, GetInvalidationCommandInput } from "../commands/GetInvalidationCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: CloudFrontClient, input: GetInvalidationCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetInvalidationCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Invalidation.Status;
       };
       if (returnComparator() === "Completed") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until an invalidation has completed.
+ *  @deprecated in favor of waitUntilInvalidationCompleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetInvalidationCommand for polling.
  */
@@ -27,4 +32,17 @@ export const waitForInvalidationCompleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 20, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until an invalidation has completed.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetInvalidationCommand for polling.
+ */
+export const waitUntilInvalidationCompleted = async (
+  params: WaiterConfiguration<CloudFrontClient>,
+  input: GetInvalidationCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 20, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-cloudfront/waiters/waitForInvalidationCompleted.ts
+++ b/clients/client-cloudfront/waiters/waitForInvalidationCompleted.ts
@@ -22,9 +22,9 @@ const checkState = async (client: CloudFrontClient, input: GetInvalidationComman
 };
 /**
  * Wait until an invalidation has completed.
- *  @deprecated in favor of waitUntilInvalidationCompleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetInvalidationCommand for polling.
+ *  @deprecated In favor of waitUntilInvalidationCompleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetInvalidationCommand for polling.
  */
 export const waitForInvalidationCompleted = async (
   params: WaiterConfiguration<CloudFrontClient>,
@@ -35,8 +35,8 @@ export const waitForInvalidationCompleted = async (
 };
 /**
  * Wait until an invalidation has completed.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetInvalidationCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetInvalidationCommand for polling.
  */
 export const waitUntilInvalidationCompleted = async (
   params: WaiterConfiguration<CloudFrontClient>,

--- a/clients/client-cloudfront/waiters/waitForInvalidationCompleted.ts
+++ b/clients/client-cloudfront/waiters/waitForInvalidationCompleted.ts
@@ -22,9 +22,7 @@ const checkState = async (client: CloudFrontClient, input: GetInvalidationComman
 };
 /**
  * Wait until an invalidation has completed.
- *  @deprecated In favor of waitUntilInvalidationCompleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetInvalidationCommand for polling.
+ *  @deprecated Use waitUntilInvalidationCompleted instead. waitForInvalidationCompleted does not throw error in non-success cases.
  */
 export const waitForInvalidationCompleted = async (
   params: WaiterConfiguration<CloudFrontClient>,

--- a/clients/client-cloudfront/waiters/waitForStreamingDistributionDeployed.ts
+++ b/clients/client-cloudfront/waiters/waitForStreamingDistributionDeployed.ts
@@ -28,9 +28,9 @@ const checkState = async (
 };
 /**
  * Wait until a streaming distribution is deployed.
- *  @deprecated in favor of waitUntilStreamingDistributionDeployed. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetStreamingDistributionCommand for polling.
+ *  @deprecated In favor of waitUntilStreamingDistributionDeployed. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetStreamingDistributionCommand for polling.
  */
 export const waitForStreamingDistributionDeployed = async (
   params: WaiterConfiguration<CloudFrontClient>,
@@ -41,8 +41,8 @@ export const waitForStreamingDistributionDeployed = async (
 };
 /**
  * Wait until a streaming distribution is deployed.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetStreamingDistributionCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetStreamingDistributionCommand for polling.
  */
 export const waitUntilStreamingDistributionDeployed = async (
   params: WaiterConfiguration<CloudFrontClient>,

--- a/clients/client-cloudfront/waiters/waitForStreamingDistributionDeployed.ts
+++ b/clients/client-cloudfront/waiters/waitForStreamingDistributionDeployed.ts
@@ -3,27 +3,32 @@ import {
   GetStreamingDistributionCommand,
   GetStreamingDistributionCommandInput,
 } from "../commands/GetStreamingDistributionCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: CloudFrontClient,
   input: GetStreamingDistributionCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetStreamingDistributionCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.StreamingDistribution.Status;
       };
       if (returnComparator() === "Deployed") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a streaming distribution is deployed.
+ *  @deprecated in favor of waitUntilStreamingDistributionDeployed. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetStreamingDistributionCommand for polling.
  */
@@ -33,4 +38,17 @@ export const waitForStreamingDistributionDeployed = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 60, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a streaming distribution is deployed.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetStreamingDistributionCommand for polling.
+ */
+export const waitUntilStreamingDistributionDeployed = async (
+  params: WaiterConfiguration<CloudFrontClient>,
+  input: GetStreamingDistributionCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 60, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-cloudfront/waiters/waitForStreamingDistributionDeployed.ts
+++ b/clients/client-cloudfront/waiters/waitForStreamingDistributionDeployed.ts
@@ -28,9 +28,7 @@ const checkState = async (
 };
 /**
  * Wait until a streaming distribution is deployed.
- *  @deprecated In favor of waitUntilStreamingDistributionDeployed. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetStreamingDistributionCommand for polling.
+ *  @deprecated Use waitUntilStreamingDistributionDeployed instead. waitForStreamingDistributionDeployed does not throw error in non-success cases.
  */
 export const waitForStreamingDistributionDeployed = async (
   params: WaiterConfiguration<CloudFrontClient>,

--- a/clients/client-cloudwatch/waiters/waitForAlarmExists.ts
+++ b/clients/client-cloudwatch/waiters/waitForAlarmExists.ts
@@ -23,9 +23,9 @@ const checkState = async (client: CloudWatchClient, input: DescribeAlarmsCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilAlarmExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAlarmsCommand for polling.
+ *  @deprecated In favor of waitUntilAlarmExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAlarmsCommand for polling.
  */
 export const waitForAlarmExists = async (
   params: WaiterConfiguration<CloudWatchClient>,
@@ -36,8 +36,8 @@ export const waitForAlarmExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAlarmsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAlarmsCommand for polling.
  */
 export const waitUntilAlarmExists = async (
   params: WaiterConfiguration<CloudWatchClient>,

--- a/clients/client-cloudwatch/waiters/waitForAlarmExists.ts
+++ b/clients/client-cloudwatch/waiters/waitForAlarmExists.ts
@@ -1,24 +1,29 @@
 import { CloudWatchClient } from "../CloudWatchClient";
 import { DescribeAlarmsCommand, DescribeAlarmsCommandInput } from "../commands/DescribeAlarmsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: CloudWatchClient, input: DescribeAlarmsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAlarmsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.MetricAlarms);
         return flat_1.length > 0.0;
       };
       if (returnComparator() == true) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAlarmExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAlarmsCommand for polling.
  */
@@ -28,4 +33,17 @@ export const waitForAlarmExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAlarmsCommand for polling.
+ */
+export const waitUntilAlarmExists = async (
+  params: WaiterConfiguration<CloudWatchClient>,
+  input: DescribeAlarmsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-cloudwatch/waiters/waitForAlarmExists.ts
+++ b/clients/client-cloudwatch/waiters/waitForAlarmExists.ts
@@ -23,9 +23,7 @@ const checkState = async (client: CloudWatchClient, input: DescribeAlarmsCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilAlarmExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAlarmsCommand for polling.
+ *  @deprecated Use waitUntilAlarmExists instead. waitForAlarmExists does not throw error in non-success cases.
  */
 export const waitForAlarmExists = async (
   params: WaiterConfiguration<CloudWatchClient>,

--- a/clients/client-cloudwatch/waiters/waitForCompositeAlarmExists.ts
+++ b/clients/client-cloudwatch/waiters/waitForCompositeAlarmExists.ts
@@ -23,9 +23,9 @@ const checkState = async (client: CloudWatchClient, input: DescribeAlarmsCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilCompositeAlarmExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAlarmsCommand for polling.
+ *  @deprecated In favor of waitUntilCompositeAlarmExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAlarmsCommand for polling.
  */
 export const waitForCompositeAlarmExists = async (
   params: WaiterConfiguration<CloudWatchClient>,
@@ -36,8 +36,8 @@ export const waitForCompositeAlarmExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAlarmsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAlarmsCommand for polling.
  */
 export const waitUntilCompositeAlarmExists = async (
   params: WaiterConfiguration<CloudWatchClient>,

--- a/clients/client-cloudwatch/waiters/waitForCompositeAlarmExists.ts
+++ b/clients/client-cloudwatch/waiters/waitForCompositeAlarmExists.ts
@@ -1,24 +1,29 @@
 import { CloudWatchClient } from "../CloudWatchClient";
 import { DescribeAlarmsCommand, DescribeAlarmsCommandInput } from "../commands/DescribeAlarmsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: CloudWatchClient, input: DescribeAlarmsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAlarmsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.CompositeAlarms);
         return flat_1.length > 0.0;
       };
       if (returnComparator() == true) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilCompositeAlarmExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAlarmsCommand for polling.
  */
@@ -28,4 +33,17 @@ export const waitForCompositeAlarmExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAlarmsCommand for polling.
+ */
+export const waitUntilCompositeAlarmExists = async (
+  params: WaiterConfiguration<CloudWatchClient>,
+  input: DescribeAlarmsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-cloudwatch/waiters/waitForCompositeAlarmExists.ts
+++ b/clients/client-cloudwatch/waiters/waitForCompositeAlarmExists.ts
@@ -23,9 +23,7 @@ const checkState = async (client: CloudWatchClient, input: DescribeAlarmsCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilCompositeAlarmExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAlarmsCommand for polling.
+ *  @deprecated Use waitUntilCompositeAlarmExists instead. waitForCompositeAlarmExists does not throw error in non-success cases.
  */
 export const waitForCompositeAlarmExists = async (
   params: WaiterConfiguration<CloudWatchClient>,

--- a/clients/client-codedeploy/waiters/waitForDeploymentSuccessful.ts
+++ b/clients/client-codedeploy/waiters/waitForDeploymentSuccessful.ts
@@ -38,9 +38,9 @@ const checkState = async (client: CodeDeployClient, input: GetDeploymentCommandI
 };
 /**
  *
- *  @deprecated in favor of waitUntilDeploymentSuccessful. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetDeploymentCommand for polling.
+ *  @deprecated In favor of waitUntilDeploymentSuccessful. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetDeploymentCommand for polling.
  */
 export const waitForDeploymentSuccessful = async (
   params: WaiterConfiguration<CodeDeployClient>,
@@ -51,8 +51,8 @@ export const waitForDeploymentSuccessful = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetDeploymentCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetDeploymentCommand for polling.
  */
 export const waitUntilDeploymentSuccessful = async (
   params: WaiterConfiguration<CodeDeployClient>,

--- a/clients/client-codedeploy/waiters/waitForDeploymentSuccessful.ts
+++ b/clients/client-codedeploy/waiters/waitForDeploymentSuccessful.ts
@@ -38,9 +38,7 @@ const checkState = async (client: CodeDeployClient, input: GetDeploymentCommandI
 };
 /**
  *
- *  @deprecated In favor of waitUntilDeploymentSuccessful. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetDeploymentCommand for polling.
+ *  @deprecated Use waitUntilDeploymentSuccessful instead. waitForDeploymentSuccessful does not throw error in non-success cases.
  */
 export const waitForDeploymentSuccessful = async (
   params: WaiterConfiguration<CodeDeployClient>,

--- a/clients/client-codedeploy/waiters/waitForDeploymentSuccessful.ts
+++ b/clients/client-codedeploy/waiters/waitForDeploymentSuccessful.ts
@@ -1,16 +1,18 @@
 import { CodeDeployClient } from "../CodeDeployClient";
 import { GetDeploymentCommand, GetDeploymentCommandInput } from "../commands/GetDeploymentCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: CodeDeployClient, input: GetDeploymentCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetDeploymentCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.deploymentInfo.status;
       };
       if (returnComparator() === "Succeeded") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: CodeDeployClient, input: GetDeploymentCommandI
         return result.deploymentInfo.status;
       };
       if (returnComparator() === "Failed") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -26,14 +28,17 @@ const checkState = async (client: CodeDeployClient, input: GetDeploymentCommandI
         return result.deploymentInfo.status;
       };
       if (returnComparator() === "Stopped") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDeploymentSuccessful. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetDeploymentCommand for polling.
  */
@@ -43,4 +48,17 @@ export const waitForDeploymentSuccessful = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetDeploymentCommand for polling.
+ */
+export const waitUntilDeploymentSuccessful = async (
+  params: WaiterConfiguration<CodeDeployClient>,
+  input: GetDeploymentCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForEndpointDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForEndpointDeleted.ts
@@ -48,9 +48,9 @@ const checkState = async (
 };
 /**
  * Wait until testing endpoint is deleted.
- *  @deprecated in favor of waitUntilEndpointDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEndpointsCommand for polling.
+ *  @deprecated In favor of waitUntilEndpointDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEndpointsCommand for polling.
  */
 export const waitForEndpointDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -61,8 +61,8 @@ export const waitForEndpointDeleted = async (
 };
 /**
  * Wait until testing endpoint is deleted.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEndpointsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEndpointsCommand for polling.
  */
 export const waitUntilEndpointDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForEndpointDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForEndpointDeleted.ts
@@ -1,13 +1,15 @@
 import { DatabaseMigrationServiceClient } from "../DatabaseMigrationServiceClient";
 import { DescribeEndpointsCommand, DescribeEndpointsCommandInput } from "../commands/DescribeEndpointsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeEndpointsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeEndpointsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Endpoints);
@@ -18,7 +20,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "active") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -32,19 +34,21 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "creating") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundFault") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until testing endpoint is deleted.
+ *  @deprecated in favor of waitUntilEndpointDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeEndpointsCommand for polling.
  */
@@ -54,4 +58,17 @@ export const waitForEndpointDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until testing endpoint is deleted.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeEndpointsCommand for polling.
+ */
+export const waitUntilEndpointDeleted = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeEndpointsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForEndpointDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForEndpointDeleted.ts
@@ -48,9 +48,7 @@ const checkState = async (
 };
 /**
  * Wait until testing endpoint is deleted.
- *  @deprecated In favor of waitUntilEndpointDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeEndpointsCommand for polling.
+ *  @deprecated Use waitUntilEndpointDeleted instead. waitForEndpointDeleted does not throw error in non-success cases.
  */
 export const waitForEndpointDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationInstanceAvailable.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationInstanceAvailable.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationInstancesCommand,
   DescribeReplicationInstancesCommandInput,
 } from "../commands/DescribeReplicationInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeReplicationInstancesCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationInstances);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,7 +39,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -51,7 +53,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-credentials") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -65,7 +67,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-network") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -79,15 +81,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "inaccessible-encryption-credentials") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until DMS replication instance is available.
+ *  @deprecated in favor of waitUntilReplicationInstanceAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationInstancesCommand for polling.
  */
@@ -97,4 +102,17 @@ export const waitForReplicationInstanceAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 60, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until DMS replication instance is available.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationInstancesCommand for polling.
+ */
+export const waitUntilReplicationInstanceAvailable = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeReplicationInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 60, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForReplicationInstanceAvailable.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationInstanceAvailable.ts
@@ -92,9 +92,9 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication instance is available.
- *  @deprecated in favor of waitUntilReplicationInstanceAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationInstanceAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationInstancesCommand for polling.
  */
 export const waitForReplicationInstanceAvailable = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -105,8 +105,8 @@ export const waitForReplicationInstanceAvailable = async (
 };
 /**
  * Wait until DMS replication instance is available.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationInstancesCommand for polling.
  */
 export const waitUntilReplicationInstanceAvailable = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationInstanceAvailable.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationInstanceAvailable.ts
@@ -92,9 +92,7 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication instance is available.
- *  @deprecated In favor of waitUntilReplicationInstanceAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationInstancesCommand for polling.
+ *  @deprecated Use waitUntilReplicationInstanceAvailable instead. waitForReplicationInstanceAvailable does not throw error in non-success cases.
  */
 export const waitForReplicationInstanceAvailable = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationInstanceDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationInstanceDeleted.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationInstancesCommand,
   DescribeReplicationInstancesCommandInput,
 } from "../commands/DescribeReplicationInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeReplicationInstancesCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationInstances);
@@ -21,19 +23,21 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "available") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundFault") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until DMS replication instance is deleted.
+ *  @deprecated in favor of waitUntilReplicationInstanceDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationInstancesCommand for polling.
  */
@@ -43,4 +47,17 @@ export const waitForReplicationInstanceDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until DMS replication instance is deleted.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationInstancesCommand for polling.
+ */
+export const waitUntilReplicationInstanceDeleted = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeReplicationInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForReplicationInstanceDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationInstanceDeleted.ts
@@ -37,9 +37,9 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication instance is deleted.
- *  @deprecated in favor of waitUntilReplicationInstanceDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationInstanceDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationInstancesCommand for polling.
  */
 export const waitForReplicationInstanceDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -50,8 +50,8 @@ export const waitForReplicationInstanceDeleted = async (
 };
 /**
  * Wait until DMS replication instance is deleted.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationInstancesCommand for polling.
  */
 export const waitUntilReplicationInstanceDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationInstanceDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationInstanceDeleted.ts
@@ -37,9 +37,7 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication instance is deleted.
- *  @deprecated In favor of waitUntilReplicationInstanceDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationInstancesCommand for polling.
+ *  @deprecated Use waitUntilReplicationInstanceDeleted instead. waitForReplicationInstanceDeleted does not throw error in non-success cases.
  */
 export const waitForReplicationInstanceDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskDeleted.ts
@@ -93,9 +93,9 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is deleted.
- *  @deprecated in favor of waitUntilReplicationTaskDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationTaskDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitForReplicationTaskDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -106,8 +106,8 @@ export const waitForReplicationTaskDeleted = async (
 };
 /**
  * Wait until DMS replication task is deleted.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitUntilReplicationTaskDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskDeleted.ts
@@ -93,9 +93,7 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is deleted.
- *  @deprecated In favor of waitUntilReplicationTaskDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated Use waitUntilReplicationTaskDeleted instead. waitForReplicationTaskDeleted does not throw error in non-success cases.
  */
 export const waitForReplicationTaskDeleted = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskDeleted.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskDeleted.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationTasksCommand,
   DescribeReplicationTasksCommandInput,
 } from "../commands/DescribeReplicationTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeReplicationTasksCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationTasks);
@@ -21,7 +23,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "ready") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -35,7 +37,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "creating") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -49,7 +51,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopped") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -63,7 +65,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "running") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -77,19 +79,21 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundFault") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until DMS replication task is deleted.
+ *  @deprecated in favor of waitUntilReplicationTaskDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationTasksCommand for polling.
  */
@@ -99,4 +103,17 @@ export const waitForReplicationTaskDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until DMS replication task is deleted.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ */
+export const waitUntilReplicationTaskDeleted = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeReplicationTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskReady.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskReady.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationTasksCommand,
   DescribeReplicationTasksCommandInput,
 } from "../commands/DescribeReplicationTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeReplicationTasksCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationTasks);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "ready";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,7 +39,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "starting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -51,7 +53,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "running") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -65,7 +67,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopping") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -79,7 +81,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopped") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -93,7 +95,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -107,7 +109,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "modifying") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -121,7 +123,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "testing") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -135,15 +137,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until DMS replication task is ready.
+ *  @deprecated in favor of waitUntilReplicationTaskReady. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationTasksCommand for polling.
  */
@@ -153,4 +158,17 @@ export const waitForReplicationTaskReady = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until DMS replication task is ready.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ */
+export const waitUntilReplicationTaskReady = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeReplicationTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskReady.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskReady.ts
@@ -148,9 +148,7 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is ready.
- *  @deprecated In favor of waitUntilReplicationTaskReady. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated Use waitUntilReplicationTaskReady instead. waitForReplicationTaskReady does not throw error in non-success cases.
  */
 export const waitForReplicationTaskReady = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskReady.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskReady.ts
@@ -148,9 +148,9 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is ready.
- *  @deprecated in favor of waitUntilReplicationTaskReady. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationTaskReady. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitForReplicationTaskReady = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -161,8 +161,8 @@ export const waitForReplicationTaskReady = async (
 };
 /**
  * Wait until DMS replication task is ready.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitUntilReplicationTaskReady = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskRunning.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskRunning.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationTasksCommand,
   DescribeReplicationTasksCommandInput,
 } from "../commands/DescribeReplicationTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeReplicationTasksCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationTasks);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "running";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,7 +39,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "ready") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -51,7 +53,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "creating") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -65,7 +67,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopping") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -79,7 +81,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopped") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -93,7 +95,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -107,7 +109,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "modifying") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -121,7 +123,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "testing") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -135,15 +137,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until DMS replication task is running.
+ *  @deprecated in favor of waitUntilReplicationTaskRunning. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationTasksCommand for polling.
  */
@@ -153,4 +158,17 @@ export const waitForReplicationTaskRunning = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until DMS replication task is running.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ */
+export const waitUntilReplicationTaskRunning = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeReplicationTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskRunning.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskRunning.ts
@@ -148,9 +148,7 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is running.
- *  @deprecated In favor of waitUntilReplicationTaskRunning. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated Use waitUntilReplicationTaskRunning instead. waitForReplicationTaskRunning does not throw error in non-success cases.
  */
 export const waitForReplicationTaskRunning = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskRunning.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskRunning.ts
@@ -148,9 +148,9 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is running.
- *  @deprecated in favor of waitUntilReplicationTaskRunning. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationTaskRunning. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitForReplicationTaskRunning = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -161,8 +161,8 @@ export const waitForReplicationTaskRunning = async (
 };
 /**
  * Wait until DMS replication task is running.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitUntilReplicationTaskRunning = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskStopped.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskStopped.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationTasksCommand,
   DescribeReplicationTasksCommandInput,
 } from "../commands/DescribeReplicationTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeReplicationTasksCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationTasks);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "stopped";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,7 +39,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "ready") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -51,7 +53,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "creating") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -65,7 +67,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "starting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -79,7 +81,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -93,7 +95,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "modifying") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -107,7 +109,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "testing") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -121,15 +123,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until DMS replication task is stopped.
+ *  @deprecated in favor of waitUntilReplicationTaskStopped. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationTasksCommand for polling.
  */
@@ -139,4 +144,17 @@ export const waitForReplicationTaskStopped = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until DMS replication task is stopped.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ */
+export const waitUntilReplicationTaskStopped = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeReplicationTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskStopped.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskStopped.ts
@@ -134,9 +134,9 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is stopped.
- *  @deprecated in favor of waitUntilReplicationTaskStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationTaskStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitForReplicationTaskStopped = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -147,8 +147,8 @@ export const waitForReplicationTaskStopped = async (
 };
 /**
  * Wait until DMS replication task is stopped.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationTasksCommand for polling.
  */
 export const waitUntilReplicationTaskStopped = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForReplicationTaskStopped.ts
+++ b/clients/client-database-migration-service/waiters/waitForReplicationTaskStopped.ts
@@ -134,9 +134,7 @@ const checkState = async (
 };
 /**
  * Wait until DMS replication task is stopped.
- *  @deprecated In favor of waitUntilReplicationTaskStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationTasksCommand for polling.
+ *  @deprecated Use waitUntilReplicationTaskStopped instead. waitForReplicationTaskStopped does not throw error in non-success cases.
  */
 export const waitForReplicationTaskStopped = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForTestConnectionSucceeds.ts
+++ b/clients/client-database-migration-service/waiters/waitForTestConnectionSucceeds.ts
@@ -47,9 +47,7 @@ const checkState = async (
 };
 /**
  * Wait until testing connection succeeds.
- *  @deprecated In favor of waitUntilTestConnectionSucceeds. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeConnectionsCommand for polling.
+ *  @deprecated Use waitUntilTestConnectionSucceeds instead. waitForTestConnectionSucceeds does not throw error in non-success cases.
  */
 export const waitForTestConnectionSucceeds = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForTestConnectionSucceeds.ts
+++ b/clients/client-database-migration-service/waiters/waitForTestConnectionSucceeds.ts
@@ -47,9 +47,9 @@ const checkState = async (
 };
 /**
  * Wait until testing connection succeeds.
- *  @deprecated in favor of waitUntilTestConnectionSucceeds. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConnectionsCommand for polling.
+ *  @deprecated In favor of waitUntilTestConnectionSucceeds. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConnectionsCommand for polling.
  */
 export const waitForTestConnectionSucceeds = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,
@@ -60,8 +60,8 @@ export const waitForTestConnectionSucceeds = async (
 };
 /**
  * Wait until testing connection succeeds.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConnectionsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConnectionsCommand for polling.
  */
 export const waitUntilTestConnectionSucceeds = async (
   params: WaiterConfiguration<DatabaseMigrationServiceClient>,

--- a/clients/client-database-migration-service/waiters/waitForTestConnectionSucceeds.ts
+++ b/clients/client-database-migration-service/waiters/waitForTestConnectionSucceeds.ts
@@ -1,13 +1,15 @@
 import { DatabaseMigrationServiceClient } from "../DatabaseMigrationServiceClient";
 import { DescribeConnectionsCommand, DescribeConnectionsCommandInput } from "../commands/DescribeConnectionsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: DatabaseMigrationServiceClient,
   input: DescribeConnectionsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeConnectionsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Connections);
@@ -21,7 +23,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "successful";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,15 +36,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until testing connection succeeds.
+ *  @deprecated in favor of waitUntilTestConnectionSucceeds. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeConnectionsCommand for polling.
  */
@@ -52,4 +57,17 @@ export const waitForTestConnectionSucceeds = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until testing connection succeeds.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeConnectionsCommand for polling.
+ */
+export const waitUntilTestConnectionSucceeds = async (
+  params: WaiterConfiguration<DatabaseMigrationServiceClient>,
+  input: DescribeConnectionsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-docdb/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-docdb/waiters/waitForDBInstanceAvailable.ts
@@ -100,9 +100,9 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilDBInstanceAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilDBInstanceAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBInstancesCommand for polling.
  */
 export const waitForDBInstanceAvailable = async (
   params: WaiterConfiguration<DocDBClient>,
@@ -113,8 +113,8 @@ export const waitForDBInstanceAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBInstancesCommand for polling.
  */
 export const waitUntilDBInstanceAvailable = async (
   params: WaiterConfiguration<DocDBClient>,

--- a/clients/client-docdb/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-docdb/waiters/waitForDBInstanceAvailable.ts
@@ -1,10 +1,12 @@
 import { DocDBClient } from "../DocDBClient";
 import { DescribeDBInstancesCommand, DescribeDBInstancesCommandInput } from "../commands/DescribeDBInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDBInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.DBInstances);
@@ -18,7 +20,7 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-restore") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,15 +89,18 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-parameters") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDBInstanceAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDBInstancesCommand for polling.
  */
@@ -105,4 +110,17 @@ export const waitForDBInstanceAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDBInstancesCommand for polling.
+ */
+export const waitUntilDBInstanceAvailable = async (
+  params: WaiterConfiguration<DocDBClient>,
+  input: DescribeDBInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-docdb/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-docdb/waiters/waitForDBInstanceAvailable.ts
@@ -100,9 +100,7 @@ const checkState = async (client: DocDBClient, input: DescribeDBInstancesCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilDBInstanceAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDBInstancesCommand for polling.
+ *  @deprecated Use waitUntilDBInstanceAvailable instead. waitForDBInstanceAvailable does not throw error in non-success cases.
  */
 export const waitForDBInstanceAvailable = async (
   params: WaiterConfiguration<DocDBClient>,

--- a/clients/client-dynamodb/waiters/waitForTableExists.ts
+++ b/clients/client-dynamodb/waiters/waitForTableExists.ts
@@ -25,9 +25,9 @@ const checkState = async (client: DynamoDBClient, input: DescribeTableCommandInp
 };
 /**
  *
- *  @deprecated in favor of waitUntilTableExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTableCommand for polling.
+ *  @deprecated In favor of waitUntilTableExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTableCommand for polling.
  */
 export const waitForTableExists = async (
   params: WaiterConfiguration<DynamoDBClient>,
@@ -38,8 +38,8 @@ export const waitForTableExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTableCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTableCommand for polling.
  */
 export const waitUntilTableExists = async (
   params: WaiterConfiguration<DynamoDBClient>,

--- a/clients/client-dynamodb/waiters/waitForTableExists.ts
+++ b/clients/client-dynamodb/waiters/waitForTableExists.ts
@@ -25,9 +25,7 @@ const checkState = async (client: DynamoDBClient, input: DescribeTableCommandInp
 };
 /**
  *
- *  @deprecated In favor of waitUntilTableExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeTableCommand for polling.
+ *  @deprecated Use waitUntilTableExists instead. waitForTableExists does not throw error in non-success cases.
  */
 export const waitForTableExists = async (
   params: WaiterConfiguration<DynamoDBClient>,

--- a/clients/client-dynamodb/waiters/waitForTableExists.ts
+++ b/clients/client-dynamodb/waiters/waitForTableExists.ts
@@ -1,27 +1,31 @@
 import { DynamoDBClient } from "../DynamoDBClient";
 import { DescribeTableCommand, DescribeTableCommandInput } from "../commands/DescribeTableCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: DynamoDBClient, input: DescribeTableCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeTableCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Table.TableStatus;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilTableExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeTableCommand for polling.
  */
@@ -31,4 +35,17 @@ export const waitForTableExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 20, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeTableCommand for polling.
+ */
+export const waitUntilTableExists = async (
+  params: WaiterConfiguration<DynamoDBClient>,
+  input: DescribeTableCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 20, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-dynamodb/waiters/waitForTableNotExists.ts
+++ b/clients/client-dynamodb/waiters/waitForTableNotExists.ts
@@ -17,9 +17,9 @@ const checkState = async (client: DynamoDBClient, input: DescribeTableCommandInp
 };
 /**
  *
- *  @deprecated in favor of waitUntilTableNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTableCommand for polling.
+ *  @deprecated In favor of waitUntilTableNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTableCommand for polling.
  */
 export const waitForTableNotExists = async (
   params: WaiterConfiguration<DynamoDBClient>,
@@ -30,8 +30,8 @@ export const waitForTableNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTableCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTableCommand for polling.
  */
 export const waitUntilTableNotExists = async (
   params: WaiterConfiguration<DynamoDBClient>,

--- a/clients/client-dynamodb/waiters/waitForTableNotExists.ts
+++ b/clients/client-dynamodb/waiters/waitForTableNotExists.ts
@@ -1,19 +1,23 @@
 import { DynamoDBClient } from "../DynamoDBClient";
 import { DescribeTableCommand, DescribeTableCommandInput } from "../commands/DescribeTableCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: DynamoDBClient, input: DescribeTableCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeTableCommand(input));
+    reason = result;
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilTableNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeTableCommand for polling.
  */
@@ -23,4 +27,17 @@ export const waitForTableNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 20, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeTableCommand for polling.
+ */
+export const waitUntilTableNotExists = async (
+  params: WaiterConfiguration<DynamoDBClient>,
+  input: DescribeTableCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 20, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-dynamodb/waiters/waitForTableNotExists.ts
+++ b/clients/client-dynamodb/waiters/waitForTableNotExists.ts
@@ -17,9 +17,7 @@ const checkState = async (client: DynamoDBClient, input: DescribeTableCommandInp
 };
 /**
  *
- *  @deprecated In favor of waitUntilTableNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeTableCommand for polling.
+ *  @deprecated Use waitUntilTableNotExists instead. waitForTableNotExists does not throw error in non-success cases.
  */
 export const waitForTableNotExists = async (
   params: WaiterConfiguration<DynamoDBClient>,

--- a/clients/client-ec2/waiters/waitForBundleTaskComplete.ts
+++ b/clients/client-ec2/waiters/waitForBundleTaskComplete.ts
@@ -44,9 +44,7 @@ const checkState = async (client: EC2Client, input: DescribeBundleTasksCommandIn
 };
 /**
  *
- *  @deprecated In favor of waitUntilBundleTaskComplete. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeBundleTasksCommand for polling.
+ *  @deprecated Use waitUntilBundleTaskComplete instead. waitForBundleTaskComplete does not throw error in non-success cases.
  */
 export const waitForBundleTaskComplete = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForBundleTaskComplete.ts
+++ b/clients/client-ec2/waiters/waitForBundleTaskComplete.ts
@@ -44,9 +44,9 @@ const checkState = async (client: EC2Client, input: DescribeBundleTasksCommandIn
 };
 /**
  *
- *  @deprecated in favor of waitUntilBundleTaskComplete. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeBundleTasksCommand for polling.
+ *  @deprecated In favor of waitUntilBundleTaskComplete. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeBundleTasksCommand for polling.
  */
 export const waitForBundleTaskComplete = async (
   params: WaiterConfiguration<EC2Client>,
@@ -57,8 +57,8 @@ export const waitForBundleTaskComplete = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeBundleTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeBundleTasksCommand for polling.
  */
 export const waitUntilBundleTaskComplete = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForBundleTaskComplete.ts
+++ b/clients/client-ec2/waiters/waitForBundleTaskComplete.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeBundleTasksCommand, DescribeBundleTasksCommandInput } from "../commands/DescribeBundleTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeBundleTasksCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeBundleTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.BundleTasks);
@@ -18,7 +20,7 @@ const checkState = async (client: EC2Client, input: DescribeBundleTasksCommandIn
         allStringEq_5 = allStringEq_5 && element_4 == "complete";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,15 +33,18 @@ const checkState = async (client: EC2Client, input: DescribeBundleTasksCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilBundleTaskComplete. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeBundleTasksCommand for polling.
  */
@@ -49,4 +54,17 @@ export const waitForBundleTaskComplete = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeBundleTasksCommand for polling.
+ */
+export const waitUntilBundleTaskComplete = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeBundleTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForConversionTaskCancelled.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskCancelled.ts
@@ -33,9 +33,7 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
 };
 /**
  *
- *  @deprecated In favor of waitUntilConversionTaskCancelled. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeConversionTasksCommand for polling.
+ *  @deprecated Use waitUntilConversionTaskCancelled instead. waitForConversionTaskCancelled does not throw error in non-success cases.
  */
 export const waitForConversionTaskCancelled = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForConversionTaskCancelled.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskCancelled.ts
@@ -33,9 +33,9 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
 };
 /**
  *
- *  @deprecated in favor of waitUntilConversionTaskCancelled. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConversionTasksCommand for polling.
+ *  @deprecated In favor of waitUntilConversionTaskCancelled. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConversionTasksCommand for polling.
  */
 export const waitForConversionTaskCancelled = async (
   params: WaiterConfiguration<EC2Client>,
@@ -46,8 +46,8 @@ export const waitForConversionTaskCancelled = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConversionTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConversionTasksCommand for polling.
  */
 export const waitUntilConversionTaskCancelled = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForConversionTaskCancelled.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskCancelled.ts
@@ -3,11 +3,13 @@ import {
   DescribeConversionTasksCommand,
   DescribeConversionTasksCommandInput,
 } from "../commands/DescribeConversionTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeConversionTasksCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeConversionTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ConversionTasks);
@@ -21,14 +23,17 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
         allStringEq_5 = allStringEq_5 && element_4 == "cancelled";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilConversionTaskCancelled. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeConversionTasksCommand for polling.
  */
@@ -38,4 +43,17 @@ export const waitForConversionTaskCancelled = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeConversionTasksCommand for polling.
+ */
+export const waitUntilConversionTaskCancelled = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeConversionTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForConversionTaskCompleted.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskCompleted.ts
@@ -61,9 +61,9 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
 };
 /**
  *
- *  @deprecated in favor of waitUntilConversionTaskCompleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConversionTasksCommand for polling.
+ *  @deprecated In favor of waitUntilConversionTaskCompleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConversionTasksCommand for polling.
  */
 export const waitForConversionTaskCompleted = async (
   params: WaiterConfiguration<EC2Client>,
@@ -74,8 +74,8 @@ export const waitForConversionTaskCompleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConversionTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConversionTasksCommand for polling.
  */
 export const waitUntilConversionTaskCompleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForConversionTaskCompleted.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskCompleted.ts
@@ -3,11 +3,13 @@ import {
   DescribeConversionTasksCommand,
   DescribeConversionTasksCommandInput,
 } from "../commands/DescribeConversionTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeConversionTasksCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeConversionTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ConversionTasks);
@@ -21,7 +23,7 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
         allStringEq_5 = allStringEq_5 && element_4 == "completed";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,7 +36,7 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "cancelled") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -48,15 +50,18 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "cancelling") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilConversionTaskCompleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeConversionTasksCommand for polling.
  */
@@ -66,4 +71,17 @@ export const waitForConversionTaskCompleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeConversionTasksCommand for polling.
+ */
+export const waitUntilConversionTaskCompleted = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeConversionTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForConversionTaskCompleted.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskCompleted.ts
@@ -61,9 +61,7 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
 };
 /**
  *
- *  @deprecated In favor of waitUntilConversionTaskCompleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeConversionTasksCommand for polling.
+ *  @deprecated Use waitUntilConversionTaskCompleted instead. waitForConversionTaskCompleted does not throw error in non-success cases.
  */
 export const waitForConversionTaskCompleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForConversionTaskDeleted.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskDeleted.ts
@@ -3,11 +3,13 @@ import {
   DescribeConversionTasksCommand,
   DescribeConversionTasksCommandInput,
 } from "../commands/DescribeConversionTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeConversionTasksCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeConversionTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ConversionTasks);
@@ -21,14 +23,17 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
         allStringEq_5 = allStringEq_5 && element_4 == "deleted";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilConversionTaskDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeConversionTasksCommand for polling.
  */
@@ -38,4 +43,17 @@ export const waitForConversionTaskDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeConversionTasksCommand for polling.
+ */
+export const waitUntilConversionTaskDeleted = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeConversionTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForConversionTaskDeleted.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskDeleted.ts
@@ -33,9 +33,7 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
 };
 /**
  *
- *  @deprecated In favor of waitUntilConversionTaskDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeConversionTasksCommand for polling.
+ *  @deprecated Use waitUntilConversionTaskDeleted instead. waitForConversionTaskDeleted does not throw error in non-success cases.
  */
 export const waitForConversionTaskDeleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForConversionTaskDeleted.ts
+++ b/clients/client-ec2/waiters/waitForConversionTaskDeleted.ts
@@ -33,9 +33,9 @@ const checkState = async (client: EC2Client, input: DescribeConversionTasksComma
 };
 /**
  *
- *  @deprecated in favor of waitUntilConversionTaskDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConversionTasksCommand for polling.
+ *  @deprecated In favor of waitUntilConversionTaskDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConversionTasksCommand for polling.
  */
 export const waitForConversionTaskDeleted = async (
   params: WaiterConfiguration<EC2Client>,
@@ -46,8 +46,8 @@ export const waitForConversionTaskDeleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeConversionTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeConversionTasksCommand for polling.
  */
 export const waitUntilConversionTaskDeleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForCustomerGatewayAvailable.ts
+++ b/clients/client-ec2/waiters/waitForCustomerGatewayAvailable.ts
@@ -3,11 +3,13 @@ import {
   DescribeCustomerGatewaysCommand,
   DescribeCustomerGatewaysCommandInput,
 } from "../commands/DescribeCustomerGatewaysCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeCustomerGatewaysCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeCustomerGatewaysCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.CustomerGateways);
@@ -21,7 +23,7 @@ const checkState = async (client: EC2Client, input: DescribeCustomerGatewaysComm
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,7 +36,7 @@ const checkState = async (client: EC2Client, input: DescribeCustomerGatewaysComm
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -48,15 +50,18 @@ const checkState = async (client: EC2Client, input: DescribeCustomerGatewaysComm
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilCustomerGatewayAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeCustomerGatewaysCommand for polling.
  */
@@ -66,4 +71,17 @@ export const waitForCustomerGatewayAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeCustomerGatewaysCommand for polling.
+ */
+export const waitUntilCustomerGatewayAvailable = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeCustomerGatewaysCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForCustomerGatewayAvailable.ts
+++ b/clients/client-ec2/waiters/waitForCustomerGatewayAvailable.ts
@@ -61,9 +61,9 @@ const checkState = async (client: EC2Client, input: DescribeCustomerGatewaysComm
 };
 /**
  *
- *  @deprecated in favor of waitUntilCustomerGatewayAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCustomerGatewaysCommand for polling.
+ *  @deprecated In favor of waitUntilCustomerGatewayAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCustomerGatewaysCommand for polling.
  */
 export const waitForCustomerGatewayAvailable = async (
   params: WaiterConfiguration<EC2Client>,
@@ -74,8 +74,8 @@ export const waitForCustomerGatewayAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCustomerGatewaysCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCustomerGatewaysCommand for polling.
  */
 export const waitUntilCustomerGatewayAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForCustomerGatewayAvailable.ts
+++ b/clients/client-ec2/waiters/waitForCustomerGatewayAvailable.ts
@@ -61,9 +61,7 @@ const checkState = async (client: EC2Client, input: DescribeCustomerGatewaysComm
 };
 /**
  *
- *  @deprecated In favor of waitUntilCustomerGatewayAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeCustomerGatewaysCommand for polling.
+ *  @deprecated Use waitUntilCustomerGatewayAvailable instead. waitForCustomerGatewayAvailable does not throw error in non-success cases.
  */
 export const waitForCustomerGatewayAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForExportTaskCancelled.ts
+++ b/clients/client-ec2/waiters/waitForExportTaskCancelled.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EC2Client, input: DescribeExportTasksCommandIn
 };
 /**
  *
- *  @deprecated In favor of waitUntilExportTaskCancelled. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeExportTasksCommand for polling.
+ *  @deprecated Use waitUntilExportTaskCancelled instead. waitForExportTaskCancelled does not throw error in non-success cases.
  */
 export const waitForExportTaskCancelled = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForExportTaskCancelled.ts
+++ b/clients/client-ec2/waiters/waitForExportTaskCancelled.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeExportTasksCommand, DescribeExportTasksCommandInput } from "../commands/DescribeExportTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeExportTasksCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeExportTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ExportTasks);
@@ -18,14 +20,17 @@ const checkState = async (client: EC2Client, input: DescribeExportTasksCommandIn
         allStringEq_5 = allStringEq_5 && element_4 == "cancelled";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilExportTaskCancelled. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeExportTasksCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForExportTaskCancelled = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeExportTasksCommand for polling.
+ */
+export const waitUntilExportTaskCancelled = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeExportTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForExportTaskCancelled.ts
+++ b/clients/client-ec2/waiters/waitForExportTaskCancelled.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EC2Client, input: DescribeExportTasksCommandIn
 };
 /**
  *
- *  @deprecated in favor of waitUntilExportTaskCancelled. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeExportTasksCommand for polling.
+ *  @deprecated In favor of waitUntilExportTaskCancelled. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeExportTasksCommand for polling.
  */
 export const waitForExportTaskCancelled = async (
   params: WaiterConfiguration<EC2Client>,
@@ -43,8 +43,8 @@ export const waitForExportTaskCancelled = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeExportTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeExportTasksCommand for polling.
  */
 export const waitUntilExportTaskCancelled = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForExportTaskCompleted.ts
+++ b/clients/client-ec2/waiters/waitForExportTaskCompleted.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EC2Client, input: DescribeExportTasksCommandIn
 };
 /**
  *
- *  @deprecated In favor of waitUntilExportTaskCompleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeExportTasksCommand for polling.
+ *  @deprecated Use waitUntilExportTaskCompleted instead. waitForExportTaskCompleted does not throw error in non-success cases.
  */
 export const waitForExportTaskCompleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForExportTaskCompleted.ts
+++ b/clients/client-ec2/waiters/waitForExportTaskCompleted.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EC2Client, input: DescribeExportTasksCommandIn
 };
 /**
  *
- *  @deprecated in favor of waitUntilExportTaskCompleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeExportTasksCommand for polling.
+ *  @deprecated In favor of waitUntilExportTaskCompleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeExportTasksCommand for polling.
  */
 export const waitForExportTaskCompleted = async (
   params: WaiterConfiguration<EC2Client>,
@@ -43,8 +43,8 @@ export const waitForExportTaskCompleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeExportTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeExportTasksCommand for polling.
  */
 export const waitUntilExportTaskCompleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForExportTaskCompleted.ts
+++ b/clients/client-ec2/waiters/waitForExportTaskCompleted.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeExportTasksCommand, DescribeExportTasksCommandInput } from "../commands/DescribeExportTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeExportTasksCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeExportTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ExportTasks);
@@ -18,14 +20,17 @@ const checkState = async (client: EC2Client, input: DescribeExportTasksCommandIn
         allStringEq_5 = allStringEq_5 && element_4 == "completed";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilExportTaskCompleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeExportTasksCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForExportTaskCompleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeExportTasksCommand for polling.
+ */
+export const waitUntilExportTaskCompleted = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeExportTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForImageAvailable.ts
+++ b/clients/client-ec2/waiters/waitForImageAvailable.ts
@@ -44,9 +44,9 @@ const checkState = async (client: EC2Client, input: DescribeImagesCommandInput):
 };
 /**
  *
- *  @deprecated in favor of waitUntilImageAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeImagesCommand for polling.
+ *  @deprecated In favor of waitUntilImageAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeImagesCommand for polling.
  */
 export const waitForImageAvailable = async (
   params: WaiterConfiguration<EC2Client>,
@@ -57,8 +57,8 @@ export const waitForImageAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeImagesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeImagesCommand for polling.
  */
 export const waitUntilImageAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForImageAvailable.ts
+++ b/clients/client-ec2/waiters/waitForImageAvailable.ts
@@ -44,9 +44,7 @@ const checkState = async (client: EC2Client, input: DescribeImagesCommandInput):
 };
 /**
  *
- *  @deprecated In favor of waitUntilImageAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeImagesCommand for polling.
+ *  @deprecated Use waitUntilImageAvailable instead. waitForImageAvailable does not throw error in non-success cases.
  */
 export const waitForImageAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForImageAvailable.ts
+++ b/clients/client-ec2/waiters/waitForImageAvailable.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeImagesCommand, DescribeImagesCommandInput } from "../commands/DescribeImagesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeImagesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeImagesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Images);
@@ -18,7 +20,7 @@ const checkState = async (client: EC2Client, input: DescribeImagesCommandInput):
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,15 +33,18 @@ const checkState = async (client: EC2Client, input: DescribeImagesCommandInput):
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilImageAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeImagesCommand for polling.
  */
@@ -49,4 +54,17 @@ export const waitForImageAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeImagesCommand for polling.
+ */
+export const waitUntilImageAvailable = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeImagesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForInstanceStopped.ts
+++ b/clients/client-ec2/waiters/waitForInstanceStopped.ts
@@ -70,9 +70,9 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilInstanceStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilInstanceStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitForInstanceStopped = async (
   params: WaiterConfiguration<EC2Client>,
@@ -83,8 +83,8 @@ export const waitForInstanceStopped = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitUntilInstanceStopped = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForInstanceStopped.ts
+++ b/clients/client-ec2/waiters/waitForInstanceStopped.ts
@@ -70,9 +70,7 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilInstanceStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstancesCommand for polling.
+ *  @deprecated Use waitUntilInstanceStopped instead. waitForInstanceStopped does not throw error in non-success cases.
  */
 export const waitForInstanceStopped = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForInstanceStopped.ts
+++ b/clients/client-ec2/waiters/waitForInstanceStopped.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeInstancesCommand, DescribeInstancesCommandInput } from "../commands/DescribeInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Reservations);
@@ -22,7 +24,7 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
         allStringEq_8 = allStringEq_8 && element_7 == "stopped";
       }
       if (allStringEq_8) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -39,7 +41,7 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
       };
       for (let anyStringEq_7 of returnComparator()) {
         if (anyStringEq_7 == "pending") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -57,15 +59,18 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
       };
       for (let anyStringEq_7 of returnComparator()) {
         if (anyStringEq_7 == "terminated") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilInstanceStopped. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstancesCommand for polling.
  */
@@ -75,4 +80,17 @@ export const waitForInstanceStopped = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstancesCommand for polling.
+ */
+export const waitUntilInstanceStopped = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForInstanceTerminated.ts
+++ b/clients/client-ec2/waiters/waitForInstanceTerminated.ts
@@ -70,9 +70,7 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilInstanceTerminated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstancesCommand for polling.
+ *  @deprecated Use waitUntilInstanceTerminated instead. waitForInstanceTerminated does not throw error in non-success cases.
  */
 export const waitForInstanceTerminated = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForInstanceTerminated.ts
+++ b/clients/client-ec2/waiters/waitForInstanceTerminated.ts
@@ -70,9 +70,9 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilInstanceTerminated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilInstanceTerminated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitForInstanceTerminated = async (
   params: WaiterConfiguration<EC2Client>,
@@ -83,8 +83,8 @@ export const waitForInstanceTerminated = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitUntilInstanceTerminated = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForInstanceTerminated.ts
+++ b/clients/client-ec2/waiters/waitForInstanceTerminated.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeInstancesCommand, DescribeInstancesCommandInput } from "../commands/DescribeInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Reservations);
@@ -22,7 +24,7 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
         allStringEq_8 = allStringEq_8 && element_7 == "terminated";
       }
       if (allStringEq_8) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -39,7 +41,7 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
       };
       for (let anyStringEq_7 of returnComparator()) {
         if (anyStringEq_7 == "pending") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -57,15 +59,18 @@ const checkState = async (client: EC2Client, input: DescribeInstancesCommandInpu
       };
       for (let anyStringEq_7 of returnComparator()) {
         if (anyStringEq_7 == "stopping") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilInstanceTerminated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstancesCommand for polling.
  */
@@ -75,4 +80,17 @@ export const waitForInstanceTerminated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstancesCommand for polling.
+ */
+export const waitUntilInstanceTerminated = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForPasswordDataAvailable.ts
+++ b/clients/client-ec2/waiters/waitForPasswordDataAvailable.ts
@@ -22,9 +22,9 @@ const checkState = async (client: EC2Client, input: GetPasswordDataCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilPasswordDataAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetPasswordDataCommand for polling.
+ *  @deprecated In favor of waitUntilPasswordDataAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetPasswordDataCommand for polling.
  */
 export const waitForPasswordDataAvailable = async (
   params: WaiterConfiguration<EC2Client>,
@@ -35,8 +35,8 @@ export const waitForPasswordDataAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetPasswordDataCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetPasswordDataCommand for polling.
  */
 export const waitUntilPasswordDataAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForPasswordDataAvailable.ts
+++ b/clients/client-ec2/waiters/waitForPasswordDataAvailable.ts
@@ -22,9 +22,7 @@ const checkState = async (client: EC2Client, input: GetPasswordDataCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilPasswordDataAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetPasswordDataCommand for polling.
+ *  @deprecated Use waitUntilPasswordDataAvailable instead. waitForPasswordDataAvailable does not throw error in non-success cases.
  */
 export const waitForPasswordDataAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForPasswordDataAvailable.ts
+++ b/clients/client-ec2/waiters/waitForPasswordDataAvailable.ts
@@ -1,23 +1,28 @@
 import { EC2Client } from "../EC2Client";
 import { GetPasswordDataCommand, GetPasswordDataCommandInput } from "../commands/GetPasswordDataCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: GetPasswordDataCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetPasswordDataCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.PasswordData.length > 0.0;
       };
       if (returnComparator() == true) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilPasswordDataAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetPasswordDataCommand for polling.
  */
@@ -27,4 +32,17 @@ export const waitForPasswordDataAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetPasswordDataCommand for polling.
+ */
+export const waitUntilPasswordDataAvailable = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: GetPasswordDataCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForSnapshotCompleted.ts
+++ b/clients/client-ec2/waiters/waitForSnapshotCompleted.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeSnapshotsCommand, DescribeSnapshotsCommandInput } from "../commands/DescribeSnapshotsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeSnapshotsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeSnapshotsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Snapshots);
@@ -18,14 +20,17 @@ const checkState = async (client: EC2Client, input: DescribeSnapshotsCommandInpu
         allStringEq_5 = allStringEq_5 && element_4 == "completed";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilSnapshotCompleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeSnapshotsCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForSnapshotCompleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeSnapshotsCommand for polling.
+ */
+export const waitUntilSnapshotCompleted = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeSnapshotsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForSnapshotCompleted.ts
+++ b/clients/client-ec2/waiters/waitForSnapshotCompleted.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EC2Client, input: DescribeSnapshotsCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilSnapshotCompleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeSnapshotsCommand for polling.
+ *  @deprecated In favor of waitUntilSnapshotCompleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeSnapshotsCommand for polling.
  */
 export const waitForSnapshotCompleted = async (
   params: WaiterConfiguration<EC2Client>,
@@ -43,8 +43,8 @@ export const waitForSnapshotCompleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeSnapshotsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeSnapshotsCommand for polling.
  */
 export const waitUntilSnapshotCompleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForSnapshotCompleted.ts
+++ b/clients/client-ec2/waiters/waitForSnapshotCompleted.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EC2Client, input: DescribeSnapshotsCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilSnapshotCompleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeSnapshotsCommand for polling.
+ *  @deprecated Use waitUntilSnapshotCompleted instead. waitForSnapshotCompleted does not throw error in non-success cases.
  */
 export const waitForSnapshotCompleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForSubnetAvailable.ts
+++ b/clients/client-ec2/waiters/waitForSubnetAvailable.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EC2Client, input: DescribeSubnetsCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilSubnetAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeSubnetsCommand for polling.
+ *  @deprecated In favor of waitUntilSubnetAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeSubnetsCommand for polling.
  */
 export const waitForSubnetAvailable = async (
   params: WaiterConfiguration<EC2Client>,
@@ -43,8 +43,8 @@ export const waitForSubnetAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeSubnetsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeSubnetsCommand for polling.
  */
 export const waitUntilSubnetAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForSubnetAvailable.ts
+++ b/clients/client-ec2/waiters/waitForSubnetAvailable.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EC2Client, input: DescribeSubnetsCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilSubnetAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeSubnetsCommand for polling.
+ *  @deprecated Use waitUntilSubnetAvailable instead. waitForSubnetAvailable does not throw error in non-success cases.
  */
 export const waitForSubnetAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForSubnetAvailable.ts
+++ b/clients/client-ec2/waiters/waitForSubnetAvailable.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeSubnetsCommand, DescribeSubnetsCommandInput } from "../commands/DescribeSubnetsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeSubnetsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeSubnetsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Subnets);
@@ -18,14 +20,17 @@ const checkState = async (client: EC2Client, input: DescribeSubnetsCommandInput)
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilSubnetAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeSubnetsCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForSubnetAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeSubnetsCommand for polling.
+ */
+export const waitUntilSubnetAvailable = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeSubnetsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForSystemStatusOk.ts
+++ b/clients/client-ec2/waiters/waitForSystemStatusOk.ts
@@ -33,9 +33,9 @@ const checkState = async (client: EC2Client, input: DescribeInstanceStatusComman
 };
 /**
  *
- *  @deprecated in favor of waitUntilSystemStatusOk. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstanceStatusCommand for polling.
+ *  @deprecated In favor of waitUntilSystemStatusOk. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstanceStatusCommand for polling.
  */
 export const waitForSystemStatusOk = async (
   params: WaiterConfiguration<EC2Client>,
@@ -46,8 +46,8 @@ export const waitForSystemStatusOk = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstanceStatusCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstanceStatusCommand for polling.
  */
 export const waitUntilSystemStatusOk = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForSystemStatusOk.ts
+++ b/clients/client-ec2/waiters/waitForSystemStatusOk.ts
@@ -33,9 +33,7 @@ const checkState = async (client: EC2Client, input: DescribeInstanceStatusComman
 };
 /**
  *
- *  @deprecated In favor of waitUntilSystemStatusOk. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstanceStatusCommand for polling.
+ *  @deprecated Use waitUntilSystemStatusOk instead. waitForSystemStatusOk does not throw error in non-success cases.
  */
 export const waitForSystemStatusOk = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForSystemStatusOk.ts
+++ b/clients/client-ec2/waiters/waitForSystemStatusOk.ts
@@ -3,11 +3,13 @@ import {
   DescribeInstanceStatusCommand,
   DescribeInstanceStatusCommandInput,
 } from "../commands/DescribeInstanceStatusCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeInstanceStatusCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstanceStatusCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.InstanceStatuses);
@@ -21,14 +23,17 @@ const checkState = async (client: EC2Client, input: DescribeInstanceStatusComman
         allStringEq_5 = allStringEq_5 && element_4 == "ok";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilSystemStatusOk. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstanceStatusCommand for polling.
  */
@@ -38,4 +43,17 @@ export const waitForSystemStatusOk = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstanceStatusCommand for polling.
+ */
+export const waitUntilSystemStatusOk = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeInstanceStatusCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForVolumeAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVolumeAvailable.ts
@@ -44,9 +44,7 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilVolumeAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeVolumesCommand for polling.
+ *  @deprecated Use waitUntilVolumeAvailable instead. waitForVolumeAvailable does not throw error in non-success cases.
  */
 export const waitForVolumeAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVolumeAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVolumeAvailable.ts
@@ -44,9 +44,9 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilVolumeAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVolumesCommand for polling.
+ *  @deprecated In favor of waitUntilVolumeAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVolumesCommand for polling.
  */
 export const waitForVolumeAvailable = async (
   params: WaiterConfiguration<EC2Client>,
@@ -57,8 +57,8 @@ export const waitForVolumeAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVolumesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVolumesCommand for polling.
  */
 export const waitUntilVolumeAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVolumeAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVolumeAvailable.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeVolumesCommand, DescribeVolumesCommandInput } from "../commands/DescribeVolumesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeVolumesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Volumes);
@@ -18,7 +20,7 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,15 +33,18 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilVolumeAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeVolumesCommand for polling.
  */
@@ -49,4 +54,17 @@ export const waitForVolumeAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeVolumesCommand for polling.
+ */
+export const waitUntilVolumeAvailable = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeVolumesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForVolumeInUse.ts
+++ b/clients/client-ec2/waiters/waitForVolumeInUse.ts
@@ -44,9 +44,9 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilVolumeInUse. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVolumesCommand for polling.
+ *  @deprecated In favor of waitUntilVolumeInUse. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVolumesCommand for polling.
  */
 export const waitForVolumeInUse = async (
   params: WaiterConfiguration<EC2Client>,
@@ -57,8 +57,8 @@ export const waitForVolumeInUse = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVolumesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVolumesCommand for polling.
  */
 export const waitUntilVolumeInUse = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVolumeInUse.ts
+++ b/clients/client-ec2/waiters/waitForVolumeInUse.ts
@@ -44,9 +44,7 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilVolumeInUse. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeVolumesCommand for polling.
+ *  @deprecated Use waitUntilVolumeInUse instead. waitForVolumeInUse does not throw error in non-success cases.
  */
 export const waitForVolumeInUse = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVolumeInUse.ts
+++ b/clients/client-ec2/waiters/waitForVolumeInUse.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeVolumesCommand, DescribeVolumesCommandInput } from "../commands/DescribeVolumesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeVolumesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Volumes);
@@ -18,7 +20,7 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
         allStringEq_5 = allStringEq_5 && element_4 == "in-use";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,15 +33,18 @@ const checkState = async (client: EC2Client, input: DescribeVolumesCommandInput)
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilVolumeInUse. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeVolumesCommand for polling.
  */
@@ -49,4 +54,17 @@ export const waitForVolumeInUse = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeVolumesCommand for polling.
+ */
+export const waitUntilVolumeInUse = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeVolumesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForVpcAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVpcAvailable.ts
@@ -1,10 +1,12 @@
 import { EC2Client } from "../EC2Client";
 import { DescribeVpcsCommand, DescribeVpcsCommandInput } from "../commands/DescribeVpcsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeVpcsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeVpcsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Vpcs);
@@ -18,14 +20,17 @@ const checkState = async (client: EC2Client, input: DescribeVpcsCommandInput): P
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilVpcAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeVpcsCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForVpcAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeVpcsCommand for polling.
+ */
+export const waitUntilVpcAvailable = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeVpcsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForVpcAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVpcAvailable.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EC2Client, input: DescribeVpcsCommandInput): P
 };
 /**
  *
- *  @deprecated in favor of waitUntilVpcAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVpcsCommand for polling.
+ *  @deprecated In favor of waitUntilVpcAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVpcsCommand for polling.
  */
 export const waitForVpcAvailable = async (
   params: WaiterConfiguration<EC2Client>,
@@ -43,8 +43,8 @@ export const waitForVpcAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVpcsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVpcsCommand for polling.
  */
 export const waitUntilVpcAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVpcAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVpcAvailable.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EC2Client, input: DescribeVpcsCommandInput): P
 };
 /**
  *
- *  @deprecated In favor of waitUntilVpcAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeVpcsCommand for polling.
+ *  @deprecated Use waitUntilVpcAvailable instead. waitForVpcAvailable does not throw error in non-success cases.
  */
 export const waitForVpcAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVpnConnectionAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVpnConnectionAvailable.ts
@@ -61,9 +61,7 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
 };
 /**
  *
- *  @deprecated In favor of waitUntilVpnConnectionAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeVpnConnectionsCommand for polling.
+ *  @deprecated Use waitUntilVpnConnectionAvailable instead. waitForVpnConnectionAvailable does not throw error in non-success cases.
  */
 export const waitForVpnConnectionAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVpnConnectionAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVpnConnectionAvailable.ts
@@ -3,11 +3,13 @@ import {
   DescribeVpnConnectionsCommand,
   DescribeVpnConnectionsCommandInput,
 } from "../commands/DescribeVpnConnectionsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeVpnConnectionsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeVpnConnectionsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.VpnConnections);
@@ -21,7 +23,7 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,7 +36,7 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -48,15 +50,18 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilVpnConnectionAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeVpnConnectionsCommand for polling.
  */
@@ -66,4 +71,17 @@ export const waitForVpnConnectionAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeVpnConnectionsCommand for polling.
+ */
+export const waitUntilVpnConnectionAvailable = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeVpnConnectionsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForVpnConnectionAvailable.ts
+++ b/clients/client-ec2/waiters/waitForVpnConnectionAvailable.ts
@@ -61,9 +61,9 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
 };
 /**
  *
- *  @deprecated in favor of waitUntilVpnConnectionAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVpnConnectionsCommand for polling.
+ *  @deprecated In favor of waitUntilVpnConnectionAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVpnConnectionsCommand for polling.
  */
 export const waitForVpnConnectionAvailable = async (
   params: WaiterConfiguration<EC2Client>,
@@ -74,8 +74,8 @@ export const waitForVpnConnectionAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVpnConnectionsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVpnConnectionsCommand for polling.
  */
 export const waitUntilVpnConnectionAvailable = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVpnConnectionDeleted.ts
+++ b/clients/client-ec2/waiters/waitForVpnConnectionDeleted.ts
@@ -3,11 +3,13 @@ import {
   DescribeVpnConnectionsCommand,
   DescribeVpnConnectionsCommandInput,
 } from "../commands/DescribeVpnConnectionsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EC2Client, input: DescribeVpnConnectionsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeVpnConnectionsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.VpnConnections);
@@ -21,7 +23,7 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
         allStringEq_5 = allStringEq_5 && element_4 == "deleted";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,15 +36,18 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "pending") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilVpnConnectionDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeVpnConnectionsCommand for polling.
  */
@@ -52,4 +57,17 @@ export const waitForVpnConnectionDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeVpnConnectionsCommand for polling.
+ */
+export const waitUntilVpnConnectionDeleted = async (
+  params: WaiterConfiguration<EC2Client>,
+  input: DescribeVpnConnectionsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ec2/waiters/waitForVpnConnectionDeleted.ts
+++ b/clients/client-ec2/waiters/waitForVpnConnectionDeleted.ts
@@ -47,9 +47,7 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
 };
 /**
  *
- *  @deprecated In favor of waitUntilVpnConnectionDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeVpnConnectionsCommand for polling.
+ *  @deprecated Use waitUntilVpnConnectionDeleted instead. waitForVpnConnectionDeleted does not throw error in non-success cases.
  */
 export const waitForVpnConnectionDeleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ec2/waiters/waitForVpnConnectionDeleted.ts
+++ b/clients/client-ec2/waiters/waitForVpnConnectionDeleted.ts
@@ -47,9 +47,9 @@ const checkState = async (client: EC2Client, input: DescribeVpnConnectionsComman
 };
 /**
  *
- *  @deprecated in favor of waitUntilVpnConnectionDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVpnConnectionsCommand for polling.
+ *  @deprecated In favor of waitUntilVpnConnectionDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVpnConnectionsCommand for polling.
  */
 export const waitForVpnConnectionDeleted = async (
   params: WaiterConfiguration<EC2Client>,
@@ -60,8 +60,8 @@ export const waitForVpnConnectionDeleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVpnConnectionsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVpnConnectionsCommand for polling.
  */
 export const waitUntilVpnConnectionDeleted = async (
   params: WaiterConfiguration<EC2Client>,

--- a/clients/client-ecr/waiters/waitForImageScanComplete.ts
+++ b/clients/client-ecr/waiters/waitForImageScanComplete.ts
@@ -3,17 +3,19 @@ import {
   DescribeImageScanFindingsCommand,
   DescribeImageScanFindingsCommandInput,
 } from "../commands/DescribeImageScanFindingsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: ECRClient, input: DescribeImageScanFindingsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeImageScanFindingsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.imageScanStatus.status;
       };
       if (returnComparator() === "COMPLETE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -21,14 +23,17 @@ const checkState = async (client: ECRClient, input: DescribeImageScanFindingsCom
         return result.imageScanStatus.status;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until an image scan is complete and findings can be accessed
+ *  @deprecated in favor of waitUntilImageScanComplete. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeImageScanFindingsCommand for polling.
  */
@@ -38,4 +43,17 @@ export const waitForImageScanComplete = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until an image scan is complete and findings can be accessed
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeImageScanFindingsCommand for polling.
+ */
+export const waitUntilImageScanComplete = async (
+  params: WaiterConfiguration<ECRClient>,
+  input: DescribeImageScanFindingsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ecr/waiters/waitForImageScanComplete.ts
+++ b/clients/client-ecr/waiters/waitForImageScanComplete.ts
@@ -33,9 +33,9 @@ const checkState = async (client: ECRClient, input: DescribeImageScanFindingsCom
 };
 /**
  * Wait until an image scan is complete and findings can be accessed
- *  @deprecated in favor of waitUntilImageScanComplete. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeImageScanFindingsCommand for polling.
+ *  @deprecated In favor of waitUntilImageScanComplete. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeImageScanFindingsCommand for polling.
  */
 export const waitForImageScanComplete = async (
   params: WaiterConfiguration<ECRClient>,
@@ -46,8 +46,8 @@ export const waitForImageScanComplete = async (
 };
 /**
  * Wait until an image scan is complete and findings can be accessed
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeImageScanFindingsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeImageScanFindingsCommand for polling.
  */
 export const waitUntilImageScanComplete = async (
   params: WaiterConfiguration<ECRClient>,

--- a/clients/client-ecr/waiters/waitForImageScanComplete.ts
+++ b/clients/client-ecr/waiters/waitForImageScanComplete.ts
@@ -33,9 +33,7 @@ const checkState = async (client: ECRClient, input: DescribeImageScanFindingsCom
 };
 /**
  * Wait until an image scan is complete and findings can be accessed
- *  @deprecated In favor of waitUntilImageScanComplete. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeImageScanFindingsCommand for polling.
+ *  @deprecated Use waitUntilImageScanComplete instead. waitForImageScanComplete does not throw error in non-success cases.
  */
 export const waitForImageScanComplete = async (
   params: WaiterConfiguration<ECRClient>,

--- a/clients/client-ecr/waiters/waitForLifecyclePolicyPreviewComplete.ts
+++ b/clients/client-ecr/waiters/waitForLifecyclePolicyPreviewComplete.ts
@@ -3,17 +3,19 @@ import {
   GetLifecyclePolicyPreviewCommand,
   GetLifecyclePolicyPreviewCommandInput,
 } from "../commands/GetLifecyclePolicyPreviewCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: ECRClient, input: GetLifecyclePolicyPreviewCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetLifecyclePolicyPreviewCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.status;
       };
       if (returnComparator() === "COMPLETE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -21,14 +23,17 @@ const checkState = async (client: ECRClient, input: GetLifecyclePolicyPreviewCom
         return result.status;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a lifecycle policy preview request is complete and results can be accessed
+ *  @deprecated in favor of waitUntilLifecyclePolicyPreviewComplete. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetLifecyclePolicyPreviewCommand for polling.
  */
@@ -38,4 +43,17 @@ export const waitForLifecyclePolicyPreviewComplete = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a lifecycle policy preview request is complete and results can be accessed
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetLifecyclePolicyPreviewCommand for polling.
+ */
+export const waitUntilLifecyclePolicyPreviewComplete = async (
+  params: WaiterConfiguration<ECRClient>,
+  input: GetLifecyclePolicyPreviewCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ecr/waiters/waitForLifecyclePolicyPreviewComplete.ts
+++ b/clients/client-ecr/waiters/waitForLifecyclePolicyPreviewComplete.ts
@@ -33,9 +33,7 @@ const checkState = async (client: ECRClient, input: GetLifecyclePolicyPreviewCom
 };
 /**
  * Wait until a lifecycle policy preview request is complete and results can be accessed
- *  @deprecated In favor of waitUntilLifecyclePolicyPreviewComplete. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetLifecyclePolicyPreviewCommand for polling.
+ *  @deprecated Use waitUntilLifecyclePolicyPreviewComplete instead. waitForLifecyclePolicyPreviewComplete does not throw error in non-success cases.
  */
 export const waitForLifecyclePolicyPreviewComplete = async (
   params: WaiterConfiguration<ECRClient>,

--- a/clients/client-ecr/waiters/waitForLifecyclePolicyPreviewComplete.ts
+++ b/clients/client-ecr/waiters/waitForLifecyclePolicyPreviewComplete.ts
@@ -33,9 +33,9 @@ const checkState = async (client: ECRClient, input: GetLifecyclePolicyPreviewCom
 };
 /**
  * Wait until a lifecycle policy preview request is complete and results can be accessed
- *  @deprecated in favor of waitUntilLifecyclePolicyPreviewComplete. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetLifecyclePolicyPreviewCommand for polling.
+ *  @deprecated In favor of waitUntilLifecyclePolicyPreviewComplete. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetLifecyclePolicyPreviewCommand for polling.
  */
 export const waitForLifecyclePolicyPreviewComplete = async (
   params: WaiterConfiguration<ECRClient>,
@@ -46,8 +46,8 @@ export const waitForLifecyclePolicyPreviewComplete = async (
 };
 /**
  * Wait until a lifecycle policy preview request is complete and results can be accessed
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetLifecyclePolicyPreviewCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetLifecyclePolicyPreviewCommand for polling.
  */
 export const waitUntilLifecyclePolicyPreviewComplete = async (
   params: WaiterConfiguration<ECRClient>,

--- a/clients/client-ecs/waiters/waitForServicesInactive.ts
+++ b/clients/client-ecs/waiters/waitForServicesInactive.ts
@@ -42,9 +42,7 @@ const checkState = async (client: ECSClient, input: DescribeServicesCommandInput
 };
 /**
  *
- *  @deprecated In favor of waitUntilServicesInactive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeServicesCommand for polling.
+ *  @deprecated Use waitUntilServicesInactive instead. waitForServicesInactive does not throw error in non-success cases.
  */
 export const waitForServicesInactive = async (
   params: WaiterConfiguration<ECSClient>,

--- a/clients/client-ecs/waiters/waitForServicesInactive.ts
+++ b/clients/client-ecs/waiters/waitForServicesInactive.ts
@@ -42,9 +42,9 @@ const checkState = async (client: ECSClient, input: DescribeServicesCommandInput
 };
 /**
  *
- *  @deprecated in favor of waitUntilServicesInactive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeServicesCommand for polling.
+ *  @deprecated In favor of waitUntilServicesInactive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeServicesCommand for polling.
  */
 export const waitForServicesInactive = async (
   params: WaiterConfiguration<ECSClient>,
@@ -55,8 +55,8 @@ export const waitForServicesInactive = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeServicesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeServicesCommand for polling.
  */
 export const waitUntilServicesInactive = async (
   params: WaiterConfiguration<ECSClient>,

--- a/clients/client-ecs/waiters/waitForServicesInactive.ts
+++ b/clients/client-ecs/waiters/waitForServicesInactive.ts
@@ -1,10 +1,12 @@
 import { ECSClient } from "../ECSClient";
 import { DescribeServicesCommand, DescribeServicesCommandInput } from "../commands/DescribeServicesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: ECSClient, input: DescribeServicesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeServicesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.failures);
@@ -15,7 +17,7 @@ const checkState = async (client: ECSClient, input: DescribeServicesCommandInput
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "MISSING") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -29,15 +31,18 @@ const checkState = async (client: ECSClient, input: DescribeServicesCommandInput
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "INACTIVE") {
-          return { state: WaiterState.SUCCESS };
+          return { state: WaiterState.SUCCESS, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilServicesInactive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeServicesCommand for polling.
  */
@@ -47,4 +52,17 @@ export const waitForServicesInactive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeServicesCommand for polling.
+ */
+export const waitUntilServicesInactive = async (
+  params: WaiterConfiguration<ECSClient>,
+  input: DescribeServicesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ecs/waiters/waitForTasksRunning.ts
+++ b/clients/client-ecs/waiters/waitForTasksRunning.ts
@@ -58,9 +58,9 @@ const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): 
 };
 /**
  *
- *  @deprecated in favor of waitUntilTasksRunning. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTasksCommand for polling.
+ *  @deprecated In favor of waitUntilTasksRunning. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTasksCommand for polling.
  */
 export const waitForTasksRunning = async (
   params: WaiterConfiguration<ECSClient>,
@@ -71,8 +71,8 @@ export const waitForTasksRunning = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTasksCommand for polling.
  */
 export const waitUntilTasksRunning = async (
   params: WaiterConfiguration<ECSClient>,

--- a/clients/client-ecs/waiters/waitForTasksRunning.ts
+++ b/clients/client-ecs/waiters/waitForTasksRunning.ts
@@ -58,9 +58,7 @@ const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): 
 };
 /**
  *
- *  @deprecated In favor of waitUntilTasksRunning. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeTasksCommand for polling.
+ *  @deprecated Use waitUntilTasksRunning instead. waitForTasksRunning does not throw error in non-success cases.
  */
 export const waitForTasksRunning = async (
   params: WaiterConfiguration<ECSClient>,

--- a/clients/client-ecs/waiters/waitForTasksRunning.ts
+++ b/clients/client-ecs/waiters/waitForTasksRunning.ts
@@ -1,10 +1,12 @@
 import { ECSClient } from "../ECSClient";
 import { DescribeTasksCommand, DescribeTasksCommandInput } from "../commands/DescribeTasksCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeTasksCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.tasks);
@@ -15,7 +17,7 @@ const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): 
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "STOPPED") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -29,7 +31,7 @@ const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): 
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "MISSING") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -46,14 +48,17 @@ const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): 
         allStringEq_5 = allStringEq_5 && element_4 == "RUNNING";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilTasksRunning. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeTasksCommand for polling.
  */
@@ -63,4 +68,17 @@ export const waitForTasksRunning = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 6, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeTasksCommand for polling.
+ */
+export const waitUntilTasksRunning = async (
+  params: WaiterConfiguration<ECSClient>,
+  input: DescribeTasksCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 6, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ecs/waiters/waitForTasksStopped.ts
+++ b/clients/client-ecs/waiters/waitForTasksStopped.ts
@@ -30,9 +30,7 @@ const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): 
 };
 /**
  *
- *  @deprecated In favor of waitUntilTasksStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeTasksCommand for polling.
+ *  @deprecated Use waitUntilTasksStopped instead. waitForTasksStopped does not throw error in non-success cases.
  */
 export const waitForTasksStopped = async (
   params: WaiterConfiguration<ECSClient>,

--- a/clients/client-ecs/waiters/waitForTasksStopped.ts
+++ b/clients/client-ecs/waiters/waitForTasksStopped.ts
@@ -30,9 +30,9 @@ const checkState = async (client: ECSClient, input: DescribeTasksCommandInput): 
 };
 /**
  *
- *  @deprecated in favor of waitUntilTasksStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTasksCommand for polling.
+ *  @deprecated In favor of waitUntilTasksStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTasksCommand for polling.
  */
 export const waitForTasksStopped = async (
   params: WaiterConfiguration<ECSClient>,
@@ -43,8 +43,8 @@ export const waitForTasksStopped = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeTasksCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeTasksCommand for polling.
  */
 export const waitUntilTasksStopped = async (
   params: WaiterConfiguration<ECSClient>,

--- a/clients/client-eks/waiters/waitForAddonActive.ts
+++ b/clients/client-eks/waiters/waitForAddonActive.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EKSClient, input: DescribeAddonCommandInput): 
 };
 /**
  *
- *  @deprecated in favor of waitUntilAddonActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAddonCommand for polling.
+ *  @deprecated In favor of waitUntilAddonActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAddonCommand for polling.
  */
 export const waitForAddonActive = async (
   params: WaiterConfiguration<EKSClient>,
@@ -43,8 +43,8 @@ export const waitForAddonActive = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAddonCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAddonCommand for polling.
  */
 export const waitUntilAddonActive = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForAddonActive.ts
+++ b/clients/client-eks/waiters/waitForAddonActive.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EKSClient, input: DescribeAddonCommandInput): 
 };
 /**
  *
- *  @deprecated In favor of waitUntilAddonActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAddonCommand for polling.
+ *  @deprecated Use waitUntilAddonActive instead. waitForAddonActive does not throw error in non-success cases.
  */
 export const waitForAddonActive = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForAddonActive.ts
+++ b/clients/client-eks/waiters/waitForAddonActive.ts
@@ -1,16 +1,18 @@
 import { EKSClient } from "../EKSClient";
 import { DescribeAddonCommand, DescribeAddonCommandInput } from "../commands/DescribeAddonCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EKSClient, input: DescribeAddonCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAddonCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.addon.status;
       };
       if (returnComparator() === "CREATE_FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -18,14 +20,17 @@ const checkState = async (client: EKSClient, input: DescribeAddonCommandInput): 
         return result.addon.status;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAddonActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAddonCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForAddonActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 10, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAddonCommand for polling.
+ */
+export const waitUntilAddonActive = async (
+  params: WaiterConfiguration<EKSClient>,
+  input: DescribeAddonCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 10, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-eks/waiters/waitForAddonDeleted.ts
+++ b/clients/client-eks/waiters/waitForAddonDeleted.ts
@@ -25,9 +25,9 @@ const checkState = async (client: EKSClient, input: DescribeAddonCommandInput): 
 };
 /**
  *
- *  @deprecated in favor of waitUntilAddonDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAddonCommand for polling.
+ *  @deprecated In favor of waitUntilAddonDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAddonCommand for polling.
  */
 export const waitForAddonDeleted = async (
   params: WaiterConfiguration<EKSClient>,
@@ -38,8 +38,8 @@ export const waitForAddonDeleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAddonCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAddonCommand for polling.
  */
 export const waitUntilAddonDeleted = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForAddonDeleted.ts
+++ b/clients/client-eks/waiters/waitForAddonDeleted.ts
@@ -25,9 +25,7 @@ const checkState = async (client: EKSClient, input: DescribeAddonCommandInput): 
 };
 /**
  *
- *  @deprecated In favor of waitUntilAddonDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAddonCommand for polling.
+ *  @deprecated Use waitUntilAddonDeleted instead. waitForAddonDeleted does not throw error in non-success cases.
  */
 export const waitForAddonDeleted = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForClusterActive.ts
+++ b/clients/client-eks/waiters/waitForClusterActive.ts
@@ -38,9 +38,9 @@ const checkState = async (client: EKSClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilClusterActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @deprecated In favor of waitUntilClusterActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitForClusterActive = async (
   params: WaiterConfiguration<EKSClient>,
@@ -51,8 +51,8 @@ export const waitForClusterActive = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitUntilClusterActive = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForClusterActive.ts
+++ b/clients/client-eks/waiters/waitForClusterActive.ts
@@ -1,16 +1,18 @@
 import { EKSClient } from "../EKSClient";
 import { DescribeClusterCommand, DescribeClusterCommandInput } from "../commands/DescribeClusterCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EKSClient, input: DescribeClusterCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeClusterCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.cluster.status;
       };
       if (returnComparator() === "DELETING") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: EKSClient, input: DescribeClusterCommandInput)
         return result.cluster.status;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -26,14 +28,17 @@ const checkState = async (client: EKSClient, input: DescribeClusterCommandInput)
         return result.cluster.status;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilClusterActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeClusterCommand for polling.
  */
@@ -43,4 +48,17 @@ export const waitForClusterActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeClusterCommand for polling.
+ */
+export const waitUntilClusterActive = async (
+  params: WaiterConfiguration<EKSClient>,
+  input: DescribeClusterCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-eks/waiters/waitForClusterActive.ts
+++ b/clients/client-eks/waiters/waitForClusterActive.ts
@@ -38,9 +38,7 @@ const checkState = async (client: EKSClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilClusterActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeClusterCommand for polling.
+ *  @deprecated Use waitUntilClusterActive instead. waitForClusterActive does not throw error in non-success cases.
  */
 export const waitForClusterActive = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForClusterDeleted.ts
+++ b/clients/client-eks/waiters/waitForClusterDeleted.ts
@@ -1,16 +1,18 @@
 import { EKSClient } from "../EKSClient";
 import { DescribeClusterCommand, DescribeClusterCommandInput } from "../commands/DescribeClusterCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EKSClient, input: DescribeClusterCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeClusterCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.cluster.status;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: EKSClient, input: DescribeClusterCommandInput)
         return result.cluster.status;
       };
       if (returnComparator() === "CREATING") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilClusterDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeClusterCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForClusterDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeClusterCommand for polling.
+ */
+export const waitUntilClusterDeleted = async (
+  params: WaiterConfiguration<EKSClient>,
+  input: DescribeClusterCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-eks/waiters/waitForClusterDeleted.ts
+++ b/clients/client-eks/waiters/waitForClusterDeleted.ts
@@ -33,9 +33,7 @@ const checkState = async (client: EKSClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilClusterDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeClusterCommand for polling.
+ *  @deprecated Use waitUntilClusterDeleted instead. waitForClusterDeleted does not throw error in non-success cases.
  */
 export const waitForClusterDeleted = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForClusterDeleted.ts
+++ b/clients/client-eks/waiters/waitForClusterDeleted.ts
@@ -33,9 +33,9 @@ const checkState = async (client: EKSClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilClusterDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @deprecated In favor of waitUntilClusterDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitForClusterDeleted = async (
   params: WaiterConfiguration<EKSClient>,
@@ -46,8 +46,8 @@ export const waitForClusterDeleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitUntilClusterDeleted = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForNodegroupActive.ts
+++ b/clients/client-eks/waiters/waitForNodegroupActive.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EKSClient, input: DescribeNodegroupCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilNodegroupActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNodegroupCommand for polling.
+ *  @deprecated In favor of waitUntilNodegroupActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNodegroupCommand for polling.
  */
 export const waitForNodegroupActive = async (
   params: WaiterConfiguration<EKSClient>,
@@ -43,8 +43,8 @@ export const waitForNodegroupActive = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNodegroupCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNodegroupCommand for polling.
  */
 export const waitUntilNodegroupActive = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForNodegroupActive.ts
+++ b/clients/client-eks/waiters/waitForNodegroupActive.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EKSClient, input: DescribeNodegroupCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilNodegroupActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeNodegroupCommand for polling.
+ *  @deprecated Use waitUntilNodegroupActive instead. waitForNodegroupActive does not throw error in non-success cases.
  */
 export const waitForNodegroupActive = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForNodegroupActive.ts
+++ b/clients/client-eks/waiters/waitForNodegroupActive.ts
@@ -1,16 +1,18 @@
 import { EKSClient } from "../EKSClient";
 import { DescribeNodegroupCommand, DescribeNodegroupCommandInput } from "../commands/DescribeNodegroupCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EKSClient, input: DescribeNodegroupCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeNodegroupCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.nodegroup.status;
       };
       if (returnComparator() === "CREATE_FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -18,14 +20,17 @@ const checkState = async (client: EKSClient, input: DescribeNodegroupCommandInpu
         return result.nodegroup.status;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilNodegroupActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeNodegroupCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForNodegroupActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeNodegroupCommand for polling.
+ */
+export const waitUntilNodegroupActive = async (
+  params: WaiterConfiguration<EKSClient>,
+  input: DescribeNodegroupCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-eks/waiters/waitForNodegroupDeleted.ts
+++ b/clients/client-eks/waiters/waitForNodegroupDeleted.ts
@@ -1,27 +1,31 @@
 import { EKSClient } from "../EKSClient";
 import { DescribeNodegroupCommand, DescribeNodegroupCommandInput } from "../commands/DescribeNodegroupCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EKSClient, input: DescribeNodegroupCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeNodegroupCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.nodegroup.status;
       };
       if (returnComparator() === "DELETE_FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilNodegroupDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeNodegroupCommand for polling.
  */
@@ -31,4 +35,17 @@ export const waitForNodegroupDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeNodegroupCommand for polling.
+ */
+export const waitUntilNodegroupDeleted = async (
+  params: WaiterConfiguration<EKSClient>,
+  input: DescribeNodegroupCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-eks/waiters/waitForNodegroupDeleted.ts
+++ b/clients/client-eks/waiters/waitForNodegroupDeleted.ts
@@ -25,9 +25,9 @@ const checkState = async (client: EKSClient, input: DescribeNodegroupCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilNodegroupDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNodegroupCommand for polling.
+ *  @deprecated In favor of waitUntilNodegroupDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNodegroupCommand for polling.
  */
 export const waitForNodegroupDeleted = async (
   params: WaiterConfiguration<EKSClient>,
@@ -38,8 +38,8 @@ export const waitForNodegroupDeleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNodegroupCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNodegroupCommand for polling.
  */
 export const waitUntilNodegroupDeleted = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-eks/waiters/waitForNodegroupDeleted.ts
+++ b/clients/client-eks/waiters/waitForNodegroupDeleted.ts
@@ -25,9 +25,7 @@ const checkState = async (client: EKSClient, input: DescribeNodegroupCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilNodegroupDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeNodegroupCommand for polling.
+ *  @deprecated Use waitUntilNodegroupDeleted instead. waitForNodegroupDeleted does not throw error in non-success cases.
  */
 export const waitForNodegroupDeleted = async (
   params: WaiterConfiguration<EKSClient>,

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentExists.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentExists.ts
@@ -49,9 +49,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilEnvironmentExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ *  @deprecated In favor of waitUntilEnvironmentExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEnvironmentsCommand for polling.
  */
 export const waitForEnvironmentExists = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,
@@ -62,8 +62,8 @@ export const waitForEnvironmentExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEnvironmentsCommand for polling.
  */
 export const waitUntilEnvironmentExists = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentExists.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentExists.ts
@@ -1,13 +1,15 @@
 import { ElasticBeanstalkClient } from "../ElasticBeanstalkClient";
 import { DescribeEnvironmentsCommand, DescribeEnvironmentsCommandInput } from "../commands/DescribeEnvironmentsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ElasticBeanstalkClient,
   input: DescribeEnvironmentsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeEnvironmentsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Environments);
@@ -21,7 +23,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "Ready";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,14 +39,17 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "Launching";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilEnvironmentExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeEnvironmentsCommand for polling.
  */
@@ -54,4 +59,17 @@ export const waitForEnvironmentExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 20, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ */
+export const waitUntilEnvironmentExists = async (
+  params: WaiterConfiguration<ElasticBeanstalkClient>,
+  input: DescribeEnvironmentsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 20, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentExists.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentExists.ts
@@ -49,9 +49,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilEnvironmentExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeEnvironmentsCommand for polling.
+ *  @deprecated Use waitUntilEnvironmentExists instead. waitForEnvironmentExists does not throw error in non-success cases.
  */
 export const waitForEnvironmentExists = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentTerminated.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentTerminated.ts
@@ -49,9 +49,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilEnvironmentTerminated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeEnvironmentsCommand for polling.
+ *  @deprecated Use waitUntilEnvironmentTerminated instead. waitForEnvironmentTerminated does not throw error in non-success cases.
  */
 export const waitForEnvironmentTerminated = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentTerminated.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentTerminated.ts
@@ -49,9 +49,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilEnvironmentTerminated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ *  @deprecated In favor of waitUntilEnvironmentTerminated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEnvironmentsCommand for polling.
  */
 export const waitForEnvironmentTerminated = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,
@@ -62,8 +62,8 @@ export const waitForEnvironmentTerminated = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEnvironmentsCommand for polling.
  */
 export const waitUntilEnvironmentTerminated = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentTerminated.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentTerminated.ts
@@ -1,13 +1,15 @@
 import { ElasticBeanstalkClient } from "../ElasticBeanstalkClient";
 import { DescribeEnvironmentsCommand, DescribeEnvironmentsCommandInput } from "../commands/DescribeEnvironmentsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ElasticBeanstalkClient,
   input: DescribeEnvironmentsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeEnvironmentsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Environments);
@@ -21,7 +23,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "Terminated";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,14 +39,17 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "Terminating";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilEnvironmentTerminated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeEnvironmentsCommand for polling.
  */
@@ -54,4 +59,17 @@ export const waitForEnvironmentTerminated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 20, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ */
+export const waitUntilEnvironmentTerminated = async (
+  params: WaiterConfiguration<ElasticBeanstalkClient>,
+  input: DescribeEnvironmentsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 20, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentUpdated.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentUpdated.ts
@@ -49,9 +49,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilEnvironmentUpdated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ *  @deprecated In favor of waitUntilEnvironmentUpdated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEnvironmentsCommand for polling.
  */
 export const waitForEnvironmentUpdated = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,
@@ -62,8 +62,8 @@ export const waitForEnvironmentUpdated = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEnvironmentsCommand for polling.
  */
 export const waitUntilEnvironmentUpdated = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentUpdated.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentUpdated.ts
@@ -49,9 +49,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilEnvironmentUpdated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeEnvironmentsCommand for polling.
+ *  @deprecated Use waitUntilEnvironmentUpdated instead. waitForEnvironmentUpdated does not throw error in non-success cases.
  */
 export const waitForEnvironmentUpdated = async (
   params: WaiterConfiguration<ElasticBeanstalkClient>,

--- a/clients/client-elastic-beanstalk/waiters/waitForEnvironmentUpdated.ts
+++ b/clients/client-elastic-beanstalk/waiters/waitForEnvironmentUpdated.ts
@@ -1,13 +1,15 @@
 import { ElasticBeanstalkClient } from "../ElasticBeanstalkClient";
 import { DescribeEnvironmentsCommand, DescribeEnvironmentsCommandInput } from "../commands/DescribeEnvironmentsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ElasticBeanstalkClient,
   input: DescribeEnvironmentsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeEnvironmentsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Environments);
@@ -21,7 +23,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "Ready";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,14 +39,17 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "Updating";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilEnvironmentUpdated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeEnvironmentsCommand for polling.
  */
@@ -54,4 +59,17 @@ export const waitForEnvironmentUpdated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 20, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeEnvironmentsCommand for polling.
+ */
+export const waitUntilEnvironmentUpdated = async (
+  params: WaiterConfiguration<ElasticBeanstalkClient>,
+  input: DescribeEnvironmentsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 20, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-elastic-load-balancing/waiters/waitForAnyInstanceInService.ts
+++ b/clients/client-elastic-load-balancing/waiters/waitForAnyInstanceInService.ts
@@ -34,9 +34,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilAnyInstanceInService. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstanceHealthCommand for polling.
+ *  @deprecated In favor of waitUntilAnyInstanceInService. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstanceHealthCommand for polling.
  */
 export const waitForAnyInstanceInService = async (
   params: WaiterConfiguration<ElasticLoadBalancingClient>,
@@ -47,8 +47,8 @@ export const waitForAnyInstanceInService = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstanceHealthCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstanceHealthCommand for polling.
  */
 export const waitUntilAnyInstanceInService = async (
   params: WaiterConfiguration<ElasticLoadBalancingClient>,

--- a/clients/client-elastic-load-balancing/waiters/waitForAnyInstanceInService.ts
+++ b/clients/client-elastic-load-balancing/waiters/waitForAnyInstanceInService.ts
@@ -34,9 +34,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilAnyInstanceInService. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstanceHealthCommand for polling.
+ *  @deprecated Use waitUntilAnyInstanceInService instead. waitForAnyInstanceInService does not throw error in non-success cases.
  */
 export const waitForAnyInstanceInService = async (
   params: WaiterConfiguration<ElasticLoadBalancingClient>,

--- a/clients/client-elastic-load-balancing/waiters/waitForAnyInstanceInService.ts
+++ b/clients/client-elastic-load-balancing/waiters/waitForAnyInstanceInService.ts
@@ -3,14 +3,16 @@ import {
   DescribeInstanceHealthCommand,
   DescribeInstanceHealthCommandInput,
 } from "../commands/DescribeInstanceHealthCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ElasticLoadBalancingClient,
   input: DescribeInstanceHealthCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstanceHealthCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.InstanceStates);
@@ -21,15 +23,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "InService") {
-          return { state: WaiterState.SUCCESS };
+          return { state: WaiterState.SUCCESS, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAnyInstanceInService. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstanceHealthCommand for polling.
  */
@@ -39,4 +44,17 @@ export const waitForAnyInstanceInService = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstanceHealthCommand for polling.
+ */
+export const waitUntilAnyInstanceInService = async (
+  params: WaiterConfiguration<ElasticLoadBalancingClient>,
+  input: DescribeInstanceHealthCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-elastic-transcoder/waiters/waitForJobComplete.ts
+++ b/clients/client-elastic-transcoder/waiters/waitForJobComplete.ts
@@ -1,16 +1,18 @@
 import { ElasticTranscoderClient } from "../ElasticTranscoderClient";
 import { ReadJobCommand, ReadJobCommandInput } from "../commands/ReadJobCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: ElasticTranscoderClient, input: ReadJobCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new ReadJobCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Job.Status;
       };
       if (returnComparator() === "Complete") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: ElasticTranscoderClient, input: ReadJobCommand
         return result.Job.Status;
       };
       if (returnComparator() === "Canceled") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -26,14 +28,17 @@ const checkState = async (client: ElasticTranscoderClient, input: ReadJobCommand
         return result.Job.Status;
       };
       if (returnComparator() === "Error") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilJobComplete. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to ReadJobCommand for polling.
  */
@@ -43,4 +48,17 @@ export const waitForJobComplete = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to ReadJobCommand for polling.
+ */
+export const waitUntilJobComplete = async (
+  params: WaiterConfiguration<ElasticTranscoderClient>,
+  input: ReadJobCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-elastic-transcoder/waiters/waitForJobComplete.ts
+++ b/clients/client-elastic-transcoder/waiters/waitForJobComplete.ts
@@ -38,9 +38,7 @@ const checkState = async (client: ElasticTranscoderClient, input: ReadJobCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilJobComplete. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to ReadJobCommand for polling.
+ *  @deprecated Use waitUntilJobComplete instead. waitForJobComplete does not throw error in non-success cases.
  */
 export const waitForJobComplete = async (
   params: WaiterConfiguration<ElasticTranscoderClient>,

--- a/clients/client-elastic-transcoder/waiters/waitForJobComplete.ts
+++ b/clients/client-elastic-transcoder/waiters/waitForJobComplete.ts
@@ -38,9 +38,9 @@ const checkState = async (client: ElasticTranscoderClient, input: ReadJobCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilJobComplete. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to ReadJobCommand for polling.
+ *  @deprecated In favor of waitUntilJobComplete. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to ReadJobCommand for polling.
  */
 export const waitForJobComplete = async (
   params: WaiterConfiguration<ElasticTranscoderClient>,
@@ -51,8 +51,8 @@ export const waitForJobComplete = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to ReadJobCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to ReadJobCommand for polling.
  */
 export const waitUntilJobComplete = async (
   params: WaiterConfiguration<ElasticTranscoderClient>,

--- a/clients/client-elasticache/waiters/waitForCacheClusterAvailable.ts
+++ b/clients/client-elasticache/waiters/waitForCacheClusterAvailable.ts
@@ -3,14 +3,16 @@ import {
   DescribeCacheClustersCommand,
   DescribeCacheClustersCommandInput,
 } from "../commands/DescribeCacheClustersCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ElastiCacheClient,
   input: DescribeCacheClustersCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeCacheClustersCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.CacheClusters);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,7 +39,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -51,7 +53,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -65,7 +67,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-network") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -79,15 +81,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "restore-failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until ElastiCache cluster is available.
+ *  @deprecated in favor of waitUntilCacheClusterAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeCacheClustersCommand for polling.
  */
@@ -97,4 +102,17 @@ export const waitForCacheClusterAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until ElastiCache cluster is available.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeCacheClustersCommand for polling.
+ */
+export const waitUntilCacheClusterAvailable = async (
+  params: WaiterConfiguration<ElastiCacheClient>,
+  input: DescribeCacheClustersCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-elasticache/waiters/waitForCacheClusterAvailable.ts
+++ b/clients/client-elasticache/waiters/waitForCacheClusterAvailable.ts
@@ -92,9 +92,7 @@ const checkState = async (
 };
 /**
  * Wait until ElastiCache cluster is available.
- *  @deprecated In favor of waitUntilCacheClusterAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeCacheClustersCommand for polling.
+ *  @deprecated Use waitUntilCacheClusterAvailable instead. waitForCacheClusterAvailable does not throw error in non-success cases.
  */
 export const waitForCacheClusterAvailable = async (
   params: WaiterConfiguration<ElastiCacheClient>,

--- a/clients/client-elasticache/waiters/waitForCacheClusterAvailable.ts
+++ b/clients/client-elasticache/waiters/waitForCacheClusterAvailable.ts
@@ -92,9 +92,9 @@ const checkState = async (
 };
 /**
  * Wait until ElastiCache cluster is available.
- *  @deprecated in favor of waitUntilCacheClusterAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCacheClustersCommand for polling.
+ *  @deprecated In favor of waitUntilCacheClusterAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCacheClustersCommand for polling.
  */
 export const waitForCacheClusterAvailable = async (
   params: WaiterConfiguration<ElastiCacheClient>,
@@ -105,8 +105,8 @@ export const waitForCacheClusterAvailable = async (
 };
 /**
  * Wait until ElastiCache cluster is available.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCacheClustersCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCacheClustersCommand for polling.
  */
 export const waitUntilCacheClusterAvailable = async (
   params: WaiterConfiguration<ElastiCacheClient>,

--- a/clients/client-elasticache/waiters/waitForReplicationGroupAvailable.ts
+++ b/clients/client-elasticache/waiters/waitForReplicationGroupAvailable.ts
@@ -50,9 +50,9 @@ const checkState = async (
 };
 /**
  * Wait until ElastiCache replication group is available.
- *  @deprecated in favor of waitUntilReplicationGroupAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationGroupsCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationGroupAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationGroupsCommand for polling.
  */
 export const waitForReplicationGroupAvailable = async (
   params: WaiterConfiguration<ElastiCacheClient>,
@@ -63,8 +63,8 @@ export const waitForReplicationGroupAvailable = async (
 };
 /**
  * Wait until ElastiCache replication group is available.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationGroupsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationGroupsCommand for polling.
  */
 export const waitUntilReplicationGroupAvailable = async (
   params: WaiterConfiguration<ElastiCacheClient>,

--- a/clients/client-elasticache/waiters/waitForReplicationGroupAvailable.ts
+++ b/clients/client-elasticache/waiters/waitForReplicationGroupAvailable.ts
@@ -50,9 +50,7 @@ const checkState = async (
 };
 /**
  * Wait until ElastiCache replication group is available.
- *  @deprecated In favor of waitUntilReplicationGroupAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationGroupsCommand for polling.
+ *  @deprecated Use waitUntilReplicationGroupAvailable instead. waitForReplicationGroupAvailable does not throw error in non-success cases.
  */
 export const waitForReplicationGroupAvailable = async (
   params: WaiterConfiguration<ElastiCacheClient>,

--- a/clients/client-elasticache/waiters/waitForReplicationGroupAvailable.ts
+++ b/clients/client-elasticache/waiters/waitForReplicationGroupAvailable.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationGroupsCommand,
   DescribeReplicationGroupsCommandInput,
 } from "../commands/DescribeReplicationGroupsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ElastiCacheClient,
   input: DescribeReplicationGroupsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationGroupsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationGroups);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,15 +39,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until ElastiCache replication group is available.
+ *  @deprecated in favor of waitUntilReplicationGroupAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationGroupsCommand for polling.
  */
@@ -55,4 +60,17 @@ export const waitForReplicationGroupAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until ElastiCache replication group is available.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationGroupsCommand for polling.
+ */
+export const waitUntilReplicationGroupAvailable = async (
+  params: WaiterConfiguration<ElastiCacheClient>,
+  input: DescribeReplicationGroupsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-elasticache/waiters/waitForReplicationGroupDeleted.ts
+++ b/clients/client-elasticache/waiters/waitForReplicationGroupDeleted.ts
@@ -53,9 +53,9 @@ const checkState = async (
 };
 /**
  * Wait until ElastiCache replication group is deleted.
- *  @deprecated in favor of waitUntilReplicationGroupDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationGroupsCommand for polling.
+ *  @deprecated In favor of waitUntilReplicationGroupDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationGroupsCommand for polling.
  */
 export const waitForReplicationGroupDeleted = async (
   params: WaiterConfiguration<ElastiCacheClient>,
@@ -66,8 +66,8 @@ export const waitForReplicationGroupDeleted = async (
 };
 /**
  * Wait until ElastiCache replication group is deleted.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeReplicationGroupsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeReplicationGroupsCommand for polling.
  */
 export const waitUntilReplicationGroupDeleted = async (
   params: WaiterConfiguration<ElastiCacheClient>,

--- a/clients/client-elasticache/waiters/waitForReplicationGroupDeleted.ts
+++ b/clients/client-elasticache/waiters/waitForReplicationGroupDeleted.ts
@@ -53,9 +53,7 @@ const checkState = async (
 };
 /**
  * Wait until ElastiCache replication group is deleted.
- *  @deprecated In favor of waitUntilReplicationGroupDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeReplicationGroupsCommand for polling.
+ *  @deprecated Use waitUntilReplicationGroupDeleted instead. waitForReplicationGroupDeleted does not throw error in non-success cases.
  */
 export const waitForReplicationGroupDeleted = async (
   params: WaiterConfiguration<ElastiCacheClient>,

--- a/clients/client-elasticache/waiters/waitForReplicationGroupDeleted.ts
+++ b/clients/client-elasticache/waiters/waitForReplicationGroupDeleted.ts
@@ -3,14 +3,16 @@ import {
   DescribeReplicationGroupsCommand,
   DescribeReplicationGroupsCommandInput,
 } from "../commands/DescribeReplicationGroupsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: ElastiCacheClient,
   input: DescribeReplicationGroupsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeReplicationGroupsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ReplicationGroups);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "deleted";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,19 +39,21 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "available") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ReplicationGroupNotFoundFault") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until ElastiCache replication group is deleted.
+ *  @deprecated in favor of waitUntilReplicationGroupDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeReplicationGroupsCommand for polling.
  */
@@ -59,4 +63,17 @@ export const waitForReplicationGroupDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until ElastiCache replication group is deleted.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeReplicationGroupsCommand for polling.
+ */
+export const waitUntilReplicationGroupDeleted = async (
+  params: WaiterConfiguration<ElastiCacheClient>,
+  input: DescribeReplicationGroupsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-emr/waiters/waitForClusterRunning.ts
+++ b/clients/client-emr/waiters/waitForClusterRunning.ts
@@ -54,9 +54,9 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilClusterRunning. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @deprecated In favor of waitUntilClusterRunning. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitForClusterRunning = async (
   params: WaiterConfiguration<EMRClient>,
@@ -67,8 +67,8 @@ export const waitForClusterRunning = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitUntilClusterRunning = async (
   params: WaiterConfiguration<EMRClient>,

--- a/clients/client-emr/waiters/waitForClusterRunning.ts
+++ b/clients/client-emr/waiters/waitForClusterRunning.ts
@@ -54,9 +54,7 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilClusterRunning. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeClusterCommand for polling.
+ *  @deprecated Use waitUntilClusterRunning instead. waitForClusterRunning does not throw error in non-success cases.
  */
 export const waitForClusterRunning = async (
   params: WaiterConfiguration<EMRClient>,

--- a/clients/client-emr/waiters/waitForClusterRunning.ts
+++ b/clients/client-emr/waiters/waitForClusterRunning.ts
@@ -1,16 +1,18 @@
 import { EMRClient } from "../EMRClient";
 import { DescribeClusterCommand, DescribeClusterCommandInput } from "../commands/DescribeClusterCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EMRClient, input: DescribeClusterCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeClusterCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Cluster.Status.State;
       };
       if (returnComparator() === "RUNNING") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
         return result.Cluster.Status.State;
       };
       if (returnComparator() === "WAITING") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -26,7 +28,7 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
         return result.Cluster.Status.State;
       };
       if (returnComparator() === "TERMINATING") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -34,7 +36,7 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
         return result.Cluster.Status.State;
       };
       if (returnComparator() === "TERMINATED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -42,14 +44,17 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
         return result.Cluster.Status.State;
       };
       if (returnComparator() === "TERMINATED_WITH_ERRORS") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilClusterRunning. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeClusterCommand for polling.
  */
@@ -59,4 +64,17 @@ export const waitForClusterRunning = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeClusterCommand for polling.
+ */
+export const waitUntilClusterRunning = async (
+  params: WaiterConfiguration<EMRClient>,
+  input: DescribeClusterCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-emr/waiters/waitForClusterTerminated.ts
+++ b/clients/client-emr/waiters/waitForClusterTerminated.ts
@@ -30,9 +30,9 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated in favor of waitUntilClusterTerminated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @deprecated In favor of waitUntilClusterTerminated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitForClusterTerminated = async (
   params: WaiterConfiguration<EMRClient>,
@@ -43,8 +43,8 @@ export const waitForClusterTerminated = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterCommand for polling.
  */
 export const waitUntilClusterTerminated = async (
   params: WaiterConfiguration<EMRClient>,

--- a/clients/client-emr/waiters/waitForClusterTerminated.ts
+++ b/clients/client-emr/waiters/waitForClusterTerminated.ts
@@ -30,9 +30,7 @@ const checkState = async (client: EMRClient, input: DescribeClusterCommandInput)
 };
 /**
  *
- *  @deprecated In favor of waitUntilClusterTerminated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeClusterCommand for polling.
+ *  @deprecated Use waitUntilClusterTerminated instead. waitForClusterTerminated does not throw error in non-success cases.
  */
 export const waitForClusterTerminated = async (
   params: WaiterConfiguration<EMRClient>,

--- a/clients/client-emr/waiters/waitForStepComplete.ts
+++ b/clients/client-emr/waiters/waitForStepComplete.ts
@@ -38,9 +38,9 @@ const checkState = async (client: EMRClient, input: DescribeStepCommandInput): P
 };
 /**
  *
- *  @deprecated in favor of waitUntilStepComplete. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeStepCommand for polling.
+ *  @deprecated In favor of waitUntilStepComplete. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeStepCommand for polling.
  */
 export const waitForStepComplete = async (
   params: WaiterConfiguration<EMRClient>,
@@ -51,8 +51,8 @@ export const waitForStepComplete = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeStepCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeStepCommand for polling.
  */
 export const waitUntilStepComplete = async (
   params: WaiterConfiguration<EMRClient>,

--- a/clients/client-emr/waiters/waitForStepComplete.ts
+++ b/clients/client-emr/waiters/waitForStepComplete.ts
@@ -1,16 +1,18 @@
 import { EMRClient } from "../EMRClient";
 import { DescribeStepCommand, DescribeStepCommandInput } from "../commands/DescribeStepCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: EMRClient, input: DescribeStepCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeStepCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Step.Status.State;
       };
       if (returnComparator() === "COMPLETED") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: EMRClient, input: DescribeStepCommandInput): P
         return result.Step.Status.State;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -26,14 +28,17 @@ const checkState = async (client: EMRClient, input: DescribeStepCommandInput): P
         return result.Step.Status.State;
       };
       if (returnComparator() === "CANCELLED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilStepComplete. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeStepCommand for polling.
  */
@@ -43,4 +48,17 @@ export const waitForStepComplete = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeStepCommand for polling.
+ */
+export const waitUntilStepComplete = async (
+  params: WaiterConfiguration<EMRClient>,
+  input: DescribeStepCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-emr/waiters/waitForStepComplete.ts
+++ b/clients/client-emr/waiters/waitForStepComplete.ts
@@ -38,9 +38,7 @@ const checkState = async (client: EMRClient, input: DescribeStepCommandInput): P
 };
 /**
  *
- *  @deprecated In favor of waitUntilStepComplete. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeStepCommand for polling.
+ *  @deprecated Use waitUntilStepComplete instead. waitForStepComplete does not throw error in non-success cases.
  */
 export const waitForStepComplete = async (
   params: WaiterConfiguration<EMRClient>,

--- a/clients/client-glacier/waiters/waitForVaultExists.ts
+++ b/clients/client-glacier/waiters/waitForVaultExists.ts
@@ -18,9 +18,9 @@ const checkState = async (client: GlacierClient, input: DescribeVaultCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilVaultExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVaultCommand for polling.
+ *  @deprecated In favor of waitUntilVaultExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVaultCommand for polling.
  */
 export const waitForVaultExists = async (
   params: WaiterConfiguration<GlacierClient>,
@@ -31,8 +31,8 @@ export const waitForVaultExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVaultCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVaultCommand for polling.
  */
 export const waitUntilVaultExists = async (
   params: WaiterConfiguration<GlacierClient>,

--- a/clients/client-glacier/waiters/waitForVaultExists.ts
+++ b/clients/client-glacier/waiters/waitForVaultExists.ts
@@ -18,9 +18,7 @@ const checkState = async (client: GlacierClient, input: DescribeVaultCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilVaultExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeVaultCommand for polling.
+ *  @deprecated Use waitUntilVaultExists instead. waitForVaultExists does not throw error in non-success cases.
  */
 export const waitForVaultExists = async (
   params: WaiterConfiguration<GlacierClient>,

--- a/clients/client-glacier/waiters/waitForVaultExists.ts
+++ b/clients/client-glacier/waiters/waitForVaultExists.ts
@@ -1,20 +1,24 @@
 import { GlacierClient } from "../GlacierClient";
 import { DescribeVaultCommand, DescribeVaultCommandInput } from "../commands/DescribeVaultCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: GlacierClient, input: DescribeVaultCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeVaultCommand(input));
-    return { state: WaiterState.SUCCESS };
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilVaultExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeVaultCommand for polling.
  */
@@ -24,4 +28,17 @@ export const waitForVaultExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeVaultCommand for polling.
+ */
+export const waitUntilVaultExists = async (
+  params: WaiterConfiguration<GlacierClient>,
+  input: DescribeVaultCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-glacier/waiters/waitForVaultNotExists.ts
+++ b/clients/client-glacier/waiters/waitForVaultNotExists.ts
@@ -18,9 +18,7 @@ const checkState = async (client: GlacierClient, input: DescribeVaultCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilVaultNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeVaultCommand for polling.
+ *  @deprecated Use waitUntilVaultNotExists instead. waitForVaultNotExists does not throw error in non-success cases.
  */
 export const waitForVaultNotExists = async (
   params: WaiterConfiguration<GlacierClient>,

--- a/clients/client-glacier/waiters/waitForVaultNotExists.ts
+++ b/clients/client-glacier/waiters/waitForVaultNotExists.ts
@@ -18,9 +18,9 @@ const checkState = async (client: GlacierClient, input: DescribeVaultCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilVaultNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVaultCommand for polling.
+ *  @deprecated In favor of waitUntilVaultNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVaultCommand for polling.
  */
 export const waitForVaultNotExists = async (
   params: WaiterConfiguration<GlacierClient>,
@@ -31,8 +31,8 @@ export const waitForVaultNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeVaultCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeVaultCommand for polling.
  */
 export const waitUntilVaultNotExists = async (
   params: WaiterConfiguration<GlacierClient>,

--- a/clients/client-glacier/waiters/waitForVaultNotExists.ts
+++ b/clients/client-glacier/waiters/waitForVaultNotExists.ts
@@ -1,20 +1,24 @@
 import { GlacierClient } from "../GlacierClient";
 import { DescribeVaultCommand, DescribeVaultCommandInput } from "../commands/DescribeVaultCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: GlacierClient, input: DescribeVaultCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeVaultCommand(input));
-    return { state: WaiterState.RETRY };
+    reason = result;
+    return { state: WaiterState.RETRY, reason };
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilVaultNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeVaultCommand for polling.
  */
@@ -24,4 +28,17 @@ export const waitForVaultNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeVaultCommand for polling.
+ */
+export const waitUntilVaultNotExists = async (
+  params: WaiterConfiguration<GlacierClient>,
+  input: DescribeVaultCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iam/waiters/waitForInstanceProfileExists.ts
+++ b/clients/client-iam/waiters/waitForInstanceProfileExists.ts
@@ -18,9 +18,9 @@ const checkState = async (client: IAMClient, input: GetInstanceProfileCommandInp
 };
 /**
  *
- *  @deprecated in favor of waitUntilInstanceProfileExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetInstanceProfileCommand for polling.
+ *  @deprecated In favor of waitUntilInstanceProfileExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetInstanceProfileCommand for polling.
  */
 export const waitForInstanceProfileExists = async (
   params: WaiterConfiguration<IAMClient>,
@@ -31,8 +31,8 @@ export const waitForInstanceProfileExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetInstanceProfileCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetInstanceProfileCommand for polling.
  */
 export const waitUntilInstanceProfileExists = async (
   params: WaiterConfiguration<IAMClient>,

--- a/clients/client-iam/waiters/waitForInstanceProfileExists.ts
+++ b/clients/client-iam/waiters/waitForInstanceProfileExists.ts
@@ -18,9 +18,7 @@ const checkState = async (client: IAMClient, input: GetInstanceProfileCommandInp
 };
 /**
  *
- *  @deprecated In favor of waitUntilInstanceProfileExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetInstanceProfileCommand for polling.
+ *  @deprecated Use waitUntilInstanceProfileExists instead. waitForInstanceProfileExists does not throw error in non-success cases.
  */
 export const waitForInstanceProfileExists = async (
   params: WaiterConfiguration<IAMClient>,

--- a/clients/client-iam/waiters/waitForInstanceProfileExists.ts
+++ b/clients/client-iam/waiters/waitForInstanceProfileExists.ts
@@ -1,20 +1,24 @@
 import { IAMClient } from "../IAMClient";
 import { GetInstanceProfileCommand, GetInstanceProfileCommandInput } from "../commands/GetInstanceProfileCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: IAMClient, input: GetInstanceProfileCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetInstanceProfileCommand(input));
-    return { state: WaiterState.SUCCESS };
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "NoSuchEntityException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilInstanceProfileExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetInstanceProfileCommand for polling.
  */
@@ -24,4 +28,17 @@ export const waitForInstanceProfileExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 1, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetInstanceProfileCommand for polling.
+ */
+export const waitUntilInstanceProfileExists = async (
+  params: WaiterConfiguration<IAMClient>,
+  input: GetInstanceProfileCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 1, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iotsitewise/waiters/waitForAssetActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetActive.ts
@@ -1,16 +1,18 @@
 import { IoTSiteWiseClient } from "../IoTSiteWiseClient";
 import { DescribeAssetCommand, DescribeAssetCommandInput } from "../commands/DescribeAssetCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAssetCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.assetStatus.state;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,14 +20,17 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetCommand
         return result.assetStatus.state;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAssetActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAssetCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForAssetActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAssetCommand for polling.
+ */
+export const waitUntilAssetActive = async (
+  params: WaiterConfiguration<IoTSiteWiseClient>,
+  input: DescribeAssetCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iotsitewise/waiters/waitForAssetActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetActive.ts
@@ -30,9 +30,9 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilAssetActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetCommand for polling.
+ *  @deprecated In favor of waitUntilAssetActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetCommand for polling.
  */
 export const waitForAssetActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,
@@ -43,8 +43,8 @@ export const waitForAssetActive = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetCommand for polling.
  */
 export const waitUntilAssetActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForAssetActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetActive.ts
@@ -30,9 +30,7 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilAssetActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAssetCommand for polling.
+ *  @deprecated Use waitUntilAssetActive instead. waitForAssetActive does not throw error in non-success cases.
  */
 export const waitForAssetActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForAssetModelActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetModelActive.ts
@@ -30,9 +30,7 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetModelCo
 };
 /**
  *
- *  @deprecated In favor of waitUntilAssetModelActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAssetModelCommand for polling.
+ *  @deprecated Use waitUntilAssetModelActive instead. waitForAssetModelActive does not throw error in non-success cases.
  */
 export const waitForAssetModelActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForAssetModelActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetModelActive.ts
@@ -1,16 +1,18 @@
 import { IoTSiteWiseClient } from "../IoTSiteWiseClient";
 import { DescribeAssetModelCommand, DescribeAssetModelCommandInput } from "../commands/DescribeAssetModelCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetModelCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAssetModelCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.assetModelStatus.state;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,14 +20,17 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetModelCo
         return result.assetModelStatus.state;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAssetModelActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAssetModelCommand for polling.
  */
@@ -35,4 +40,17 @@ export const waitForAssetModelActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAssetModelCommand for polling.
+ */
+export const waitUntilAssetModelActive = async (
+  params: WaiterConfiguration<IoTSiteWiseClient>,
+  input: DescribeAssetModelCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iotsitewise/waiters/waitForAssetModelActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetModelActive.ts
@@ -30,9 +30,9 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetModelCo
 };
 /**
  *
- *  @deprecated in favor of waitUntilAssetModelActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetModelCommand for polling.
+ *  @deprecated In favor of waitUntilAssetModelActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetModelCommand for polling.
  */
 export const waitForAssetModelActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,
@@ -43,8 +43,8 @@ export const waitForAssetModelActive = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetModelCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetModelCommand for polling.
  */
 export const waitUntilAssetModelActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForAssetModelNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetModelNotExists.ts
@@ -1,19 +1,23 @@
 import { IoTSiteWiseClient } from "../IoTSiteWiseClient";
 import { DescribeAssetModelCommand, DescribeAssetModelCommandInput } from "../commands/DescribeAssetModelCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetModelCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAssetModelCommand(input));
+    reason = result;
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAssetModelNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAssetModelCommand for polling.
  */
@@ -23,4 +27,17 @@ export const waitForAssetModelNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAssetModelCommand for polling.
+ */
+export const waitUntilAssetModelNotExists = async (
+  params: WaiterConfiguration<IoTSiteWiseClient>,
+  input: DescribeAssetModelCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iotsitewise/waiters/waitForAssetModelNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetModelNotExists.ts
@@ -17,9 +17,7 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetModelCo
 };
 /**
  *
- *  @deprecated In favor of waitUntilAssetModelNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAssetModelCommand for polling.
+ *  @deprecated Use waitUntilAssetModelNotExists instead. waitForAssetModelNotExists does not throw error in non-success cases.
  */
 export const waitForAssetModelNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForAssetModelNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetModelNotExists.ts
@@ -17,9 +17,9 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetModelCo
 };
 /**
  *
- *  @deprecated in favor of waitUntilAssetModelNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetModelCommand for polling.
+ *  @deprecated In favor of waitUntilAssetModelNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetModelCommand for polling.
  */
 export const waitForAssetModelNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,
@@ -30,8 +30,8 @@ export const waitForAssetModelNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetModelCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetModelCommand for polling.
  */
 export const waitUntilAssetModelNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForAssetNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetNotExists.ts
@@ -1,19 +1,23 @@
 import { IoTSiteWiseClient } from "../IoTSiteWiseClient";
 import { DescribeAssetCommand, DescribeAssetCommandInput } from "../commands/DescribeAssetCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAssetCommand(input));
+    reason = result;
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAssetNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAssetCommand for polling.
  */
@@ -23,4 +27,17 @@ export const waitForAssetNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAssetCommand for polling.
+ */
+export const waitUntilAssetNotExists = async (
+  params: WaiterConfiguration<IoTSiteWiseClient>,
+  input: DescribeAssetCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iotsitewise/waiters/waitForAssetNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetNotExists.ts
@@ -17,9 +17,7 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilAssetNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAssetCommand for polling.
+ *  @deprecated Use waitUntilAssetNotExists instead. waitForAssetNotExists does not throw error in non-success cases.
  */
 export const waitForAssetNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForAssetNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForAssetNotExists.ts
@@ -17,9 +17,9 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribeAssetCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilAssetNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetCommand for polling.
+ *  @deprecated In favor of waitUntilAssetNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetCommand for polling.
  */
 export const waitForAssetNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,
@@ -30,8 +30,8 @@ export const waitForAssetNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAssetCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAssetCommand for polling.
  */
 export const waitUntilAssetNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForPortalActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForPortalActive.ts
@@ -1,23 +1,28 @@
 import { IoTSiteWiseClient } from "../IoTSiteWiseClient";
 import { DescribePortalCommand, DescribePortalCommandInput } from "../commands/DescribePortalCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: IoTSiteWiseClient, input: DescribePortalCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribePortalCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.portalStatus.state;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilPortalActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribePortalCommand for polling.
  */
@@ -27,4 +32,17 @@ export const waitForPortalActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribePortalCommand for polling.
+ */
+export const waitUntilPortalActive = async (
+  params: WaiterConfiguration<IoTSiteWiseClient>,
+  input: DescribePortalCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iotsitewise/waiters/waitForPortalActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForPortalActive.ts
@@ -22,9 +22,9 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribePortalComman
 };
 /**
  *
- *  @deprecated in favor of waitUntilPortalActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribePortalCommand for polling.
+ *  @deprecated In favor of waitUntilPortalActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribePortalCommand for polling.
  */
 export const waitForPortalActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,
@@ -35,8 +35,8 @@ export const waitForPortalActive = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribePortalCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribePortalCommand for polling.
  */
 export const waitUntilPortalActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForPortalActive.ts
+++ b/clients/client-iotsitewise/waiters/waitForPortalActive.ts
@@ -22,9 +22,7 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribePortalComman
 };
 /**
  *
- *  @deprecated In favor of waitUntilPortalActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribePortalCommand for polling.
+ *  @deprecated Use waitUntilPortalActive instead. waitForPortalActive does not throw error in non-success cases.
  */
 export const waitForPortalActive = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForPortalNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForPortalNotExists.ts
@@ -17,9 +17,9 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribePortalComman
 };
 /**
  *
- *  @deprecated in favor of waitUntilPortalNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribePortalCommand for polling.
+ *  @deprecated In favor of waitUntilPortalNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribePortalCommand for polling.
  */
 export const waitForPortalNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,
@@ -30,8 +30,8 @@ export const waitForPortalNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribePortalCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribePortalCommand for polling.
  */
 export const waitUntilPortalNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-iotsitewise/waiters/waitForPortalNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForPortalNotExists.ts
@@ -1,19 +1,23 @@
 import { IoTSiteWiseClient } from "../IoTSiteWiseClient";
 import { DescribePortalCommand, DescribePortalCommandInput } from "../commands/DescribePortalCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: IoTSiteWiseClient, input: DescribePortalCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribePortalCommand(input));
+    reason = result;
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilPortalNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribePortalCommand for polling.
  */
@@ -23,4 +27,17 @@ export const waitForPortalNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribePortalCommand for polling.
+ */
+export const waitUntilPortalNotExists = async (
+  params: WaiterConfiguration<IoTSiteWiseClient>,
+  input: DescribePortalCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-iotsitewise/waiters/waitForPortalNotExists.ts
+++ b/clients/client-iotsitewise/waiters/waitForPortalNotExists.ts
@@ -17,9 +17,7 @@ const checkState = async (client: IoTSiteWiseClient, input: DescribePortalComman
 };
 /**
  *
- *  @deprecated In favor of waitUntilPortalNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribePortalCommand for polling.
+ *  @deprecated Use waitUntilPortalNotExists instead. waitForPortalNotExists does not throw error in non-success cases.
  */
 export const waitForPortalNotExists = async (
   params: WaiterConfiguration<IoTSiteWiseClient>,

--- a/clients/client-kinesis/waiters/waitForStreamExists.ts
+++ b/clients/client-kinesis/waiters/waitForStreamExists.ts
@@ -1,23 +1,28 @@
 import { KinesisClient } from "../KinesisClient";
 import { DescribeStreamCommand, DescribeStreamCommandInput } from "../commands/DescribeStreamCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: KinesisClient, input: DescribeStreamCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeStreamCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.StreamDescription.StreamStatus;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilStreamExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeStreamCommand for polling.
  */
@@ -27,4 +32,17 @@ export const waitForStreamExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 10, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeStreamCommand for polling.
+ */
+export const waitUntilStreamExists = async (
+  params: WaiterConfiguration<KinesisClient>,
+  input: DescribeStreamCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 10, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-kinesis/waiters/waitForStreamExists.ts
+++ b/clients/client-kinesis/waiters/waitForStreamExists.ts
@@ -22,9 +22,9 @@ const checkState = async (client: KinesisClient, input: DescribeStreamCommandInp
 };
 /**
  *
- *  @deprecated in favor of waitUntilStreamExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeStreamCommand for polling.
+ *  @deprecated In favor of waitUntilStreamExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeStreamCommand for polling.
  */
 export const waitForStreamExists = async (
   params: WaiterConfiguration<KinesisClient>,
@@ -35,8 +35,8 @@ export const waitForStreamExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeStreamCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeStreamCommand for polling.
  */
 export const waitUntilStreamExists = async (
   params: WaiterConfiguration<KinesisClient>,

--- a/clients/client-kinesis/waiters/waitForStreamExists.ts
+++ b/clients/client-kinesis/waiters/waitForStreamExists.ts
@@ -22,9 +22,7 @@ const checkState = async (client: KinesisClient, input: DescribeStreamCommandInp
 };
 /**
  *
- *  @deprecated In favor of waitUntilStreamExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeStreamCommand for polling.
+ *  @deprecated Use waitUntilStreamExists instead. waitForStreamExists does not throw error in non-success cases.
  */
 export const waitForStreamExists = async (
   params: WaiterConfiguration<KinesisClient>,

--- a/clients/client-kinesis/waiters/waitForStreamNotExists.ts
+++ b/clients/client-kinesis/waiters/waitForStreamNotExists.ts
@@ -17,9 +17,7 @@ const checkState = async (client: KinesisClient, input: DescribeStreamCommandInp
 };
 /**
  *
- *  @deprecated In favor of waitUntilStreamNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeStreamCommand for polling.
+ *  @deprecated Use waitUntilStreamNotExists instead. waitForStreamNotExists does not throw error in non-success cases.
  */
 export const waitForStreamNotExists = async (
   params: WaiterConfiguration<KinesisClient>,

--- a/clients/client-kinesis/waiters/waitForStreamNotExists.ts
+++ b/clients/client-kinesis/waiters/waitForStreamNotExists.ts
@@ -1,19 +1,23 @@
 import { KinesisClient } from "../KinesisClient";
 import { DescribeStreamCommand, DescribeStreamCommandInput } from "../commands/DescribeStreamCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: KinesisClient, input: DescribeStreamCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeStreamCommand(input));
+    reason = result;
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilStreamNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeStreamCommand for polling.
  */
@@ -23,4 +27,17 @@ export const waitForStreamNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 10, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeStreamCommand for polling.
+ */
+export const waitUntilStreamNotExists = async (
+  params: WaiterConfiguration<KinesisClient>,
+  input: DescribeStreamCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 10, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-kinesis/waiters/waitForStreamNotExists.ts
+++ b/clients/client-kinesis/waiters/waitForStreamNotExists.ts
@@ -17,9 +17,9 @@ const checkState = async (client: KinesisClient, input: DescribeStreamCommandInp
 };
 /**
  *
- *  @deprecated in favor of waitUntilStreamNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeStreamCommand for polling.
+ *  @deprecated In favor of waitUntilStreamNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeStreamCommand for polling.
  */
 export const waitForStreamNotExists = async (
   params: WaiterConfiguration<KinesisClient>,
@@ -30,8 +30,8 @@ export const waitForStreamNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeStreamCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeStreamCommand for polling.
  */
 export const waitUntilStreamNotExists = async (
   params: WaiterConfiguration<KinesisClient>,

--- a/clients/client-lambda/waiters/waitForFunctionActive.ts
+++ b/clients/client-lambda/waiters/waitForFunctionActive.ts
@@ -41,9 +41,9 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
 };
 /**
  * Waits for the function's State to be Active.
- *  @deprecated in favor of waitUntilFunctionActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetFunctionConfigurationCommand for polling.
+ *  @deprecated In favor of waitUntilFunctionActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetFunctionConfigurationCommand for polling.
  */
 export const waitForFunctionActive = async (
   params: WaiterConfiguration<LambdaClient>,
@@ -54,8 +54,8 @@ export const waitForFunctionActive = async (
 };
 /**
  * Waits for the function's State to be Active.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetFunctionConfigurationCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetFunctionConfigurationCommand for polling.
  */
 export const waitUntilFunctionActive = async (
   params: WaiterConfiguration<LambdaClient>,

--- a/clients/client-lambda/waiters/waitForFunctionActive.ts
+++ b/clients/client-lambda/waiters/waitForFunctionActive.ts
@@ -41,9 +41,7 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
 };
 /**
  * Waits for the function's State to be Active.
- *  @deprecated In favor of waitUntilFunctionActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetFunctionConfigurationCommand for polling.
+ *  @deprecated Use waitUntilFunctionActive instead. waitForFunctionActive does not throw error in non-success cases.
  */
 export const waitForFunctionActive = async (
   params: WaiterConfiguration<LambdaClient>,

--- a/clients/client-lambda/waiters/waitForFunctionActive.ts
+++ b/clients/client-lambda/waiters/waitForFunctionActive.ts
@@ -3,17 +3,19 @@ import {
   GetFunctionConfigurationCommand,
   GetFunctionConfigurationCommandInput,
 } from "../commands/GetFunctionConfigurationCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: LambdaClient, input: GetFunctionConfigurationCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetFunctionConfigurationCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "Active") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -21,7 +23,7 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
         return result.State;
       };
       if (returnComparator() === "Failed") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -29,14 +31,17 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
         return result.State;
       };
       if (returnComparator() === "Pending") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Waits for the function's State to be Active.
+ *  @deprecated in favor of waitUntilFunctionActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetFunctionConfigurationCommand for polling.
  */
@@ -46,4 +51,17 @@ export const waitForFunctionActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Waits for the function's State to be Active.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetFunctionConfigurationCommand for polling.
+ */
+export const waitUntilFunctionActive = async (
+  params: WaiterConfiguration<LambdaClient>,
+  input: GetFunctionConfigurationCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-lambda/waiters/waitForFunctionExists.ts
+++ b/clients/client-lambda/waiters/waitForFunctionExists.ts
@@ -1,20 +1,24 @@
 import { LambdaClient } from "../LambdaClient";
 import { GetFunctionCommand, GetFunctionCommandInput } from "../commands/GetFunctionCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: LambdaClient, input: GetFunctionCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetFunctionCommand(input));
-    return { state: WaiterState.SUCCESS };
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilFunctionExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetFunctionCommand for polling.
  */
@@ -24,4 +28,17 @@ export const waitForFunctionExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 1, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetFunctionCommand for polling.
+ */
+export const waitUntilFunctionExists = async (
+  params: WaiterConfiguration<LambdaClient>,
+  input: GetFunctionCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 1, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-lambda/waiters/waitForFunctionExists.ts
+++ b/clients/client-lambda/waiters/waitForFunctionExists.ts
@@ -18,9 +18,9 @@ const checkState = async (client: LambdaClient, input: GetFunctionCommandInput):
 };
 /**
  *
- *  @deprecated in favor of waitUntilFunctionExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetFunctionCommand for polling.
+ *  @deprecated In favor of waitUntilFunctionExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetFunctionCommand for polling.
  */
 export const waitForFunctionExists = async (
   params: WaiterConfiguration<LambdaClient>,
@@ -31,8 +31,8 @@ export const waitForFunctionExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetFunctionCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetFunctionCommand for polling.
  */
 export const waitUntilFunctionExists = async (
   params: WaiterConfiguration<LambdaClient>,

--- a/clients/client-lambda/waiters/waitForFunctionExists.ts
+++ b/clients/client-lambda/waiters/waitForFunctionExists.ts
@@ -18,9 +18,7 @@ const checkState = async (client: LambdaClient, input: GetFunctionCommandInput):
 };
 /**
  *
- *  @deprecated In favor of waitUntilFunctionExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetFunctionCommand for polling.
+ *  @deprecated Use waitUntilFunctionExists instead. waitForFunctionExists does not throw error in non-success cases.
  */
 export const waitForFunctionExists = async (
   params: WaiterConfiguration<LambdaClient>,

--- a/clients/client-lambda/waiters/waitForFunctionUpdated.ts
+++ b/clients/client-lambda/waiters/waitForFunctionUpdated.ts
@@ -3,17 +3,19 @@ import {
   GetFunctionConfigurationCommand,
   GetFunctionConfigurationCommandInput,
 } from "../commands/GetFunctionConfigurationCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: LambdaClient, input: GetFunctionConfigurationCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetFunctionConfigurationCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.LastUpdateStatus;
       };
       if (returnComparator() === "Successful") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -21,7 +23,7 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
         return result.LastUpdateStatus;
       };
       if (returnComparator() === "Failed") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -29,14 +31,17 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
         return result.LastUpdateStatus;
       };
       if (returnComparator() === "InProgress") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Waits for the function's LastUpdateStatus to be Successful.
+ *  @deprecated in favor of waitUntilFunctionUpdated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetFunctionConfigurationCommand for polling.
  */
@@ -46,4 +51,17 @@ export const waitForFunctionUpdated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Waits for the function's LastUpdateStatus to be Successful.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetFunctionConfigurationCommand for polling.
+ */
+export const waitUntilFunctionUpdated = async (
+  params: WaiterConfiguration<LambdaClient>,
+  input: GetFunctionConfigurationCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-lambda/waiters/waitForFunctionUpdated.ts
+++ b/clients/client-lambda/waiters/waitForFunctionUpdated.ts
@@ -41,9 +41,7 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
 };
 /**
  * Waits for the function's LastUpdateStatus to be Successful.
- *  @deprecated In favor of waitUntilFunctionUpdated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetFunctionConfigurationCommand for polling.
+ *  @deprecated Use waitUntilFunctionUpdated instead. waitForFunctionUpdated does not throw error in non-success cases.
  */
 export const waitForFunctionUpdated = async (
   params: WaiterConfiguration<LambdaClient>,

--- a/clients/client-lambda/waiters/waitForFunctionUpdated.ts
+++ b/clients/client-lambda/waiters/waitForFunctionUpdated.ts
@@ -41,9 +41,9 @@ const checkState = async (client: LambdaClient, input: GetFunctionConfigurationC
 };
 /**
  * Waits for the function's LastUpdateStatus to be Successful.
- *  @deprecated in favor of waitUntilFunctionUpdated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetFunctionConfigurationCommand for polling.
+ *  @deprecated In favor of waitUntilFunctionUpdated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetFunctionConfigurationCommand for polling.
  */
 export const waitForFunctionUpdated = async (
   params: WaiterConfiguration<LambdaClient>,
@@ -54,8 +54,8 @@ export const waitForFunctionUpdated = async (
 };
 /**
  * Waits for the function's LastUpdateStatus to be Successful.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetFunctionConfigurationCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetFunctionConfigurationCommand for polling.
  */
 export const waitUntilFunctionUpdated = async (
   params: WaiterConfiguration<LambdaClient>,

--- a/clients/client-machine-learning/waiters/waitForBatchPredictionAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForBatchPredictionAvailable.ts
@@ -3,14 +3,16 @@ import {
   DescribeBatchPredictionsCommand,
   DescribeBatchPredictionsCommandInput,
 } from "../commands/DescribeBatchPredictionsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: MachineLearningClient,
   input: DescribeBatchPredictionsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeBatchPredictionsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Results);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "COMPLETED";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,15 +39,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "FAILED") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilBatchPredictionAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeBatchPredictionsCommand for polling.
  */
@@ -55,4 +60,17 @@ export const waitForBatchPredictionAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeBatchPredictionsCommand for polling.
+ */
+export const waitUntilBatchPredictionAvailable = async (
+  params: WaiterConfiguration<MachineLearningClient>,
+  input: DescribeBatchPredictionsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-machine-learning/waiters/waitForBatchPredictionAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForBatchPredictionAvailable.ts
@@ -50,9 +50,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilBatchPredictionAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeBatchPredictionsCommand for polling.
+ *  @deprecated In favor of waitUntilBatchPredictionAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeBatchPredictionsCommand for polling.
  */
 export const waitForBatchPredictionAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,
@@ -63,8 +63,8 @@ export const waitForBatchPredictionAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeBatchPredictionsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeBatchPredictionsCommand for polling.
  */
 export const waitUntilBatchPredictionAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForBatchPredictionAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForBatchPredictionAvailable.ts
@@ -50,9 +50,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilBatchPredictionAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeBatchPredictionsCommand for polling.
+ *  @deprecated Use waitUntilBatchPredictionAvailable instead. waitForBatchPredictionAvailable does not throw error in non-success cases.
  */
 export const waitForBatchPredictionAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForDataSourceAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForDataSourceAvailable.ts
@@ -47,9 +47,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilDataSourceAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDataSourcesCommand for polling.
+ *  @deprecated In favor of waitUntilDataSourceAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDataSourcesCommand for polling.
  */
 export const waitForDataSourceAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,
@@ -60,8 +60,8 @@ export const waitForDataSourceAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDataSourcesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDataSourcesCommand for polling.
  */
 export const waitUntilDataSourceAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForDataSourceAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForDataSourceAvailable.ts
@@ -1,13 +1,15 @@
 import { MachineLearningClient } from "../MachineLearningClient";
 import { DescribeDataSourcesCommand, DescribeDataSourcesCommandInput } from "../commands/DescribeDataSourcesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: MachineLearningClient,
   input: DescribeDataSourcesCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDataSourcesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Results);
@@ -21,7 +23,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "COMPLETED";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,15 +36,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "FAILED") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDataSourceAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDataSourcesCommand for polling.
  */
@@ -52,4 +57,17 @@ export const waitForDataSourceAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDataSourcesCommand for polling.
+ */
+export const waitUntilDataSourceAvailable = async (
+  params: WaiterConfiguration<MachineLearningClient>,
+  input: DescribeDataSourcesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-machine-learning/waiters/waitForDataSourceAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForDataSourceAvailable.ts
@@ -47,9 +47,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilDataSourceAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDataSourcesCommand for polling.
+ *  @deprecated Use waitUntilDataSourceAvailable instead. waitForDataSourceAvailable does not throw error in non-success cases.
  */
 export const waitForDataSourceAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForEvaluationAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForEvaluationAvailable.ts
@@ -1,13 +1,15 @@
 import { MachineLearningClient } from "../MachineLearningClient";
 import { DescribeEvaluationsCommand, DescribeEvaluationsCommandInput } from "../commands/DescribeEvaluationsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: MachineLearningClient,
   input: DescribeEvaluationsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeEvaluationsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Results);
@@ -21,7 +23,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "COMPLETED";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,15 +36,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "FAILED") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilEvaluationAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeEvaluationsCommand for polling.
  */
@@ -52,4 +57,17 @@ export const waitForEvaluationAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeEvaluationsCommand for polling.
+ */
+export const waitUntilEvaluationAvailable = async (
+  params: WaiterConfiguration<MachineLearningClient>,
+  input: DescribeEvaluationsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-machine-learning/waiters/waitForEvaluationAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForEvaluationAvailable.ts
@@ -47,9 +47,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilEvaluationAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEvaluationsCommand for polling.
+ *  @deprecated In favor of waitUntilEvaluationAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEvaluationsCommand for polling.
  */
 export const waitForEvaluationAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,
@@ -60,8 +60,8 @@ export const waitForEvaluationAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeEvaluationsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeEvaluationsCommand for polling.
  */
 export const waitUntilEvaluationAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForEvaluationAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForEvaluationAvailable.ts
@@ -47,9 +47,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilEvaluationAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeEvaluationsCommand for polling.
+ *  @deprecated Use waitUntilEvaluationAvailable instead. waitForEvaluationAvailable does not throw error in non-success cases.
  */
 export const waitForEvaluationAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForMLModelAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForMLModelAvailable.ts
@@ -47,9 +47,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilMLModelAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMLModelsCommand for polling.
+ *  @deprecated In favor of waitUntilMLModelAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMLModelsCommand for polling.
  */
 export const waitForMLModelAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,
@@ -60,8 +60,8 @@ export const waitForMLModelAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMLModelsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMLModelsCommand for polling.
  */
 export const waitUntilMLModelAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForMLModelAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForMLModelAvailable.ts
@@ -47,9 +47,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilMLModelAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeMLModelsCommand for polling.
+ *  @deprecated Use waitUntilMLModelAvailable instead. waitForMLModelAvailable does not throw error in non-success cases.
  */
 export const waitForMLModelAvailable = async (
   params: WaiterConfiguration<MachineLearningClient>,

--- a/clients/client-machine-learning/waiters/waitForMLModelAvailable.ts
+++ b/clients/client-machine-learning/waiters/waitForMLModelAvailable.ts
@@ -1,13 +1,15 @@
 import { MachineLearningClient } from "../MachineLearningClient";
 import { DescribeMLModelsCommand, DescribeMLModelsCommandInput } from "../commands/DescribeMLModelsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: MachineLearningClient,
   input: DescribeMLModelsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeMLModelsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Results);
@@ -21,7 +23,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "COMPLETED";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,15 +36,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "FAILED") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilMLModelAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeMLModelsCommand for polling.
  */
@@ -52,4 +57,17 @@ export const waitForMLModelAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeMLModelsCommand for polling.
+ */
+export const waitUntilMLModelAvailable = async (
+  params: WaiterConfiguration<MachineLearningClient>,
+  input: DescribeMLModelsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-mediaconnect/waiters/waitForFlowActive.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowActive.ts
@@ -52,9 +52,9 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
 };
 /**
  * Wait until a flow is active
- *  @deprecated in favor of waitUntilFlowActive. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFlowCommand for polling.
+ *  @deprecated In favor of waitUntilFlowActive. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFlowCommand for polling.
  */
 export const waitForFlowActive = async (
   params: WaiterConfiguration<MediaConnectClient>,
@@ -65,8 +65,8 @@ export const waitForFlowActive = async (
 };
 /**
  * Wait until a flow is active
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFlowCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFlowCommand for polling.
  */
 export const waitUntilFlowActive = async (
   params: WaiterConfiguration<MediaConnectClient>,

--- a/clients/client-mediaconnect/waiters/waitForFlowActive.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowActive.ts
@@ -1,16 +1,18 @@
 import { MediaConnectClient } from "../MediaConnectClient";
 import { DescribeFlowCommand, DescribeFlowCommandInput } from "../commands/DescribeFlowCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaConnectClient, input: DescribeFlowCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeFlowCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Flow.Status;
       };
       if (returnComparator() === "ACTIVE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
         return result.Flow.Status;
       };
       if (returnComparator() === "STARTING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -26,7 +28,7 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
         return result.Flow.Status;
       };
       if (returnComparator() === "UPDATING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -34,21 +36,23 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
         return result.Flow.Status;
       };
       if (returnComparator() === "ERROR") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
     if (exception.name && exception.name == "ServiceUnavailableException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a flow is active
+ *  @deprecated in favor of waitUntilFlowActive. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeFlowCommand for polling.
  */
@@ -58,4 +62,17 @@ export const waitForFlowActive = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a flow is active
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeFlowCommand for polling.
+ */
+export const waitUntilFlowActive = async (
+  params: WaiterConfiguration<MediaConnectClient>,
+  input: DescribeFlowCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-mediaconnect/waiters/waitForFlowActive.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowActive.ts
@@ -52,9 +52,7 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
 };
 /**
  * Wait until a flow is active
- *  @deprecated In favor of waitUntilFlowActive. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeFlowCommand for polling.
+ *  @deprecated Use waitUntilFlowActive instead. waitForFlowActive does not throw error in non-success cases.
  */
 export const waitForFlowActive = async (
   params: WaiterConfiguration<MediaConnectClient>,

--- a/clients/client-mediaconnect/waiters/waitForFlowDeleted.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowDeleted.ts
@@ -39,9 +39,7 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
 };
 /**
  * Wait until a flow is deleted
- *  @deprecated In favor of waitUntilFlowDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeFlowCommand for polling.
+ *  @deprecated Use waitUntilFlowDeleted instead. waitForFlowDeleted does not throw error in non-success cases.
  */
 export const waitForFlowDeleted = async (
   params: WaiterConfiguration<MediaConnectClient>,

--- a/clients/client-mediaconnect/waiters/waitForFlowDeleted.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowDeleted.ts
@@ -39,9 +39,9 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
 };
 /**
  * Wait until a flow is deleted
- *  @deprecated in favor of waitUntilFlowDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFlowCommand for polling.
+ *  @deprecated In favor of waitUntilFlowDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFlowCommand for polling.
  */
 export const waitForFlowDeleted = async (
   params: WaiterConfiguration<MediaConnectClient>,
@@ -52,8 +52,8 @@ export const waitForFlowDeleted = async (
 };
 /**
  * Wait until a flow is deleted
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFlowCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFlowCommand for polling.
  */
 export const waitUntilFlowDeleted = async (
   params: WaiterConfiguration<MediaConnectClient>,

--- a/clients/client-mediaconnect/waiters/waitForFlowDeleted.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowDeleted.ts
@@ -1,16 +1,18 @@
 import { MediaConnectClient } from "../MediaConnectClient";
 import { DescribeFlowCommand, DescribeFlowCommandInput } from "../commands/DescribeFlowCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaConnectClient, input: DescribeFlowCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeFlowCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Flow.Status;
       };
       if (returnComparator() === "DELETING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -18,24 +20,26 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
         return result.Flow.Status;
       };
       if (returnComparator() === "ERROR") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "NotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
     if (exception.name && exception.name == "ServiceUnavailableException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a flow is deleted
+ *  @deprecated in favor of waitUntilFlowDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeFlowCommand for polling.
  */
@@ -45,4 +49,17 @@ export const waitForFlowDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a flow is deleted
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeFlowCommand for polling.
+ */
+export const waitUntilFlowDeleted = async (
+  params: WaiterConfiguration<MediaConnectClient>,
+  input: DescribeFlowCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-mediaconnect/waiters/waitForFlowStandby.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowStandby.ts
@@ -44,9 +44,7 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
 };
 /**
  * Wait until a flow is in standby mode
- *  @deprecated In favor of waitUntilFlowStandby. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeFlowCommand for polling.
+ *  @deprecated Use waitUntilFlowStandby instead. waitForFlowStandby does not throw error in non-success cases.
  */
 export const waitForFlowStandby = async (
   params: WaiterConfiguration<MediaConnectClient>,

--- a/clients/client-mediaconnect/waiters/waitForFlowStandby.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowStandby.ts
@@ -1,16 +1,18 @@
 import { MediaConnectClient } from "../MediaConnectClient";
 import { DescribeFlowCommand, DescribeFlowCommandInput } from "../commands/DescribeFlowCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaConnectClient, input: DescribeFlowCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeFlowCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Flow.Status;
       };
       if (returnComparator() === "STANDBY") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
         return result.Flow.Status;
       };
       if (returnComparator() === "STOPPING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -26,21 +28,23 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
         return result.Flow.Status;
       };
       if (returnComparator() === "ERROR") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
     if (exception.name && exception.name == "ServiceUnavailableException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a flow is in standby mode
+ *  @deprecated in favor of waitUntilFlowStandby. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeFlowCommand for polling.
  */
@@ -50,4 +54,17 @@ export const waitForFlowStandby = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a flow is in standby mode
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeFlowCommand for polling.
+ */
+export const waitUntilFlowStandby = async (
+  params: WaiterConfiguration<MediaConnectClient>,
+  input: DescribeFlowCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-mediaconnect/waiters/waitForFlowStandby.ts
+++ b/clients/client-mediaconnect/waiters/waitForFlowStandby.ts
@@ -44,9 +44,9 @@ const checkState = async (client: MediaConnectClient, input: DescribeFlowCommand
 };
 /**
  * Wait until a flow is in standby mode
- *  @deprecated in favor of waitUntilFlowStandby. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFlowCommand for polling.
+ *  @deprecated In favor of waitUntilFlowStandby. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFlowCommand for polling.
  */
 export const waitForFlowStandby = async (
   params: WaiterConfiguration<MediaConnectClient>,
@@ -57,8 +57,8 @@ export const waitForFlowStandby = async (
 };
 /**
  * Wait until a flow is in standby mode
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeFlowCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeFlowCommand for polling.
  */
 export const waitUntilFlowStandby = async (
   params: WaiterConfiguration<MediaConnectClient>,

--- a/clients/client-medialive/waiters/waitForChannelCreated.ts
+++ b/clients/client-medialive/waiters/waitForChannelCreated.ts
@@ -41,9 +41,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel has been created
- *  @deprecated In favor of waitUntilChannelCreated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeChannelCommand for polling.
+ *  @deprecated Use waitUntilChannelCreated instead. waitForChannelCreated does not throw error in non-success cases.
  */
 export const waitForChannelCreated = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelCreated.ts
+++ b/clients/client-medialive/waiters/waitForChannelCreated.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeChannelCommand, DescribeChannelCommandInput } from "../commands/DescribeChannelCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeChannelCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeChannelCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "IDLE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
         return result.State;
       };
       if (returnComparator() === "CREATING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -26,18 +28,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
         return result.State;
       };
       if (returnComparator() === "CREATE_FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a channel has been created
+ *  @deprecated in favor of waitUntilChannelCreated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeChannelCommand for polling.
  */
@@ -47,4 +51,17 @@ export const waitForChannelCreated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a channel has been created
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeChannelCommand for polling.
+ */
+export const waitUntilChannelCreated = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeChannelCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForChannelCreated.ts
+++ b/clients/client-medialive/waiters/waitForChannelCreated.ts
@@ -41,9 +41,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel has been created
- *  @deprecated in favor of waitUntilChannelCreated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @deprecated In favor of waitUntilChannelCreated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitForChannelCreated = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -54,8 +54,8 @@ export const waitForChannelCreated = async (
 };
 /**
  * Wait until a channel has been created
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitUntilChannelCreated = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelDeleted.ts
+++ b/clients/client-medialive/waiters/waitForChannelDeleted.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel has been deleted
- *  @deprecated In favor of waitUntilChannelDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeChannelCommand for polling.
+ *  @deprecated Use waitUntilChannelDeleted instead. waitForChannelDeleted does not throw error in non-success cases.
  */
 export const waitForChannelDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelDeleted.ts
+++ b/clients/client-medialive/waiters/waitForChannelDeleted.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeChannelCommand, DescribeChannelCommandInput } from "../commands/DescribeChannelCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeChannelCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeChannelCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "DELETED") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
         return result.State;
       };
       if (returnComparator() === "DELETING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a channel has been deleted
+ *  @deprecated in favor of waitUntilChannelDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeChannelCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForChannelDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a channel has been deleted
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeChannelCommand for polling.
+ */
+export const waitUntilChannelDeleted = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeChannelCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForChannelDeleted.ts
+++ b/clients/client-medialive/waiters/waitForChannelDeleted.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel has been deleted
- *  @deprecated in favor of waitUntilChannelDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @deprecated In favor of waitUntilChannelDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitForChannelDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForChannelDeleted = async (
 };
 /**
  * Wait until a channel has been deleted
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitUntilChannelDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelRunning.ts
+++ b/clients/client-medialive/waiters/waitForChannelRunning.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel is running
- *  @deprecated In favor of waitUntilChannelRunning. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeChannelCommand for polling.
+ *  @deprecated Use waitUntilChannelRunning instead. waitForChannelRunning does not throw error in non-success cases.
  */
 export const waitForChannelRunning = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelRunning.ts
+++ b/clients/client-medialive/waiters/waitForChannelRunning.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeChannelCommand, DescribeChannelCommandInput } from "../commands/DescribeChannelCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeChannelCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeChannelCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "RUNNING") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
         return result.State;
       };
       if (returnComparator() === "STARTING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a channel is running
+ *  @deprecated in favor of waitUntilChannelRunning. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeChannelCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForChannelRunning = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a channel is running
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeChannelCommand for polling.
+ */
+export const waitUntilChannelRunning = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeChannelCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForChannelRunning.ts
+++ b/clients/client-medialive/waiters/waitForChannelRunning.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel is running
- *  @deprecated in favor of waitUntilChannelRunning. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @deprecated In favor of waitUntilChannelRunning. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitForChannelRunning = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForChannelRunning = async (
 };
 /**
  * Wait until a channel is running
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitUntilChannelRunning = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelStopped.ts
+++ b/clients/client-medialive/waiters/waitForChannelStopped.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel has is stopped
- *  @deprecated In favor of waitUntilChannelStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeChannelCommand for polling.
+ *  @deprecated Use waitUntilChannelStopped instead. waitForChannelStopped does not throw error in non-success cases.
  */
 export const waitForChannelStopped = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelStopped.ts
+++ b/clients/client-medialive/waiters/waitForChannelStopped.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
 };
 /**
  * Wait until a channel has is stopped
- *  @deprecated in favor of waitUntilChannelStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @deprecated In favor of waitUntilChannelStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitForChannelStopped = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForChannelStopped = async (
 };
 /**
  * Wait until a channel has is stopped
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeChannelCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeChannelCommand for polling.
  */
 export const waitUntilChannelStopped = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForChannelStopped.ts
+++ b/clients/client-medialive/waiters/waitForChannelStopped.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeChannelCommand, DescribeChannelCommandInput } from "../commands/DescribeChannelCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeChannelCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeChannelCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "IDLE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeChannelCommand
         return result.State;
       };
       if (returnComparator() === "STOPPING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a channel has is stopped
+ *  @deprecated in favor of waitUntilChannelStopped. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeChannelCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForChannelStopped = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a channel has is stopped
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeChannelCommand for polling.
+ */
+export const waitUntilChannelStopped = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeChannelCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForInputAttached.ts
+++ b/clients/client-medialive/waiters/waitForInputAttached.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeInputCommand, DescribeInputCommandInput } from "../commands/DescribeInputCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeInputCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInputCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "ATTACHED") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
         return result.State;
       };
       if (returnComparator() === "DETACHED") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until an input has been attached
+ *  @deprecated in favor of waitUntilInputAttached. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInputCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForInputAttached = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until an input has been attached
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInputCommand for polling.
+ */
+export const waitUntilInputAttached = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeInputCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForInputAttached.ts
+++ b/clients/client-medialive/waiters/waitForInputAttached.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
 };
 /**
  * Wait until an input has been attached
- *  @deprecated in favor of waitUntilInputAttached. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInputCommand for polling.
+ *  @deprecated In favor of waitUntilInputAttached. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInputCommand for polling.
  */
 export const waitForInputAttached = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForInputAttached = async (
 };
 /**
  * Wait until an input has been attached
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInputCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInputCommand for polling.
  */
 export const waitUntilInputAttached = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForInputAttached.ts
+++ b/clients/client-medialive/waiters/waitForInputAttached.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
 };
 /**
  * Wait until an input has been attached
- *  @deprecated In favor of waitUntilInputAttached. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInputCommand for polling.
+ *  @deprecated Use waitUntilInputAttached instead. waitForInputAttached does not throw error in non-success cases.
  */
 export const waitForInputAttached = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForInputDeleted.ts
+++ b/clients/client-medialive/waiters/waitForInputDeleted.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
 };
 /**
  * Wait until an input has been deleted
- *  @deprecated in favor of waitUntilInputDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInputCommand for polling.
+ *  @deprecated In favor of waitUntilInputDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInputCommand for polling.
  */
 export const waitForInputDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForInputDeleted = async (
 };
 /**
  * Wait until an input has been deleted
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInputCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInputCommand for polling.
  */
 export const waitUntilInputDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForInputDeleted.ts
+++ b/clients/client-medialive/waiters/waitForInputDeleted.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
 };
 /**
  * Wait until an input has been deleted
- *  @deprecated In favor of waitUntilInputDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInputCommand for polling.
+ *  @deprecated Use waitUntilInputDeleted instead. waitForInputDeleted does not throw error in non-success cases.
  */
 export const waitForInputDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForInputDeleted.ts
+++ b/clients/client-medialive/waiters/waitForInputDeleted.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeInputCommand, DescribeInputCommandInput } from "../commands/DescribeInputCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeInputCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInputCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "DELETED") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
         return result.State;
       };
       if (returnComparator() === "DELETING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until an input has been deleted
+ *  @deprecated in favor of waitUntilInputDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInputCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForInputDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until an input has been deleted
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInputCommand for polling.
+ */
+export const waitUntilInputDeleted = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeInputCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForInputDetached.ts
+++ b/clients/client-medialive/waiters/waitForInputDetached.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeInputCommand, DescribeInputCommandInput } from "../commands/DescribeInputCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeInputCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInputCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "DETACHED") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
         return result.State;
       };
       if (returnComparator() === "CREATING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -26,18 +28,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
         return result.State;
       };
       if (returnComparator() === "ATTACHED") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until an input has been detached
+ *  @deprecated in favor of waitUntilInputDetached. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInputCommand for polling.
  */
@@ -47,4 +51,17 @@ export const waitForInputDetached = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until an input has been detached
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInputCommand for polling.
+ */
+export const waitUntilInputDetached = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeInputCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForInputDetached.ts
+++ b/clients/client-medialive/waiters/waitForInputDetached.ts
@@ -41,9 +41,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
 };
 /**
  * Wait until an input has been detached
- *  @deprecated in favor of waitUntilInputDetached. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInputCommand for polling.
+ *  @deprecated In favor of waitUntilInputDetached. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInputCommand for polling.
  */
 export const waitForInputDetached = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -54,8 +54,8 @@ export const waitForInputDetached = async (
 };
 /**
  * Wait until an input has been detached
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInputCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInputCommand for polling.
  */
 export const waitUntilInputDetached = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForInputDetached.ts
+++ b/clients/client-medialive/waiters/waitForInputDetached.ts
@@ -41,9 +41,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeInputCommandIn
 };
 /**
  * Wait until an input has been detached
- *  @deprecated In favor of waitUntilInputDetached. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInputCommand for polling.
+ *  @deprecated Use waitUntilInputDetached instead. waitForInputDetached does not throw error in non-success cases.
  */
 export const waitForInputDetached = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexCreated.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexCreated.ts
@@ -41,9 +41,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex has been created
- *  @deprecated in favor of waitUntilMultiplexCreated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @deprecated In favor of waitUntilMultiplexCreated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitForMultiplexCreated = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -54,8 +54,8 @@ export const waitForMultiplexCreated = async (
 };
 /**
  * Wait until a multiplex has been created
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitUntilMultiplexCreated = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexCreated.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexCreated.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeMultiplexCommand, DescribeMultiplexCommandInput } from "../commands/DescribeMultiplexCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeMultiplexCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeMultiplexCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "IDLE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
         return result.State;
       };
       if (returnComparator() === "CREATING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -26,18 +28,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
         return result.State;
       };
       if (returnComparator() === "CREATE_FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a multiplex has been created
+ *  @deprecated in favor of waitUntilMultiplexCreated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeMultiplexCommand for polling.
  */
@@ -47,4 +51,17 @@ export const waitForMultiplexCreated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a multiplex has been created
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeMultiplexCommand for polling.
+ */
+export const waitUntilMultiplexCreated = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeMultiplexCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForMultiplexCreated.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexCreated.ts
@@ -41,9 +41,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex has been created
- *  @deprecated In favor of waitUntilMultiplexCreated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeMultiplexCommand for polling.
+ *  @deprecated Use waitUntilMultiplexCreated instead. waitForMultiplexCreated does not throw error in non-success cases.
  */
 export const waitForMultiplexCreated = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexDeleted.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexDeleted.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex has been deleted
- *  @deprecated In favor of waitUntilMultiplexDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeMultiplexCommand for polling.
+ *  @deprecated Use waitUntilMultiplexDeleted instead. waitForMultiplexDeleted does not throw error in non-success cases.
  */
 export const waitForMultiplexDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexDeleted.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexDeleted.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeMultiplexCommand, DescribeMultiplexCommandInput } from "../commands/DescribeMultiplexCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeMultiplexCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeMultiplexCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "DELETED") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
         return result.State;
       };
       if (returnComparator() === "DELETING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a multiplex has been deleted
+ *  @deprecated in favor of waitUntilMultiplexDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeMultiplexCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForMultiplexDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a multiplex has been deleted
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeMultiplexCommand for polling.
+ */
+export const waitUntilMultiplexDeleted = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeMultiplexCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForMultiplexDeleted.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexDeleted.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex has been deleted
- *  @deprecated in favor of waitUntilMultiplexDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @deprecated In favor of waitUntilMultiplexDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitForMultiplexDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForMultiplexDeleted = async (
 };
 /**
  * Wait until a multiplex has been deleted
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitUntilMultiplexDeleted = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexRunning.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexRunning.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex is running
- *  @deprecated In favor of waitUntilMultiplexRunning. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeMultiplexCommand for polling.
+ *  @deprecated Use waitUntilMultiplexRunning instead. waitForMultiplexRunning does not throw error in non-success cases.
  */
 export const waitForMultiplexRunning = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexRunning.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexRunning.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeMultiplexCommand, DescribeMultiplexCommandInput } from "../commands/DescribeMultiplexCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeMultiplexCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeMultiplexCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "RUNNING") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
         return result.State;
       };
       if (returnComparator() === "STARTING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a multiplex is running
+ *  @deprecated in favor of waitUntilMultiplexRunning. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeMultiplexCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForMultiplexRunning = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a multiplex is running
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeMultiplexCommand for polling.
+ */
+export const waitUntilMultiplexRunning = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeMultiplexCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForMultiplexRunning.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexRunning.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex is running
- *  @deprecated in favor of waitUntilMultiplexRunning. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @deprecated In favor of waitUntilMultiplexRunning. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitForMultiplexRunning = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForMultiplexRunning = async (
 };
 /**
  * Wait until a multiplex is running
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitUntilMultiplexRunning = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexStopped.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexStopped.ts
@@ -1,16 +1,18 @@
 import { MediaLiveClient } from "../MediaLiveClient";
 import { DescribeMultiplexCommand, DescribeMultiplexCommandInput } from "../commands/DescribeMultiplexCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: MediaLiveClient, input: DescribeMultiplexCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeMultiplexCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.State;
       };
       if (returnComparator() === "IDLE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
         return result.State;
       };
       if (returnComparator() === "STOPPING") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "InternalServerErrorException") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a multiplex has is stopped
+ *  @deprecated in favor of waitUntilMultiplexStopped. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeMultiplexCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForMultiplexStopped = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a multiplex has is stopped
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeMultiplexCommand for polling.
+ */
+export const waitUntilMultiplexStopped = async (
+  params: WaiterConfiguration<MediaLiveClient>,
+  input: DescribeMultiplexCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-medialive/waiters/waitForMultiplexStopped.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexStopped.ts
@@ -33,9 +33,7 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex has is stopped
- *  @deprecated In favor of waitUntilMultiplexStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeMultiplexCommand for polling.
+ *  @deprecated Use waitUntilMultiplexStopped instead. waitForMultiplexStopped does not throw error in non-success cases.
  */
 export const waitForMultiplexStopped = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-medialive/waiters/waitForMultiplexStopped.ts
+++ b/clients/client-medialive/waiters/waitForMultiplexStopped.ts
@@ -33,9 +33,9 @@ const checkState = async (client: MediaLiveClient, input: DescribeMultiplexComma
 };
 /**
  * Wait until a multiplex has is stopped
- *  @deprecated in favor of waitUntilMultiplexStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @deprecated In favor of waitUntilMultiplexStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitForMultiplexStopped = async (
   params: WaiterConfiguration<MediaLiveClient>,
@@ -46,8 +46,8 @@ export const waitForMultiplexStopped = async (
 };
 /**
  * Wait until a multiplex has is stopped
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeMultiplexCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeMultiplexCommand for polling.
  */
 export const waitUntilMultiplexStopped = async (
   params: WaiterConfiguration<MediaLiveClient>,

--- a/clients/client-neptune/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-neptune/waiters/waitForDBInstanceAvailable.ts
@@ -100,9 +100,9 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
 };
 /**
  *
- *  @deprecated in favor of waitUntilDBInstanceAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilDBInstanceAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBInstancesCommand for polling.
  */
 export const waitForDBInstanceAvailable = async (
   params: WaiterConfiguration<NeptuneClient>,
@@ -113,8 +113,8 @@ export const waitForDBInstanceAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBInstancesCommand for polling.
  */
 export const waitUntilDBInstanceAvailable = async (
   params: WaiterConfiguration<NeptuneClient>,

--- a/clients/client-neptune/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-neptune/waiters/waitForDBInstanceAvailable.ts
@@ -100,9 +100,7 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
 };
 /**
  *
- *  @deprecated In favor of waitUntilDBInstanceAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDBInstancesCommand for polling.
+ *  @deprecated Use waitUntilDBInstanceAvailable instead. waitForDBInstanceAvailable does not throw error in non-success cases.
  */
 export const waitForDBInstanceAvailable = async (
   params: WaiterConfiguration<NeptuneClient>,

--- a/clients/client-neptune/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-neptune/waiters/waitForDBInstanceAvailable.ts
@@ -1,10 +1,12 @@
 import { NeptuneClient } from "../NeptuneClient";
 import { DescribeDBInstancesCommand, DescribeDBInstancesCommandInput } from "../commands/DescribeDBInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: NeptuneClient, input: DescribeDBInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDBInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.DBInstances);
@@ -18,7 +20,7 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-restore") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,15 +89,18 @@ const checkState = async (client: NeptuneClient, input: DescribeDBInstancesComma
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-parameters") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDBInstanceAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDBInstancesCommand for polling.
  */
@@ -105,4 +110,17 @@ export const waitForDBInstanceAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDBInstancesCommand for polling.
+ */
+export const waitUntilDBInstanceAvailable = async (
+  params: WaiterConfiguration<NeptuneClient>,
+  input: DescribeDBInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworks/waiters/waitForAppExists.ts
+++ b/clients/client-opsworks/waiters/waitForAppExists.ts
@@ -1,18 +1,22 @@
 import { OpsWorksClient } from "../OpsWorksClient";
 import { DescribeAppsCommand, DescribeAppsCommandInput } from "../commands/DescribeAppsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: OpsWorksClient, input: DescribeAppsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeAppsCommand(input));
-    return { state: WaiterState.SUCCESS };
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
-    return { state: WaiterState.FAILURE };
+    reason = exception;
+    return { state: WaiterState.FAILURE, reason };
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilAppExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeAppsCommand for polling.
  */
@@ -22,4 +26,17 @@ export const waitForAppExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 1, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeAppsCommand for polling.
+ */
+export const waitUntilAppExists = async (
+  params: WaiterConfiguration<OpsWorksClient>,
+  input: DescribeAppsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 1, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworks/waiters/waitForAppExists.ts
+++ b/clients/client-opsworks/waiters/waitForAppExists.ts
@@ -16,9 +16,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeAppsCommandInpu
 };
 /**
  *
- *  @deprecated In favor of waitUntilAppExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeAppsCommand for polling.
+ *  @deprecated Use waitUntilAppExists instead. waitForAppExists does not throw error in non-success cases.
  */
 export const waitForAppExists = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForAppExists.ts
+++ b/clients/client-opsworks/waiters/waitForAppExists.ts
@@ -16,9 +16,9 @@ const checkState = async (client: OpsWorksClient, input: DescribeAppsCommandInpu
 };
 /**
  *
- *  @deprecated in favor of waitUntilAppExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAppsCommand for polling.
+ *  @deprecated In favor of waitUntilAppExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAppsCommand for polling.
  */
 export const waitForAppExists = async (
   params: WaiterConfiguration<OpsWorksClient>,
@@ -29,8 +29,8 @@ export const waitForAppExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeAppsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeAppsCommand for polling.
  */
 export const waitUntilAppExists = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForDeploymentSuccessful.ts
+++ b/clients/client-opsworks/waiters/waitForDeploymentSuccessful.ts
@@ -44,9 +44,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeDeploymentsComm
 };
 /**
  * Wait until a deployment has completed successfully.
- *  @deprecated In favor of waitUntilDeploymentSuccessful. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDeploymentsCommand for polling.
+ *  @deprecated Use waitUntilDeploymentSuccessful instead. waitForDeploymentSuccessful does not throw error in non-success cases.
  */
 export const waitForDeploymentSuccessful = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForDeploymentSuccessful.ts
+++ b/clients/client-opsworks/waiters/waitForDeploymentSuccessful.ts
@@ -1,10 +1,12 @@
 import { OpsWorksClient } from "../OpsWorksClient";
 import { DescribeDeploymentsCommand, DescribeDeploymentsCommandInput } from "../commands/DescribeDeploymentsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: OpsWorksClient, input: DescribeDeploymentsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDeploymentsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Deployments);
@@ -18,7 +20,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeDeploymentsComm
         allStringEq_5 = allStringEq_5 && element_4 == "successful";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,15 +33,18 @@ const checkState = async (client: OpsWorksClient, input: DescribeDeploymentsComm
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until a deployment has completed successfully.
+ *  @deprecated in favor of waitUntilDeploymentSuccessful. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDeploymentsCommand for polling.
  */
@@ -49,4 +54,17 @@ export const waitForDeploymentSuccessful = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until a deployment has completed successfully.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDeploymentsCommand for polling.
+ */
+export const waitUntilDeploymentSuccessful = async (
+  params: WaiterConfiguration<OpsWorksClient>,
+  input: DescribeDeploymentsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworks/waiters/waitForDeploymentSuccessful.ts
+++ b/clients/client-opsworks/waiters/waitForDeploymentSuccessful.ts
@@ -44,9 +44,9 @@ const checkState = async (client: OpsWorksClient, input: DescribeDeploymentsComm
 };
 /**
  * Wait until a deployment has completed successfully.
- *  @deprecated in favor of waitUntilDeploymentSuccessful. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDeploymentsCommand for polling.
+ *  @deprecated In favor of waitUntilDeploymentSuccessful. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDeploymentsCommand for polling.
  */
 export const waitForDeploymentSuccessful = async (
   params: WaiterConfiguration<OpsWorksClient>,
@@ -57,8 +57,8 @@ export const waitForDeploymentSuccessful = async (
 };
 /**
  * Wait until a deployment has completed successfully.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDeploymentsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDeploymentsCommand for polling.
  */
 export const waitUntilDeploymentSuccessful = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceOnline.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceOnline.ts
@@ -142,9 +142,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is online.
- *  @deprecated In favor of waitUntilInstanceOnline. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstancesCommand for polling.
+ *  @deprecated Use waitUntilInstanceOnline instead. waitForInstanceOnline does not throw error in non-success cases.
  */
 export const waitForInstanceOnline = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceOnline.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceOnline.ts
@@ -142,9 +142,9 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is online.
- *  @deprecated in favor of waitUntilInstanceOnline. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilInstanceOnline. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitForInstanceOnline = async (
   params: WaiterConfiguration<OpsWorksClient>,
@@ -155,8 +155,8 @@ export const waitForInstanceOnline = async (
 };
 /**
  * Wait until OpsWorks instance is online.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitUntilInstanceOnline = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceOnline.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceOnline.ts
@@ -1,10 +1,12 @@
 import { OpsWorksClient } from "../OpsWorksClient";
 import { DescribeInstancesCommand, DescribeInstancesCommandInput } from "../commands/DescribeInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: OpsWorksClient, input: DescribeInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Instances);
@@ -18,7 +20,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
         allStringEq_5 = allStringEq_5 && element_4 == "online";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "setup_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "shutting_down") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "start_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopped") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,7 +89,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopping") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -101,7 +103,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "terminating") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -115,7 +117,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "terminated") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -129,15 +131,18 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stop_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until OpsWorks instance is online.
+ *  @deprecated in favor of waitUntilInstanceOnline. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstancesCommand for polling.
  */
@@ -147,4 +152,17 @@ export const waitForInstanceOnline = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until OpsWorks instance is online.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstancesCommand for polling.
+ */
+export const waitUntilInstanceOnline = async (
+  params: WaiterConfiguration<OpsWorksClient>,
+  input: DescribeInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworks/waiters/waitForInstanceRegistered.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceRegistered.ts
@@ -128,9 +128,9 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is registered.
- *  @deprecated in favor of waitUntilInstanceRegistered. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilInstanceRegistered. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitForInstanceRegistered = async (
   params: WaiterConfiguration<OpsWorksClient>,
@@ -141,8 +141,8 @@ export const waitForInstanceRegistered = async (
 };
 /**
  * Wait until OpsWorks instance is registered.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitUntilInstanceRegistered = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceRegistered.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceRegistered.ts
@@ -128,9 +128,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is registered.
- *  @deprecated In favor of waitUntilInstanceRegistered. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstancesCommand for polling.
+ *  @deprecated Use waitUntilInstanceRegistered instead. waitForInstanceRegistered does not throw error in non-success cases.
  */
 export const waitForInstanceRegistered = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceRegistered.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceRegistered.ts
@@ -1,10 +1,12 @@
 import { OpsWorksClient } from "../OpsWorksClient";
 import { DescribeInstancesCommand, DescribeInstancesCommandInput } from "../commands/DescribeInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: OpsWorksClient, input: DescribeInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Instances);
@@ -18,7 +20,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
         allStringEq_5 = allStringEq_5 && element_4 == "registered";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "setup_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "shutting_down") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopped") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stopping") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,7 +89,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "terminating") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -101,7 +103,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "terminated") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -115,15 +117,18 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stop_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until OpsWorks instance is registered.
+ *  @deprecated in favor of waitUntilInstanceRegistered. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstancesCommand for polling.
  */
@@ -133,4 +138,17 @@ export const waitForInstanceRegistered = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until OpsWorks instance is registered.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstancesCommand for polling.
+ */
+export const waitUntilInstanceRegistered = async (
+  params: WaiterConfiguration<OpsWorksClient>,
+  input: DescribeInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworks/waiters/waitForInstanceStopped.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceStopped.ts
@@ -142,9 +142,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is stopped.
- *  @deprecated In favor of waitUntilInstanceStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstancesCommand for polling.
+ *  @deprecated Use waitUntilInstanceStopped instead. waitForInstanceStopped does not throw error in non-success cases.
  */
 export const waitForInstanceStopped = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceStopped.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceStopped.ts
@@ -142,9 +142,9 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is stopped.
- *  @deprecated in favor of waitUntilInstanceStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilInstanceStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitForInstanceStopped = async (
   params: WaiterConfiguration<OpsWorksClient>,
@@ -155,8 +155,8 @@ export const waitForInstanceStopped = async (
 };
 /**
  * Wait until OpsWorks instance is stopped.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitUntilInstanceStopped = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceStopped.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceStopped.ts
@@ -1,10 +1,12 @@
 import { OpsWorksClient } from "../OpsWorksClient";
 import { DescribeInstancesCommand, DescribeInstancesCommandInput } from "../commands/DescribeInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: OpsWorksClient, input: DescribeInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Instances);
@@ -18,7 +20,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
         allStringEq_5 = allStringEq_5 && element_4 == "stopped";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "booting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "pending") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "rebooting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "requested") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,7 +89,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "running_setup") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -101,7 +103,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "setup_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -115,7 +117,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "start_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -129,15 +131,18 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "stop_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until OpsWorks instance is stopped.
+ *  @deprecated in favor of waitUntilInstanceStopped. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstancesCommand for polling.
  */
@@ -147,4 +152,17 @@ export const waitForInstanceStopped = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until OpsWorks instance is stopped.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstancesCommand for polling.
+ */
+export const waitUntilInstanceStopped = async (
+  params: WaiterConfiguration<OpsWorksClient>,
+  input: DescribeInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworks/waiters/waitForInstanceTerminated.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceTerminated.ts
@@ -145,9 +145,9 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is terminated.
- *  @deprecated in favor of waitUntilInstanceTerminated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilInstanceTerminated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitForInstanceTerminated = async (
   params: WaiterConfiguration<OpsWorksClient>,
@@ -158,8 +158,8 @@ export const waitForInstanceTerminated = async (
 };
 /**
  * Wait until OpsWorks instance is terminated.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeInstancesCommand for polling.
  */
 export const waitUntilInstanceTerminated = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworks/waiters/waitForInstanceTerminated.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceTerminated.ts
@@ -1,10 +1,12 @@
 import { OpsWorksClient } from "../OpsWorksClient";
 import { DescribeInstancesCommand, DescribeInstancesCommandInput } from "../commands/DescribeInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: OpsWorksClient, input: DescribeInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Instances);
@@ -18,7 +20,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
         allStringEq_5 = allStringEq_5 && element_4 == "terminated";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "booting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "online") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "pending") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "rebooting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,7 +89,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "requested") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -101,7 +103,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "running_setup") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -115,7 +117,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "setup_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -129,19 +131,21 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "start_failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until OpsWorks instance is terminated.
+ *  @deprecated in favor of waitUntilInstanceTerminated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeInstancesCommand for polling.
  */
@@ -151,4 +155,17 @@ export const waitForInstanceTerminated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until OpsWorks instance is terminated.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeInstancesCommand for polling.
+ */
+export const waitUntilInstanceTerminated = async (
+  params: WaiterConfiguration<OpsWorksClient>,
+  input: DescribeInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworks/waiters/waitForInstanceTerminated.ts
+++ b/clients/client-opsworks/waiters/waitForInstanceTerminated.ts
@@ -145,9 +145,7 @@ const checkState = async (client: OpsWorksClient, input: DescribeInstancesComman
 };
 /**
  * Wait until OpsWorks instance is terminated.
- *  @deprecated In favor of waitUntilInstanceTerminated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeInstancesCommand for polling.
+ *  @deprecated Use waitUntilInstanceTerminated instead. waitForInstanceTerminated does not throw error in non-success cases.
  */
 export const waitForInstanceTerminated = async (
   params: WaiterConfiguration<OpsWorksClient>,

--- a/clients/client-opsworkscm/waiters/waitForNodeAssociated.ts
+++ b/clients/client-opsworkscm/waiters/waitForNodeAssociated.ts
@@ -3,20 +3,22 @@ import {
   DescribeNodeAssociationStatusCommand,
   DescribeNodeAssociationStatusCommandInput,
 } from "../commands/DescribeNodeAssociationStatusCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: OpsWorksCMClient,
   input: DescribeNodeAssociationStatusCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeNodeAssociationStatusCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.NodeAssociationStatus;
       };
       if (returnComparator() === "SUCCESS") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -24,14 +26,17 @@ const checkState = async (
         return result.NodeAssociationStatus;
       };
       if (returnComparator() === "FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until node is associated or disassociated.
+ *  @deprecated in favor of waitUntilNodeAssociated. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeNodeAssociationStatusCommand for polling.
  */
@@ -41,4 +46,17 @@ export const waitForNodeAssociated = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until node is associated or disassociated.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeNodeAssociationStatusCommand for polling.
+ */
+export const waitUntilNodeAssociated = async (
+  params: WaiterConfiguration<OpsWorksCMClient>,
+  input: DescribeNodeAssociationStatusCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-opsworkscm/waiters/waitForNodeAssociated.ts
+++ b/clients/client-opsworkscm/waiters/waitForNodeAssociated.ts
@@ -36,9 +36,9 @@ const checkState = async (
 };
 /**
  * Wait until node is associated or disassociated.
- *  @deprecated in favor of waitUntilNodeAssociated. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNodeAssociationStatusCommand for polling.
+ *  @deprecated In favor of waitUntilNodeAssociated. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNodeAssociationStatusCommand for polling.
  */
 export const waitForNodeAssociated = async (
   params: WaiterConfiguration<OpsWorksCMClient>,
@@ -49,8 +49,8 @@ export const waitForNodeAssociated = async (
 };
 /**
  * Wait until node is associated or disassociated.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNodeAssociationStatusCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNodeAssociationStatusCommand for polling.
  */
 export const waitUntilNodeAssociated = async (
   params: WaiterConfiguration<OpsWorksCMClient>,

--- a/clients/client-opsworkscm/waiters/waitForNodeAssociated.ts
+++ b/clients/client-opsworkscm/waiters/waitForNodeAssociated.ts
@@ -36,9 +36,7 @@ const checkState = async (
 };
 /**
  * Wait until node is associated or disassociated.
- *  @deprecated In favor of waitUntilNodeAssociated. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeNodeAssociationStatusCommand for polling.
+ *  @deprecated Use waitUntilNodeAssociated instead. waitForNodeAssociated does not throw error in non-success cases.
  */
 export const waitForNodeAssociated = async (
   params: WaiterConfiguration<OpsWorksCMClient>,

--- a/clients/client-rds/waiters/waitForDBClusterSnapshotAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBClusterSnapshotAvailable.ts
@@ -3,11 +3,13 @@ import {
   DescribeDBClusterSnapshotsCommand,
   DescribeDBClusterSnapshotsCommandInput,
 } from "../commands/DescribeDBClusterSnapshotsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDBClusterSnapshotsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.DBClusterSnapshots);
@@ -21,7 +23,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -34,7 +36,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -48,7 +50,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -62,7 +64,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -76,7 +78,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-restore") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -90,15 +92,18 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-parameters") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDBClusterSnapshotAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
  */
@@ -108,4 +113,17 @@ export const waitForDBClusterSnapshotAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
+ */
+export const waitUntilDBClusterSnapshotAvailable = async (
+  params: WaiterConfiguration<RDSClient>,
+  input: DescribeDBClusterSnapshotsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-rds/waiters/waitForDBClusterSnapshotAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBClusterSnapshotAvailable.ts
@@ -103,9 +103,9 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
 };
 /**
  *
- *  @deprecated in favor of waitUntilDBClusterSnapshotAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
+ *  @deprecated In favor of waitUntilDBClusterSnapshotAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBClusterSnapshotsCommand for polling.
  */
 export const waitForDBClusterSnapshotAvailable = async (
   params: WaiterConfiguration<RDSClient>,
@@ -116,8 +116,8 @@ export const waitForDBClusterSnapshotAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBClusterSnapshotsCommand for polling.
  */
 export const waitUntilDBClusterSnapshotAvailable = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBClusterSnapshotAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBClusterSnapshotAvailable.ts
@@ -103,9 +103,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
 };
 /**
  *
- *  @deprecated In favor of waitUntilDBClusterSnapshotAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDBClusterSnapshotsCommand for polling.
+ *  @deprecated Use waitUntilDBClusterSnapshotAvailable instead. waitForDBClusterSnapshotAvailable does not throw error in non-success cases.
  */
 export const waitForDBClusterSnapshotAvailable = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBClusterSnapshotDeleted.ts
+++ b/clients/client-rds/waiters/waitForDBClusterSnapshotDeleted.ts
@@ -3,17 +3,19 @@ import {
   DescribeDBClusterSnapshotsCommand,
   DescribeDBClusterSnapshotsCommandInput,
 } from "../commands/DescribeDBClusterSnapshotsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDBClusterSnapshotsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.DBClusterSnapshots.length == 0.0;
       };
       if (returnComparator() == true) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -26,7 +28,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "creating") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -40,7 +42,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "modifying") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -54,7 +56,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "rebooting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -68,19 +70,21 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "resetting-master-credentials") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "DBClusterSnapshotNotFoundFault") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDBClusterSnapshotDeleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
  */
@@ -90,4 +94,17 @@ export const waitForDBClusterSnapshotDeleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
+ */
+export const waitUntilDBClusterSnapshotDeleted = async (
+  params: WaiterConfiguration<RDSClient>,
+  input: DescribeDBClusterSnapshotsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-rds/waiters/waitForDBClusterSnapshotDeleted.ts
+++ b/clients/client-rds/waiters/waitForDBClusterSnapshotDeleted.ts
@@ -84,9 +84,9 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
 };
 /**
  *
- *  @deprecated in favor of waitUntilDBClusterSnapshotDeleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
+ *  @deprecated In favor of waitUntilDBClusterSnapshotDeleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBClusterSnapshotsCommand for polling.
  */
 export const waitForDBClusterSnapshotDeleted = async (
   params: WaiterConfiguration<RDSClient>,
@@ -97,8 +97,8 @@ export const waitForDBClusterSnapshotDeleted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBClusterSnapshotsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBClusterSnapshotsCommand for polling.
  */
 export const waitUntilDBClusterSnapshotDeleted = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBClusterSnapshotDeleted.ts
+++ b/clients/client-rds/waiters/waitForDBClusterSnapshotDeleted.ts
@@ -84,9 +84,7 @@ const checkState = async (client: RDSClient, input: DescribeDBClusterSnapshotsCo
 };
 /**
  *
- *  @deprecated In favor of waitUntilDBClusterSnapshotDeleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDBClusterSnapshotsCommand for polling.
+ *  @deprecated Use waitUntilDBClusterSnapshotDeleted instead. waitForDBClusterSnapshotDeleted does not throw error in non-success cases.
  */
 export const waitForDBClusterSnapshotDeleted = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBInstanceAvailable.ts
@@ -100,9 +100,9 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
 };
 /**
  *
- *  @deprecated in favor of waitUntilDBInstanceAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBInstancesCommand for polling.
+ *  @deprecated In favor of waitUntilDBInstanceAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBInstancesCommand for polling.
  */
 export const waitForDBInstanceAvailable = async (
   params: WaiterConfiguration<RDSClient>,
@@ -113,8 +113,8 @@ export const waitForDBInstanceAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBInstancesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBInstancesCommand for polling.
  */
 export const waitUntilDBInstanceAvailable = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBInstanceAvailable.ts
@@ -100,9 +100,7 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
 };
 /**
  *
- *  @deprecated In favor of waitUntilDBInstanceAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDBInstancesCommand for polling.
+ *  @deprecated Use waitUntilDBInstanceAvailable instead. waitForDBInstanceAvailable does not throw error in non-success cases.
  */
 export const waitForDBInstanceAvailable = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBInstanceAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBInstanceAvailable.ts
@@ -1,10 +1,12 @@
 import { RDSClient } from "../RDSClient";
 import { DescribeDBInstancesCommand, DescribeDBInstancesCommandInput } from "../commands/DescribeDBInstancesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDBInstancesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.DBInstances);
@@ -18,7 +20,7 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-restore") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,15 +89,18 @@ const checkState = async (client: RDSClient, input: DescribeDBInstancesCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-parameters") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDBInstanceAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDBInstancesCommand for polling.
  */
@@ -105,4 +110,17 @@ export const waitForDBInstanceAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDBInstancesCommand for polling.
+ */
+export const waitUntilDBInstanceAvailable = async (
+  params: WaiterConfiguration<RDSClient>,
+  input: DescribeDBInstancesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-rds/waiters/waitForDBSnapshotAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBSnapshotAvailable.ts
@@ -100,9 +100,9 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
 };
 /**
  *
- *  @deprecated in favor of waitUntilDBSnapshotAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBSnapshotsCommand for polling.
+ *  @deprecated In favor of waitUntilDBSnapshotAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBSnapshotsCommand for polling.
  */
 export const waitForDBSnapshotAvailable = async (
   params: WaiterConfiguration<RDSClient>,
@@ -113,8 +113,8 @@ export const waitForDBSnapshotAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeDBSnapshotsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeDBSnapshotsCommand for polling.
  */
 export const waitUntilDBSnapshotAvailable = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBSnapshotAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBSnapshotAvailable.ts
@@ -100,9 +100,7 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
 };
 /**
  *
- *  @deprecated In favor of waitUntilDBSnapshotAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeDBSnapshotsCommand for polling.
+ *  @deprecated Use waitUntilDBSnapshotAvailable instead. waitForDBSnapshotAvailable does not throw error in non-success cases.
  */
 export const waitForDBSnapshotAvailable = async (
   params: WaiterConfiguration<RDSClient>,

--- a/clients/client-rds/waiters/waitForDBSnapshotAvailable.ts
+++ b/clients/client-rds/waiters/waitForDBSnapshotAvailable.ts
@@ -1,10 +1,12 @@
 import { RDSClient } from "../RDSClient";
 import { DescribeDBSnapshotsCommand, DescribeDBSnapshotsCommandInput } from "../commands/DescribeDBSnapshotsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeDBSnapshotsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.DBSnapshots);
@@ -18,7 +20,7 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,7 +33,7 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -45,7 +47,7 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -59,7 +61,7 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -73,7 +75,7 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-restore") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -87,15 +89,18 @@ const checkState = async (client: RDSClient, input: DescribeDBSnapshotsCommandIn
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "incompatible-parameters") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilDBSnapshotAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeDBSnapshotsCommand for polling.
  */
@@ -105,4 +110,17 @@ export const waitForDBSnapshotAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeDBSnapshotsCommand for polling.
+ */
+export const waitUntilDBSnapshotAvailable = async (
+  params: WaiterConfiguration<RDSClient>,
+  input: DescribeDBSnapshotsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-redshift/waiters/waitForClusterRestored.ts
+++ b/clients/client-redshift/waiters/waitForClusterRestored.ts
@@ -44,9 +44,9 @@ const checkState = async (client: RedshiftClient, input: DescribeClustersCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilClusterRestored. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClustersCommand for polling.
+ *  @deprecated In favor of waitUntilClusterRestored. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClustersCommand for polling.
  */
 export const waitForClusterRestored = async (
   params: WaiterConfiguration<RedshiftClient>,
@@ -57,8 +57,8 @@ export const waitForClusterRestored = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClustersCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClustersCommand for polling.
  */
 export const waitUntilClusterRestored = async (
   params: WaiterConfiguration<RedshiftClient>,

--- a/clients/client-redshift/waiters/waitForClusterRestored.ts
+++ b/clients/client-redshift/waiters/waitForClusterRestored.ts
@@ -44,9 +44,7 @@ const checkState = async (client: RedshiftClient, input: DescribeClustersCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilClusterRestored. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeClustersCommand for polling.
+ *  @deprecated Use waitUntilClusterRestored instead. waitForClusterRestored does not throw error in non-success cases.
  */
 export const waitForClusterRestored = async (
   params: WaiterConfiguration<RedshiftClient>,

--- a/clients/client-redshift/waiters/waitForClusterRestored.ts
+++ b/clients/client-redshift/waiters/waitForClusterRestored.ts
@@ -1,10 +1,12 @@
 import { RedshiftClient } from "../RedshiftClient";
 import { DescribeClustersCommand, DescribeClustersCommandInput } from "../commands/DescribeClustersCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: RedshiftClient, input: DescribeClustersCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeClustersCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Clusters);
@@ -18,7 +20,7 @@ const checkState = async (client: RedshiftClient, input: DescribeClustersCommand
         allStringEq_5 = allStringEq_5 && element_4 == "completed";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -31,15 +33,18 @@ const checkState = async (client: RedshiftClient, input: DescribeClustersCommand
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleting") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilClusterRestored. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeClustersCommand for polling.
  */
@@ -49,4 +54,17 @@ export const waitForClusterRestored = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 60, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeClustersCommand for polling.
+ */
+export const waitUntilClusterRestored = async (
+  params: WaiterConfiguration<RedshiftClient>,
+  input: DescribeClustersCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 60, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-redshift/waiters/waitForSnapshotAvailable.ts
+++ b/clients/client-redshift/waiters/waitForSnapshotAvailable.ts
@@ -3,14 +3,16 @@ import {
   DescribeClusterSnapshotsCommand,
   DescribeClusterSnapshotsCommandInput,
 } from "../commands/DescribeClusterSnapshotsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: RedshiftClient,
   input: DescribeClusterSnapshotsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeClusterSnapshotsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.Snapshots);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "available";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,7 +39,7 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "failed") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
@@ -51,15 +53,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "deleted") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilSnapshotAvailable. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeClusterSnapshotsCommand for polling.
  */
@@ -69,4 +74,17 @@ export const waitForSnapshotAvailable = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 15, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeClusterSnapshotsCommand for polling.
+ */
+export const waitUntilSnapshotAvailable = async (
+  params: WaiterConfiguration<RedshiftClient>,
+  input: DescribeClusterSnapshotsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-redshift/waiters/waitForSnapshotAvailable.ts
+++ b/clients/client-redshift/waiters/waitForSnapshotAvailable.ts
@@ -64,9 +64,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilSnapshotAvailable. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeClusterSnapshotsCommand for polling.
+ *  @deprecated Use waitUntilSnapshotAvailable instead. waitForSnapshotAvailable does not throw error in non-success cases.
  */
 export const waitForSnapshotAvailable = async (
   params: WaiterConfiguration<RedshiftClient>,

--- a/clients/client-redshift/waiters/waitForSnapshotAvailable.ts
+++ b/clients/client-redshift/waiters/waitForSnapshotAvailable.ts
@@ -64,9 +64,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilSnapshotAvailable. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterSnapshotsCommand for polling.
+ *  @deprecated In favor of waitUntilSnapshotAvailable. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterSnapshotsCommand for polling.
  */
 export const waitForSnapshotAvailable = async (
   params: WaiterConfiguration<RedshiftClient>,
@@ -77,8 +77,8 @@ export const waitForSnapshotAvailable = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeClusterSnapshotsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeClusterSnapshotsCommand for polling.
  */
 export const waitUntilSnapshotAvailable = async (
   params: WaiterConfiguration<RedshiftClient>,

--- a/clients/client-rekognition/waiters/waitForProjectVersionRunning.ts
+++ b/clients/client-rekognition/waiters/waitForProjectVersionRunning.ts
@@ -50,9 +50,7 @@ const checkState = async (
 };
 /**
  * Wait until the ProjectVersion is running.
- *  @deprecated In favor of waitUntilProjectVersionRunning. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeProjectVersionsCommand for polling.
+ *  @deprecated Use waitUntilProjectVersionRunning instead. waitForProjectVersionRunning does not throw error in non-success cases.
  */
 export const waitForProjectVersionRunning = async (
   params: WaiterConfiguration<RekognitionClient>,

--- a/clients/client-rekognition/waiters/waitForProjectVersionRunning.ts
+++ b/clients/client-rekognition/waiters/waitForProjectVersionRunning.ts
@@ -3,14 +3,16 @@ import {
   DescribeProjectVersionsCommand,
   DescribeProjectVersionsCommandInput,
 } from "../commands/DescribeProjectVersionsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: RekognitionClient,
   input: DescribeProjectVersionsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeProjectVersionsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ProjectVersionDescriptions);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "RUNNING";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,15 +39,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "FAILED") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until the ProjectVersion is running.
+ *  @deprecated in favor of waitUntilProjectVersionRunning. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeProjectVersionsCommand for polling.
  */
@@ -55,4 +60,17 @@ export const waitForProjectVersionRunning = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until the ProjectVersion is running.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeProjectVersionsCommand for polling.
+ */
+export const waitUntilProjectVersionRunning = async (
+  params: WaiterConfiguration<RekognitionClient>,
+  input: DescribeProjectVersionsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-rekognition/waiters/waitForProjectVersionRunning.ts
+++ b/clients/client-rekognition/waiters/waitForProjectVersionRunning.ts
@@ -50,9 +50,9 @@ const checkState = async (
 };
 /**
  * Wait until the ProjectVersion is running.
- *  @deprecated in favor of waitUntilProjectVersionRunning. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeProjectVersionsCommand for polling.
+ *  @deprecated In favor of waitUntilProjectVersionRunning. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeProjectVersionsCommand for polling.
  */
 export const waitForProjectVersionRunning = async (
   params: WaiterConfiguration<RekognitionClient>,
@@ -63,8 +63,8 @@ export const waitForProjectVersionRunning = async (
 };
 /**
  * Wait until the ProjectVersion is running.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeProjectVersionsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeProjectVersionsCommand for polling.
  */
 export const waitUntilProjectVersionRunning = async (
   params: WaiterConfiguration<RekognitionClient>,

--- a/clients/client-rekognition/waiters/waitForProjectVersionTrainingCompleted.ts
+++ b/clients/client-rekognition/waiters/waitForProjectVersionTrainingCompleted.ts
@@ -3,14 +3,16 @@ import {
   DescribeProjectVersionsCommand,
   DescribeProjectVersionsCommandInput,
 } from "../commands/DescribeProjectVersionsCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: RekognitionClient,
   input: DescribeProjectVersionsCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeProjectVersionsCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let flat_1: any[] = [].concat(...result.ProjectVersionDescriptions);
@@ -24,7 +26,7 @@ const checkState = async (
         allStringEq_5 = allStringEq_5 && element_4 == "TRAINING_COMPLETED";
       }
       if (allStringEq_5) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -37,15 +39,18 @@ const checkState = async (
       };
       for (let anyStringEq_4 of returnComparator()) {
         if (anyStringEq_4 == "TRAINING_FAILED") {
-          return { state: WaiterState.FAILURE };
+          return { state: WaiterState.FAILURE, reason };
         }
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until the ProjectVersion training completes.
+ *  @deprecated in favor of waitUntilProjectVersionTrainingCompleted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeProjectVersionsCommand for polling.
  */
@@ -55,4 +60,17 @@ export const waitForProjectVersionTrainingCompleted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 120, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until the ProjectVersion training completes.
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeProjectVersionsCommand for polling.
+ */
+export const waitUntilProjectVersionTrainingCompleted = async (
+  params: WaiterConfiguration<RekognitionClient>,
+  input: DescribeProjectVersionsCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 120, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-rekognition/waiters/waitForProjectVersionTrainingCompleted.ts
+++ b/clients/client-rekognition/waiters/waitForProjectVersionTrainingCompleted.ts
@@ -50,9 +50,9 @@ const checkState = async (
 };
 /**
  * Wait until the ProjectVersion training completes.
- *  @deprecated in favor of waitUntilProjectVersionTrainingCompleted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeProjectVersionsCommand for polling.
+ *  @deprecated In favor of waitUntilProjectVersionTrainingCompleted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeProjectVersionsCommand for polling.
  */
 export const waitForProjectVersionTrainingCompleted = async (
   params: WaiterConfiguration<RekognitionClient>,
@@ -63,8 +63,8 @@ export const waitForProjectVersionTrainingCompleted = async (
 };
 /**
  * Wait until the ProjectVersion training completes.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeProjectVersionsCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeProjectVersionsCommand for polling.
  */
 export const waitUntilProjectVersionTrainingCompleted = async (
   params: WaiterConfiguration<RekognitionClient>,

--- a/clients/client-rekognition/waiters/waitForProjectVersionTrainingCompleted.ts
+++ b/clients/client-rekognition/waiters/waitForProjectVersionTrainingCompleted.ts
@@ -50,9 +50,7 @@ const checkState = async (
 };
 /**
  * Wait until the ProjectVersion training completes.
- *  @deprecated In favor of waitUntilProjectVersionTrainingCompleted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeProjectVersionsCommand for polling.
+ *  @deprecated Use waitUntilProjectVersionTrainingCompleted instead. waitForProjectVersionTrainingCompleted does not throw error in non-success cases.
  */
 export const waitForProjectVersionTrainingCompleted = async (
   params: WaiterConfiguration<RekognitionClient>,

--- a/clients/client-route-53/waiters/waitForResourceRecordSetsChanged.ts
+++ b/clients/client-route-53/waiters/waitForResourceRecordSetsChanged.ts
@@ -1,23 +1,28 @@
 import { Route53Client } from "../Route53Client";
 import { GetChangeCommand, GetChangeCommandInput } from "../commands/GetChangeCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: Route53Client, input: GetChangeCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetChangeCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.ChangeInfo.Status;
       };
       if (returnComparator() === "INSYNC") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilResourceRecordSetsChanged. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetChangeCommand for polling.
  */
@@ -27,4 +32,17 @@ export const waitForResourceRecordSetsChanged = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetChangeCommand for polling.
+ */
+export const waitUntilResourceRecordSetsChanged = async (
+  params: WaiterConfiguration<Route53Client>,
+  input: GetChangeCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-route-53/waiters/waitForResourceRecordSetsChanged.ts
+++ b/clients/client-route-53/waiters/waitForResourceRecordSetsChanged.ts
@@ -22,9 +22,7 @@ const checkState = async (client: Route53Client, input: GetChangeCommandInput): 
 };
 /**
  *
- *  @deprecated In favor of waitUntilResourceRecordSetsChanged. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetChangeCommand for polling.
+ *  @deprecated Use waitUntilResourceRecordSetsChanged instead. waitForResourceRecordSetsChanged does not throw error in non-success cases.
  */
 export const waitForResourceRecordSetsChanged = async (
   params: WaiterConfiguration<Route53Client>,

--- a/clients/client-route-53/waiters/waitForResourceRecordSetsChanged.ts
+++ b/clients/client-route-53/waiters/waitForResourceRecordSetsChanged.ts
@@ -22,9 +22,9 @@ const checkState = async (client: Route53Client, input: GetChangeCommandInput): 
 };
 /**
  *
- *  @deprecated in favor of waitUntilResourceRecordSetsChanged. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetChangeCommand for polling.
+ *  @deprecated In favor of waitUntilResourceRecordSetsChanged. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetChangeCommand for polling.
  */
 export const waitForResourceRecordSetsChanged = async (
   params: WaiterConfiguration<Route53Client>,
@@ -35,8 +35,8 @@ export const waitForResourceRecordSetsChanged = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetChangeCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetChangeCommand for polling.
  */
 export const waitUntilResourceRecordSetsChanged = async (
   params: WaiterConfiguration<Route53Client>,

--- a/clients/client-s3/waiters/waitForBucketExists.ts
+++ b/clients/client-s3/waiters/waitForBucketExists.ts
@@ -18,9 +18,7 @@ const checkState = async (client: S3Client, input: HeadBucketCommandInput): Prom
 };
 /**
  *
- *  @deprecated In favor of waitUntilBucketExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to HeadBucketCommand for polling.
+ *  @deprecated Use waitUntilBucketExists instead. waitForBucketExists does not throw error in non-success cases.
  */
 export const waitForBucketExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForBucketExists.ts
+++ b/clients/client-s3/waiters/waitForBucketExists.ts
@@ -1,20 +1,24 @@
 import { S3Client } from "../S3Client";
 import { HeadBucketCommand, HeadBucketCommandInput } from "../commands/HeadBucketCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: S3Client, input: HeadBucketCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new HeadBucketCommand(input));
-    return { state: WaiterState.SUCCESS };
+    reason = result;
+    return { state: WaiterState.SUCCESS, reason };
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "NotFound") {
-      return { state: WaiterState.RETRY };
+      return { state: WaiterState.RETRY, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilBucketExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to HeadBucketCommand for polling.
  */
@@ -24,4 +28,17 @@ export const waitForBucketExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to HeadBucketCommand for polling.
+ */
+export const waitUntilBucketExists = async (
+  params: WaiterConfiguration<S3Client>,
+  input: HeadBucketCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-s3/waiters/waitForBucketExists.ts
+++ b/clients/client-s3/waiters/waitForBucketExists.ts
@@ -18,9 +18,9 @@ const checkState = async (client: S3Client, input: HeadBucketCommandInput): Prom
 };
 /**
  *
- *  @deprecated in favor of waitUntilBucketExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadBucketCommand for polling.
+ *  @deprecated In favor of waitUntilBucketExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadBucketCommand for polling.
  */
 export const waitForBucketExists = async (
   params: WaiterConfiguration<S3Client>,
@@ -31,8 +31,8 @@ export const waitForBucketExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadBucketCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadBucketCommand for polling.
  */
 export const waitUntilBucketExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForBucketNotExists.ts
+++ b/clients/client-s3/waiters/waitForBucketNotExists.ts
@@ -17,9 +17,7 @@ const checkState = async (client: S3Client, input: HeadBucketCommandInput): Prom
 };
 /**
  *
- *  @deprecated In favor of waitUntilBucketNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to HeadBucketCommand for polling.
+ *  @deprecated Use waitUntilBucketNotExists instead. waitForBucketNotExists does not throw error in non-success cases.
  */
 export const waitForBucketNotExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForBucketNotExists.ts
+++ b/clients/client-s3/waiters/waitForBucketNotExists.ts
@@ -17,9 +17,9 @@ const checkState = async (client: S3Client, input: HeadBucketCommandInput): Prom
 };
 /**
  *
- *  @deprecated in favor of waitUntilBucketNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadBucketCommand for polling.
+ *  @deprecated In favor of waitUntilBucketNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadBucketCommand for polling.
  */
 export const waitForBucketNotExists = async (
   params: WaiterConfiguration<S3Client>,
@@ -30,8 +30,8 @@ export const waitForBucketNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadBucketCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadBucketCommand for polling.
  */
 export const waitUntilBucketNotExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForBucketNotExists.ts
+++ b/clients/client-s3/waiters/waitForBucketNotExists.ts
@@ -1,19 +1,23 @@
 import { S3Client } from "../S3Client";
 import { HeadBucketCommand, HeadBucketCommandInput } from "../commands/HeadBucketCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: S3Client, input: HeadBucketCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new HeadBucketCommand(input));
+    reason = result;
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "NotFound") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilBucketNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to HeadBucketCommand for polling.
  */
@@ -23,4 +27,17 @@ export const waitForBucketNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to HeadBucketCommand for polling.
+ */
+export const waitUntilBucketNotExists = async (
+  params: WaiterConfiguration<S3Client>,
+  input: HeadBucketCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-s3/waiters/waitForObjectExists.ts
+++ b/clients/client-s3/waiters/waitForObjectExists.ts
@@ -18,9 +18,7 @@ const checkState = async (client: S3Client, input: HeadObjectCommandInput): Prom
 };
 /**
  *
- *  @deprecated In favor of waitUntilObjectExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to HeadObjectCommand for polling.
+ *  @deprecated Use waitUntilObjectExists instead. waitForObjectExists does not throw error in non-success cases.
  */
 export const waitForObjectExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForObjectExists.ts
+++ b/clients/client-s3/waiters/waitForObjectExists.ts
@@ -18,9 +18,9 @@ const checkState = async (client: S3Client, input: HeadObjectCommandInput): Prom
 };
 /**
  *
- *  @deprecated in favor of waitUntilObjectExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadObjectCommand for polling.
+ *  @deprecated In favor of waitUntilObjectExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadObjectCommand for polling.
  */
 export const waitForObjectExists = async (
   params: WaiterConfiguration<S3Client>,
@@ -31,8 +31,8 @@ export const waitForObjectExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadObjectCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadObjectCommand for polling.
  */
 export const waitUntilObjectExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForObjectNotExists.ts
+++ b/clients/client-s3/waiters/waitForObjectNotExists.ts
@@ -17,9 +17,9 @@ const checkState = async (client: S3Client, input: HeadObjectCommandInput): Prom
 };
 /**
  *
- *  @deprecated in favor of waitUntilObjectNotExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadObjectCommand for polling.
+ *  @deprecated In favor of waitUntilObjectNotExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadObjectCommand for polling.
  */
 export const waitForObjectNotExists = async (
   params: WaiterConfiguration<S3Client>,
@@ -30,8 +30,8 @@ export const waitForObjectNotExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to HeadObjectCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to HeadObjectCommand for polling.
  */
 export const waitUntilObjectNotExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForObjectNotExists.ts
+++ b/clients/client-s3/waiters/waitForObjectNotExists.ts
@@ -17,9 +17,7 @@ const checkState = async (client: S3Client, input: HeadObjectCommandInput): Prom
 };
 /**
  *
- *  @deprecated In favor of waitUntilObjectNotExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to HeadObjectCommand for polling.
+ *  @deprecated Use waitUntilObjectNotExists instead. waitForObjectNotExists does not throw error in non-success cases.
  */
 export const waitForObjectNotExists = async (
   params: WaiterConfiguration<S3Client>,

--- a/clients/client-s3/waiters/waitForObjectNotExists.ts
+++ b/clients/client-s3/waiters/waitForObjectNotExists.ts
@@ -1,19 +1,23 @@
 import { S3Client } from "../S3Client";
 import { HeadObjectCommand, HeadObjectCommandInput } from "../commands/HeadObjectCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: S3Client, input: HeadObjectCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new HeadObjectCommand(input));
+    reason = result;
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "NotFound") {
-      return { state: WaiterState.SUCCESS };
+      return { state: WaiterState.SUCCESS, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilObjectNotExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to HeadObjectCommand for polling.
  */
@@ -23,4 +27,17 @@ export const waitForObjectNotExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to HeadObjectCommand for polling.
+ */
+export const waitUntilObjectNotExists = async (
+  params: WaiterConfiguration<S3Client>,
+  input: HeadObjectCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-sagemaker/waiters/waitForNotebookInstanceInService.ts
+++ b/clients/client-sagemaker/waiters/waitForNotebookInstanceInService.ts
@@ -3,20 +3,22 @@ import {
   DescribeNotebookInstanceCommand,
   DescribeNotebookInstanceCommandInput,
 } from "../commands/DescribeNotebookInstanceCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: SageMakerClient,
   input: DescribeNotebookInstanceCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeNotebookInstanceCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.NotebookInstanceStatus;
       };
       if (returnComparator() === "InService") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -24,14 +26,17 @@ const checkState = async (
         return result.NotebookInstanceStatus;
       };
       if (returnComparator() === "Failed") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilNotebookInstanceInService. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeNotebookInstanceCommand for polling.
  */
@@ -41,4 +46,17 @@ export const waitForNotebookInstanceInService = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeNotebookInstanceCommand for polling.
+ */
+export const waitUntilNotebookInstanceInService = async (
+  params: WaiterConfiguration<SageMakerClient>,
+  input: DescribeNotebookInstanceCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-sagemaker/waiters/waitForNotebookInstanceInService.ts
+++ b/clients/client-sagemaker/waiters/waitForNotebookInstanceInService.ts
@@ -36,9 +36,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilNotebookInstanceInService. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeNotebookInstanceCommand for polling.
+ *  @deprecated Use waitUntilNotebookInstanceInService instead. waitForNotebookInstanceInService does not throw error in non-success cases.
  */
 export const waitForNotebookInstanceInService = async (
   params: WaiterConfiguration<SageMakerClient>,

--- a/clients/client-sagemaker/waiters/waitForNotebookInstanceInService.ts
+++ b/clients/client-sagemaker/waiters/waitForNotebookInstanceInService.ts
@@ -36,9 +36,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilNotebookInstanceInService. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNotebookInstanceCommand for polling.
+ *  @deprecated In favor of waitUntilNotebookInstanceInService. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNotebookInstanceCommand for polling.
  */
 export const waitForNotebookInstanceInService = async (
   params: WaiterConfiguration<SageMakerClient>,
@@ -49,8 +49,8 @@ export const waitForNotebookInstanceInService = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNotebookInstanceCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNotebookInstanceCommand for polling.
  */
 export const waitUntilNotebookInstanceInService = async (
   params: WaiterConfiguration<SageMakerClient>,

--- a/clients/client-sagemaker/waiters/waitForNotebookInstanceStopped.ts
+++ b/clients/client-sagemaker/waiters/waitForNotebookInstanceStopped.ts
@@ -36,9 +36,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilNotebookInstanceStopped. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeNotebookInstanceCommand for polling.
+ *  @deprecated Use waitUntilNotebookInstanceStopped instead. waitForNotebookInstanceStopped does not throw error in non-success cases.
  */
 export const waitForNotebookInstanceStopped = async (
   params: WaiterConfiguration<SageMakerClient>,

--- a/clients/client-sagemaker/waiters/waitForNotebookInstanceStopped.ts
+++ b/clients/client-sagemaker/waiters/waitForNotebookInstanceStopped.ts
@@ -36,9 +36,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilNotebookInstanceStopped. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNotebookInstanceCommand for polling.
+ *  @deprecated In favor of waitUntilNotebookInstanceStopped. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNotebookInstanceCommand for polling.
  */
 export const waitForNotebookInstanceStopped = async (
   params: WaiterConfiguration<SageMakerClient>,
@@ -49,8 +49,8 @@ export const waitForNotebookInstanceStopped = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeNotebookInstanceCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeNotebookInstanceCommand for polling.
  */
 export const waitUntilNotebookInstanceStopped = async (
   params: WaiterConfiguration<SageMakerClient>,

--- a/clients/client-sagemaker/waiters/waitForNotebookInstanceStopped.ts
+++ b/clients/client-sagemaker/waiters/waitForNotebookInstanceStopped.ts
@@ -3,20 +3,22 @@ import {
   DescribeNotebookInstanceCommand,
   DescribeNotebookInstanceCommandInput,
 } from "../commands/DescribeNotebookInstanceCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: SageMakerClient,
   input: DescribeNotebookInstanceCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeNotebookInstanceCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.NotebookInstanceStatus;
       };
       if (returnComparator() === "Stopped") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -24,14 +26,17 @@ const checkState = async (
         return result.NotebookInstanceStatus;
       };
       if (returnComparator() === "Failed") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilNotebookInstanceStopped. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeNotebookInstanceCommand for polling.
  */
@@ -41,4 +46,17 @@ export const waitForNotebookInstanceStopped = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 30, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeNotebookInstanceCommand for polling.
+ */
+export const waitUntilNotebookInstanceStopped = async (
+  params: WaiterConfiguration<SageMakerClient>,
+  input: DescribeNotebookInstanceCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-schemas/waiters/waitForCodeBindingExists.ts
+++ b/clients/client-schemas/waiters/waitForCodeBindingExists.ts
@@ -41,9 +41,7 @@ const checkState = async (client: SchemasClient, input: DescribeCodeBindingComma
 };
 /**
  * Wait until code binding is generated
- *  @deprecated In favor of waitUntilCodeBindingExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeCodeBindingCommand for polling.
+ *  @deprecated Use waitUntilCodeBindingExists instead. waitForCodeBindingExists does not throw error in non-success cases.
  */
 export const waitForCodeBindingExists = async (
   params: WaiterConfiguration<SchemasClient>,

--- a/clients/client-schemas/waiters/waitForCodeBindingExists.ts
+++ b/clients/client-schemas/waiters/waitForCodeBindingExists.ts
@@ -1,16 +1,18 @@
 import { SchemasClient } from "../SchemasClient";
 import { DescribeCodeBindingCommand, DescribeCodeBindingCommandInput } from "../commands/DescribeCodeBindingCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: SchemasClient, input: DescribeCodeBindingCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeCodeBindingCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Status;
       };
       if (returnComparator() === "CREATE_COMPLETE") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: SchemasClient, input: DescribeCodeBindingComma
         return result.Status;
       };
       if (returnComparator() === "CREATE_IN_PROGRESS") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -26,18 +28,20 @@ const checkState = async (client: SchemasClient, input: DescribeCodeBindingComma
         return result.Status;
       };
       if (returnComparator() === "CREATE_FAILED") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "NotFoundException") {
-      return { state: WaiterState.FAILURE };
+      return { state: WaiterState.FAILURE, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  * Wait until code binding is generated
+ *  @deprecated in favor of waitUntilCodeBindingExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeCodeBindingCommand for polling.
  */
@@ -47,4 +51,17 @@ export const waitForCodeBindingExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 2, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ * Wait until code binding is generated
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeCodeBindingCommand for polling.
+ */
+export const waitUntilCodeBindingExists = async (
+  params: WaiterConfiguration<SchemasClient>,
+  input: DescribeCodeBindingCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 2, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-schemas/waiters/waitForCodeBindingExists.ts
+++ b/clients/client-schemas/waiters/waitForCodeBindingExists.ts
@@ -41,9 +41,9 @@ const checkState = async (client: SchemasClient, input: DescribeCodeBindingComma
 };
 /**
  * Wait until code binding is generated
- *  @deprecated in favor of waitUntilCodeBindingExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCodeBindingCommand for polling.
+ *  @deprecated In favor of waitUntilCodeBindingExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCodeBindingCommand for polling.
  */
 export const waitForCodeBindingExists = async (
   params: WaiterConfiguration<SchemasClient>,
@@ -54,8 +54,8 @@ export const waitForCodeBindingExists = async (
 };
 /**
  * Wait until code binding is generated
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeCodeBindingCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeCodeBindingCommand for polling.
  */
 export const waitUntilCodeBindingExists = async (
   params: WaiterConfiguration<SchemasClient>,

--- a/clients/client-ses/waiters/waitForIdentityExists.ts
+++ b/clients/client-ses/waiters/waitForIdentityExists.ts
@@ -35,9 +35,9 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated in favor of waitUntilIdentityExists. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetIdentityVerificationAttributesCommand for polling.
+ *  @deprecated In favor of waitUntilIdentityExists. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetIdentityVerificationAttributesCommand for polling.
  */
 export const waitForIdentityExists = async (
   params: WaiterConfiguration<SESClient>,
@@ -48,8 +48,8 @@ export const waitForIdentityExists = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetIdentityVerificationAttributesCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetIdentityVerificationAttributesCommand for polling.
  */
 export const waitUntilIdentityExists = async (
   params: WaiterConfiguration<SESClient>,

--- a/clients/client-ses/waiters/waitForIdentityExists.ts
+++ b/clients/client-ses/waiters/waitForIdentityExists.ts
@@ -3,14 +3,16 @@ import {
   GetIdentityVerificationAttributesCommand,
   GetIdentityVerificationAttributesCommandInput,
 } from "../commands/GetIdentityVerificationAttributesCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (
   client: SESClient,
   input: GetIdentityVerificationAttributesCommandInput
 ): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetIdentityVerificationAttributesCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         let objectProjection_2 = Object.values(result.VerificationAttributes).map((element_1: any) => {
@@ -23,14 +25,17 @@ const checkState = async (
         allStringEq_4 = allStringEq_4 && element_3 == "Success";
       }
       if (allStringEq_4) {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilIdentityExists. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetIdentityVerificationAttributesCommand for polling.
  */
@@ -40,4 +45,17 @@ export const waitForIdentityExists = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 3, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetIdentityVerificationAttributesCommand for polling.
+ */
+export const waitUntilIdentityExists = async (
+  params: WaiterConfiguration<SESClient>,
+  input: GetIdentityVerificationAttributesCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 3, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ses/waiters/waitForIdentityExists.ts
+++ b/clients/client-ses/waiters/waitForIdentityExists.ts
@@ -35,9 +35,7 @@ const checkState = async (
 };
 /**
  *
- *  @deprecated In favor of waitUntilIdentityExists. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetIdentityVerificationAttributesCommand for polling.
+ *  @deprecated Use waitUntilIdentityExists instead. waitForIdentityExists does not throw error in non-success cases.
  */
 export const waitForIdentityExists = async (
   params: WaiterConfiguration<SESClient>,

--- a/clients/client-signer/waiters/waitForSuccessfulSigningJob.ts
+++ b/clients/client-signer/waiters/waitForSuccessfulSigningJob.ts
@@ -33,9 +33,9 @@ const checkState = async (client: SignerClient, input: DescribeSigningJobCommand
 };
 /**
  *
- *  @deprecated in favor of waitUntilSuccessfulSigningJob. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeSigningJobCommand for polling.
+ *  @deprecated In favor of waitUntilSuccessfulSigningJob. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeSigningJobCommand for polling.
  */
 export const waitForSuccessfulSigningJob = async (
   params: WaiterConfiguration<SignerClient>,
@@ -46,8 +46,8 @@ export const waitForSuccessfulSigningJob = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to DescribeSigningJobCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeSigningJobCommand for polling.
  */
 export const waitUntilSuccessfulSigningJob = async (
   params: WaiterConfiguration<SignerClient>,

--- a/clients/client-signer/waiters/waitForSuccessfulSigningJob.ts
+++ b/clients/client-signer/waiters/waitForSuccessfulSigningJob.ts
@@ -33,9 +33,7 @@ const checkState = async (client: SignerClient, input: DescribeSigningJobCommand
 };
 /**
  *
- *  @deprecated In favor of waitUntilSuccessfulSigningJob. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to DescribeSigningJobCommand for polling.
+ *  @deprecated Use waitUntilSuccessfulSigningJob instead. waitForSuccessfulSigningJob does not throw error in non-success cases.
  */
 export const waitForSuccessfulSigningJob = async (
   params: WaiterConfiguration<SignerClient>,

--- a/clients/client-signer/waiters/waitForSuccessfulSigningJob.ts
+++ b/clients/client-signer/waiters/waitForSuccessfulSigningJob.ts
@@ -1,16 +1,18 @@
 import { SignerClient } from "../SignerClient";
 import { DescribeSigningJobCommand, DescribeSigningJobCommandInput } from "../commands/DescribeSigningJobCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: SignerClient, input: DescribeSigningJobCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new DescribeSigningJobCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.status;
       };
       if (returnComparator() === "Succeeded") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -18,18 +20,20 @@ const checkState = async (client: SignerClient, input: DescribeSigningJobCommand
         return result.status;
       };
       if (returnComparator() === "Failed") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
   } catch (exception) {
+    reason = exception;
     if (exception.name && exception.name == "ResourceNotFoundException") {
-      return { state: WaiterState.FAILURE };
+      return { state: WaiterState.FAILURE, reason };
     }
   }
-  return { state: WaiterState.RETRY };
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilSuccessfulSigningJob. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to DescribeSigningJobCommand for polling.
  */
@@ -39,4 +43,17 @@ export const waitForSuccessfulSigningJob = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 20, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to DescribeSigningJobCommand for polling.
+ */
+export const waitUntilSuccessfulSigningJob = async (
+  params: WaiterConfiguration<SignerClient>,
+  input: DescribeSigningJobCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 20, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/clients/client-ssm/waiters/waitForCommandExecuted.ts
+++ b/clients/client-ssm/waiters/waitForCommandExecuted.ts
@@ -78,9 +78,9 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
 };
 /**
  *
- *  @deprecated in favor of waitUntilCommandExecuted. This does not throw on failure.
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetCommandInvocationCommand for polling.
+ *  @deprecated In favor of waitUntilCommandExecuted. This does not throw on failure.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetCommandInvocationCommand for polling.
  */
 export const waitForCommandExecuted = async (
   params: WaiterConfiguration<SSMClient>,
@@ -91,8 +91,8 @@ export const waitForCommandExecuted = async (
 };
 /**
  *
- *  @param params : Waiter configuration options.
- *  @param input : the input to GetCommandInvocationCommand for polling.
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to GetCommandInvocationCommand for polling.
  */
 export const waitUntilCommandExecuted = async (
   params: WaiterConfiguration<SSMClient>,

--- a/clients/client-ssm/waiters/waitForCommandExecuted.ts
+++ b/clients/client-ssm/waiters/waitForCommandExecuted.ts
@@ -78,9 +78,7 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
 };
 /**
  *
- *  @deprecated In favor of waitUntilCommandExecuted. This does not throw on failure.
- *  @param params - Waiter configuration options.
- *  @param input - The input to GetCommandInvocationCommand for polling.
+ *  @deprecated Use waitUntilCommandExecuted instead. waitForCommandExecuted does not throw error in non-success cases.
  */
 export const waitForCommandExecuted = async (
   params: WaiterConfiguration<SSMClient>,

--- a/clients/client-ssm/waiters/waitForCommandExecuted.ts
+++ b/clients/client-ssm/waiters/waitForCommandExecuted.ts
@@ -1,16 +1,18 @@
 import { SSMClient } from "../SSMClient";
 import { GetCommandInvocationCommand, GetCommandInvocationCommandInput } from "../commands/GetCommandInvocationCommand";
-import { WaiterConfiguration, WaiterResult, WaiterState, createWaiter } from "@aws-sdk/util-waiter";
+import { WaiterConfiguration, WaiterResult, WaiterState, checkExceptions, createWaiter } from "@aws-sdk/util-waiter";
 
 const checkState = async (client: SSMClient, input: GetCommandInvocationCommandInput): Promise<WaiterResult> => {
+  let reason;
   try {
     let result: any = await client.send(new GetCommandInvocationCommand(input));
+    reason = result;
     try {
       let returnComparator = () => {
         return result.Status;
       };
       if (returnComparator() === "Pending") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -18,7 +20,7 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
         return result.Status;
       };
       if (returnComparator() === "InProgress") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -26,7 +28,7 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
         return result.Status;
       };
       if (returnComparator() === "Delayed") {
-        return { state: WaiterState.RETRY };
+        return { state: WaiterState.RETRY, reason };
       }
     } catch (e) {}
     try {
@@ -34,7 +36,7 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
         return result.Status;
       };
       if (returnComparator() === "Success") {
-        return { state: WaiterState.SUCCESS };
+        return { state: WaiterState.SUCCESS, reason };
       }
     } catch (e) {}
     try {
@@ -42,7 +44,7 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
         return result.Status;
       };
       if (returnComparator() === "Cancelled") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -50,7 +52,7 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
         return result.Status;
       };
       if (returnComparator() === "TimedOut") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -58,7 +60,7 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
         return result.Status;
       };
       if (returnComparator() === "Failed") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
     try {
@@ -66,14 +68,17 @@ const checkState = async (client: SSMClient, input: GetCommandInvocationCommandI
         return result.Status;
       };
       if (returnComparator() === "Cancelling") {
-        return { state: WaiterState.FAILURE };
+        return { state: WaiterState.FAILURE, reason };
       }
     } catch (e) {}
-  } catch (exception) {}
-  return { state: WaiterState.RETRY };
+  } catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
 };
 /**
  *
+ *  @deprecated in favor of waitUntilCommandExecuted. This does not throw on failure.
  *  @param params : Waiter configuration options.
  *  @param input : the input to GetCommandInvocationCommand for polling.
  */
@@ -83,4 +88,17 @@ export const waitForCommandExecuted = async (
 ): Promise<WaiterResult> => {
   const serviceDefaults = { minDelay: 5, maxDelay: 120 };
   return createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+};
+/**
+ *
+ *  @param params : Waiter configuration options.
+ *  @param input : the input to GetCommandInvocationCommand for polling.
+ */
+export const waitUntilCommandExecuted = async (
+  params: WaiterConfiguration<SSMClient>,
+  input: GetCommandInvocationCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 5, maxDelay: 120 };
+  const result = await createWaiter({ ...serviceDefaults, ...params }, input, checkState);
+  return checkExceptions(result);
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,3 +13,4 @@ export * from "./response";
 export * from "./signature";
 export * from "./transfer";
 export * from "./util";
+export * from "./waiter";

--- a/packages/types/src/waiter.ts
+++ b/packages/types/src/waiter.ts
@@ -1,0 +1,38 @@
+import { AbortController } from "./abort";
+
+export interface WaiterConfiguration<Client> {
+  /**
+   * Required service client
+   */
+  client: Client;
+
+  /**
+   * The amount of time in seconds a user is willing to wait for a waiter to complete.
+   */
+  maxWaitTime: number;
+
+  /**
+   * @deprecated Use abortSignal
+   * Abort controller. Used for ending the waiter early.
+   */
+  abortController?: AbortController;
+
+  /**
+   * Abort Signal. Used for ending the waiter early.
+   */
+  abortSignal?: AbortController["signal"];
+
+  /**
+   * The minimum amount of time to delay between retries in seconds. This is the
+   * floor of the exponential backoff. This value defaults to service default
+   * if not specified. This value MUST be less than or equal to maxDelay and greater than 0.
+   */
+  minDelay?: number;
+
+  /**
+   * The maximum amount of time to delay between retries in seconds. This is the
+   * ceiling of the exponential backoff. This value defaults to service default
+   * if not specified. If specified, this value MUST be greater than or equal to 1.
+   */
+  maxDelay?: number;
+}

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -34,5 +34,10 @@ export const createWaiter = async <Client, Input>(
   if (options.abortController) {
     exitConditions.push(abortTimeout(options.abortController.signal));
   }
+
+  if (options.abortSignal) {
+    exitConditions.push(abortTimeout(options.abortSignal));
+  }
+
   return Promise.race(exitConditions);
 };

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -21,7 +21,7 @@ const randomInRange = (min: number, max: number) => min + Math.random() * (max -
  * @param stateChecker function that checks the acceptor states on each poll.
  */
 export const runPolling = async <Client, Input>(
-  { minDelay, maxDelay, maxWaitTime, abortController, client }: WaiterOptions<Client>,
+  { minDelay, maxDelay, maxWaitTime, abortController, client, abortSignal }: WaiterOptions<Client>,
   input: Input,
   acceptorChecks: (client: Client, input: Input) => Promise<WaiterResult>
 ): Promise<WaiterResult> => {
@@ -36,7 +36,7 @@ export const runPolling = async <Client, Input>(
   // Pre-compute this number to avoid Number type overflow.
   const attemptCeiling = Math.log(maxDelay / minDelay) / Math.log(2) + 1;
   while (true) {
-    if (abortController?.signal?.aborted) {
+    if (abortController?.signal?.aborted || abortSignal?.aborted) {
       return { state: WaiterState.ABORTED };
     }
     const delay = exponentialBackoffWithJitter(minDelay, maxDelay, attemptCeiling, currentAttempt);

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -1,41 +1,6 @@
-import { AbortController } from "@aws-sdk/types";
+import { WaiterConfiguration as WaiterConfiguration__ } from "@aws-sdk/types";
 
-export interface WaiterConfiguration<Client> {
-  /**
-   * Required service client
-   */
-  client: Client;
-
-  /**
-   * The amount of time in seconds a user is willing to wait for a waiter to complete.
-   */
-  maxWaitTime: number;
-
-  /**
-   * @deprecated Use abortSignal
-   * Abort controller. Used for ending the waiter early.
-   */
-  abortController?: AbortController;
-
-  /**
-   * Abort Signal. Used for ending the waiter early.
-   */
-  abortSignal?: AbortController["signal"];
-
-  /**
-   * The minimum amount of time to delay between retries in seconds. This is the
-   * floor of the exponential backoff. This value defaults to service default
-   * if not specified. This value MUST be less than or equal to maxDelay and greater than 0.
-   */
-  minDelay?: number;
-
-  /**
-   * The maximum amount of time to delay between retries in seconds. This is the
-   * ceiling of the exponential backoff. This value defaults to service default
-   * if not specified. If specified, this value MUST be greater than or equal to 1.
-   */
-  maxDelay?: number;
-}
+export interface WaiterConfiguration<T> extends WaiterConfiguration__<T> {}
 
 /**
  * @private

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -39,13 +39,23 @@ export type WaiterResult = {
  */
 export const checkExceptions = (result: WaiterResult): WaiterResult => {
   if (result.state === WaiterState.ABORTED) {
-    throw new Error(
+    const abortError = new Error(
       `${JSON.stringify({
         ...result,
-        name: "AbortError",
         reason: "Request was aborted",
       })}`
     );
+    abortError.name = "AbortError";
+    throw abortError;
+  } else if (result.state === WaiterState.TIMEOUT) {
+    const timeoutError = new Error(
+      `${JSON.stringify({
+        ...result,
+        reason: "Waiter has timed out",
+      })}`
+    );
+    timeoutError.name = "TimeoutError";
+    throw timeoutError;
   } else if (result.state !== WaiterState.SUCCESS) {
     throw new Error(`${JSON.stringify({ result })}`);
   }

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -12,9 +12,15 @@ export interface WaiterConfiguration<Client> {
   maxWaitTime: number;
 
   /**
+   * @deprecated Use abortSignal
    * Abort controller. Used for ending the waiter early.
    */
   abortController?: AbortController;
+
+  /**
+   * Abort Signal. Used for ending the waiter early.
+   */
+  abortSignal?: AbortController["signal"];
 
   /**
    * The minimum amount of time to delay between retries in seconds. This is the
@@ -55,4 +61,28 @@ export enum WaiterState {
 
 export type WaiterResult = {
   state: WaiterState;
+
+  /**
+   * (optional) Indicates a reason for why a waiter has reached its state.
+   */
+  reason?: any;
+};
+
+/**
+ * Handles and throws exceptions resulting from the waiterResult
+ * @param result WaiterResult
+ */
+export const checkExceptions = (result: WaiterResult): WaiterResult => {
+  if (result.state === WaiterState.ABORTED) {
+    throw new Error(
+      `${JSON.stringify({
+        ...result,
+        name: "AbortError",
+        reason: "Request was aborted",
+      })}`
+    );
+  } else if (result.state !== WaiterState.SUCCESS) {
+    throw new Error(`${JSON.stringify({ result })}`);
+  }
+  return result;
 };


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/1917
Issue number, if available, prefixed with "#"

### Description
1. Adds another method: `WaitUntilBlahBlah` that throws when a waiter enters a non-success state
2. Adds a deprecation flag to `WaitForBlahBlah` since it doesn't throw.
3. Adds an optional reason type to the waiterResultObject. This gives clues as to why a waiter entered a particular state.

What does this implement/fix? Explain your changes.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
