### PR TITLE
test(config-resolver): add test for CustomEndpointsConfig

### DIFF
--- a/packages/config-resolver/src/CustomEndpointsConfig.spec.ts
+++ b/packages/config-resolver/src/CustomEndpointsConfig.spec.ts
@@ -1,0 +1,64 @@
+import { Endpoint } from "@aws-sdk/types";
+
+import { resolveCustomEndpointsConfig } from "./CustomEndpointsConfig";
+
+describe("CustomEndpointsConfig", () => {
+  const urlParser = jest.fn();
+
+  const input = { urlParser };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("endpoint", () => {
+    const mockEndpoint: Endpoint = { protocol: "protocol", hostname: "hostname", path: "path" };
+
+    it("returns output of urlParser if endpoint is of type string", async () => {
+      const endpoint = "endpoint";
+      urlParser.mockReturnValueOnce(mockEndpoint);
+      const { endpoint: endpointProvider, isCustomEndpoint } = resolveCustomEndpointsConfig({ ...input, endpoint });
+      expect(isCustomEndpoint).toBe(true);
+      const endpointOutput = await endpointProvider();
+      expect(endpointOutput).toStrictEqual(mockEndpoint);
+      expect(urlParser).toHaveBeenCalledTimes(1);
+      expect(urlParser).toHaveBeenCalledWith(endpoint);
+    });
+
+    it("returns promisified endpoint if it's of type object", async () => {
+      const endpoint = mockEndpoint;
+      const { endpoint: endpointProvider, isCustomEndpoint } = resolveCustomEndpointsConfig({ ...input, endpoint });
+      expect(isCustomEndpoint).toBe(true);
+      const endpointOutput = await endpointProvider();
+      expect(endpointOutput).toStrictEqual(endpoint);
+      expect(urlParser).not.toHaveBeenCalled();
+    });
+
+    it("returns endpoint if it's already Provider<Endpoint>", async () => {
+      const endpoint = () => Promise.resolve(mockEndpoint);
+      const { endpoint: endpointProvider, isCustomEndpoint } = resolveCustomEndpointsConfig({ ...input, endpoint });
+      expect(isCustomEndpoint).toBe(true);
+      const endpointOutput = await endpointProvider();
+      expect(endpointOutput).toStrictEqual(mockEndpoint);
+      expect(urlParser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("tls", () => {
+    const endpoint = "endpoint";
+
+    beforeEach(() => {
+      urlParser.mockReturnValueOnce({ protocol: "protocol", hostname: "hostname", path: "path" });
+    });
+
+    [true, false].forEach((tls) => {
+      it(`returns input.tls when it's ${tls}`, () => {
+        expect(resolveCustomEndpointsConfig({ ...input, endpoint, tls }).tls).toStrictEqual(tls);
+      });
+    });
+
+    it("returns true is input.tls is undefined", () => {
+      expect(resolveCustomEndpointsConfig({ ...input, endpoint }).tls).toStrictEqual(true);
+    });
+  });
+});

--- a/packages/config-resolver/src/CustomEndpointsConfig.ts
+++ b/packages/config-resolver/src/CustomEndpointsConfig.ts
@@ -1,4 +1,3 @@
-// TODO: Create a .spec.ts for this
 import { Endpoint, Provider, UrlParser } from "@aws-sdk/types";
 
 export interface CustomEndpointsInputConfig {
@@ -19,7 +18,7 @@ interface PreviouslyResolved {
 
 export interface CustomEndpointsResolvedConfig extends Required<CustomEndpointsInputConfig> {
   endpoint: Provider<Endpoint>;
-  isCustomEndpoint: true; // TODO: Can this be removed or some other logic depends on this?
+  isCustomEndpoint: true;
 }
 
 export const resolveCustomEndpointsConfig = <T>(
@@ -31,7 +30,6 @@ export const resolveCustomEndpointsConfig = <T>(
   isCustomEndpoint: true,
 });
 
-// TODO: can this be shared with EndpointsConfig.ts
 const normalizeEndpoint = (input: CustomEndpointsInputConfig & PreviouslyResolved): Provider<Endpoint> => {
   const { endpoint, urlParser } = input;
   if (typeof endpoint === "string") {


### PR DESCRIPTION
### Description
Adding tests for new CustomEndpointsConfig

### Testing
```
yarn build
yarn test
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
