### PR TITLE
fix(xml-builder): xml entity encoding for more characters

### DIFF
--- a/packages/xml-builder/src/XmlText.spec.ts
+++ b/packages/xml-builder/src/XmlText.spec.ts
@@ -3,6 +3,6 @@ import { XmlText } from "./XmlText";
 describe("XmlText", () => {
   it("escapes element text", () => {
     const text = new XmlText('this & that are < or > "most"');
-    expect(text.toString()).toBe('this &amp; that are &lt; or &gt; "most"');
+    expect(text.toString()).toBe("this &amp; that are &lt; or &gt; &quot;most&quot;");
   });
 });

--- a/packages/xml-builder/src/escape-element.spec.ts
+++ b/packages/xml-builder/src/escape-element.spec.ts
@@ -1,8 +1,8 @@
 import { escapeElement } from "./escape-element";
 
 describe("escape-element", () => {
-  it("escapes: & < >", () => {
-    const value = 'abc 123 &<>"%';
-    expect(escapeElement(value)).toBe('abc 123 &amp;&lt;&gt;"%');
+  it("escapes: & < > \" ' \\n \\r \\u0085 \\u2028", () => {
+    const value = "abc 123 &<>\"'%\n\r\u0085\u2028";
+    expect(escapeElement(value)).toBe("abc 123 &amp;&lt;&gt;&quot;&apos;%&#x0A;&#x0D;&#x85;&#x2028;");
   });
 });

--- a/packages/xml-builder/src/escape-element.ts
+++ b/packages/xml-builder/src/escape-element.ts
@@ -2,5 +2,14 @@
  * Escapes characters that can not be in an XML element.
  */
 export function escapeElement(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\r/g, "&#x0D;")
+    .replace(/\n/g, "&#x0A;")
+    .replace(/\u0085/g, "&#x85;")
+    .replace(/\u2028/, "&#x2028;");
 }


### PR DESCRIPTION
XML entity encoding for carriage return, line feed, next line, line separator characters,
quote and single quote

JS-2318

**Open question**
This can bring potential, but unlikely, breaking change because the `"` and `'` which previously unencoded, is now encoded to `&quot;` `&apos;` to match the behavior of other SDKs, like [Java v2](https://github.com/aws/aws-sdk-java-v2/pull/2399/files). But I've confirmed that the same content after deserialized is not changed.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
