### PR TITLE
fix(middleware-user-agent-header): swap user agent headers for non-browser environments

### DIFF
--- a/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
@@ -11,40 +11,40 @@ describe("userAgentMiddleware", () => {
     jest.clearAllMocks();
   });
 
-  it("should collect user agent pair from default, custom-supplied, and handler context", async () => {
-    const middleware = userAgentMiddleware({
-      defaultUserAgentProvider: async () => [
-        ["default_agent", "1.0.0"],
-        ["aws-sdk-js", "1.0.0"],
-      ],
-      customUserAgent: [["custom_ua/abc"]],
-      runtime: "node",
-    });
-    const handler = middleware(mockNextHandler, { userAgent: [["cfg/retry-mode", "standard"]] });
-    await handler({ input: {}, request: new HttpRequest({ headers: {} }) });
-    expect(mockNextHandler.mock.calls.length).toEqual(1);
-    const sdkUserAgent = mockNextHandler.mock.calls[0][0].request.headers[USER_AGENT];
-    expect(sdkUserAgent).toEqual(expect.stringContaining("aws-sdk-js/1.0.0"));
-    expect(sdkUserAgent).toEqual(expect.stringContaining("default_agent/1.0.0"));
-    expect(sdkUserAgent).toEqual(expect.stringContaining("custom_ua/abc"));
-    expect(sdkUserAgent).toEqual(expect.stringContaining("cfg/retry-mode/standard"));
-    expect(mockNextHandler.mock.calls[0][0].request.headers[X_AMZ_USER_AGENT]).toEqual(
-      expect.stringContaining("aws-sdk-js/1.0.0")
+  describe("should collect user agent pair from default, custom-supplied, and handler context", () => {
+    [
+      { runtime: "node", sdkUserAgentKey: USER_AGENT, userAgentKey: X_AMZ_USER_AGENT },
+      { runtime: "browser", sdkUserAgentKey: X_AMZ_USER_AGENT, userAgentKey: USER_AGENT },
+    ].forEach(({ runtime, sdkUserAgentKey, userAgentKey }) =>
+      it(runtime, async () => {
+        const middleware = userAgentMiddleware({
+          defaultUserAgentProvider: async () => [
+            ["default_agent", "1.0.0"],
+            ["aws-sdk-js", "1.0.0"],
+          ],
+          customUserAgent: [["custom_ua/abc"]],
+          runtime,
+        });
+        const handler = middleware(mockNextHandler, { userAgent: [["cfg/retry-mode", "standard"]] });
+        await handler({ input: {}, request: new HttpRequest({ headers: {} }) });
+        expect(mockNextHandler.mock.calls.length).toEqual(1);
+        const sdkUserAgent = mockNextHandler.mock.calls[0][0].request.headers[sdkUserAgentKey];
+        expect(sdkUserAgent).toEqual(expect.stringContaining("aws-sdk-js/1.0.0"));
+        expect(sdkUserAgent).toEqual(expect.stringContaining("default_agent/1.0.0"));
+        expect(sdkUserAgent).toEqual(expect.stringContaining("custom_ua/abc"));
+        expect(sdkUserAgent).toEqual(expect.stringContaining("cfg/retry-mode/standard"));
+        if (userAgentKey === USER_AGENT) {
+          expect(mockNextHandler.mock.calls[0][0].request.headers[userAgentKey]).toBeUndefined();
+        } else {
+          expect(mockNextHandler.mock.calls[0][0].request.headers[userAgentKey]).toEqual(
+            expect.stringContaining("aws-sdk-js/1.0.0")
+          );
+        }
+      })
     );
   });
 
-  it(`should not set ${USER_AGENT} header in browser`, async () => {
-    const middleware = userAgentMiddleware({
-      defaultUserAgentProvider: async () => [["aws-sdk-js", "1.0.0"]],
-      runtime: "browser",
-    });
-    const handler = middleware(mockNextHandler, {});
-    await handler({ input: {}, request: new HttpRequest({ headers: {} }) });
-    expect(mockNextHandler.mock.calls.length).toEqual(1);
-    expect(mockNextHandler.mock.calls[0][0].request.headers[USER_AGENT]).toBeUndefined();
-  });
-
-  describe("should sanitize the user agent string", () => {
+  describe("should sanitize the SDK user agent string", () => {
     const cases: { ua: UserAgentPair; expected: string }[] = [
       { ua: ["/name", "1.0.0"], expected: "name/1.0.0" },
       { ua: ["Name", "1.0.0"], expected: "Name/1.0.0" },
@@ -54,18 +54,25 @@ describe("userAgentMiddleware", () => {
       { ua: ["name", "1.0.0(test_version)"], expected: "name/1.0.0_test_version" },
       { ua: ["api/Service", "1.0.0"], expected: "api/service/1.0.0" },
     ];
-    for (const { ua, expected } of cases) {
-      it(`should sanitize user agent ${ua} to ${expected}`, async () => {
-        const middleware = userAgentMiddleware({
-          defaultUserAgentProvider: async () => [ua],
-          runtime: "browser",
-        });
-        const handler = middleware(mockNextHandler, {});
-        await handler({ input: {}, request: new HttpRequest({ headers: {} }) });
-        expect(mockNextHandler.mock.calls[0][0].request.headers[X_AMZ_USER_AGENT]).toEqual(
-          expect.stringContaining(expected)
-        );
-      });
-    }
+    [
+      { runtime: "node", sdkUserAgentKey: USER_AGENT },
+      { runtime: "browser", sdkUserAgentKey: X_AMZ_USER_AGENT },
+    ].forEach(({ runtime, sdkUserAgentKey }) =>
+      describe(runtime, () => {
+        for (const { ua, expected } of cases) {
+          it(`should sanitize user agent ${ua} to ${expected}`, async () => {
+            const middleware = userAgentMiddleware({
+              defaultUserAgentProvider: async () => [ua],
+              runtime,
+            });
+            const handler = middleware(mockNextHandler, {});
+            await handler({ input: {}, request: new HttpRequest({ headers: {} }) });
+            expect(mockNextHandler.mock.calls[0][0].request.headers[sdkUserAgentKey]).toEqual(
+              expect.stringContaining(expected)
+            );
+          });
+        }
+      })
+    );
   });
 });

--- a/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
+++ b/packages/middleware-user-agent/src/user-agent-middleware.spec.ts
@@ -23,12 +23,12 @@ describe("userAgentMiddleware", () => {
     const handler = middleware(mockNextHandler, { userAgent: [["cfg/retry-mode", "standard"]] });
     await handler({ input: {}, request: new HttpRequest({ headers: {} }) });
     expect(mockNextHandler.mock.calls.length).toEqual(1);
-    const sdkUserAgent = mockNextHandler.mock.calls[0][0].request.headers[X_AMZ_USER_AGENT];
+    const sdkUserAgent = mockNextHandler.mock.calls[0][0].request.headers[USER_AGENT];
     expect(sdkUserAgent).toEqual(expect.stringContaining("aws-sdk-js/1.0.0"));
     expect(sdkUserAgent).toEqual(expect.stringContaining("default_agent/1.0.0"));
     expect(sdkUserAgent).toEqual(expect.stringContaining("custom_ua/abc"));
     expect(sdkUserAgent).toEqual(expect.stringContaining("cfg/retry-mode/standard"));
-    expect(mockNextHandler.mock.calls[0][0].request.headers[USER_AGENT]).toEqual(
+    expect(mockNextHandler.mock.calls[0][0].request.headers[X_AMZ_USER_AGENT]).toEqual(
       expect.stringContaining("aws-sdk-js/1.0.0")
     );
   });


### PR DESCRIPTION
### Issue
Internal JS-2583: Some services do not output custom headers in the query logs, so the UA string is missing for those services in metrics database.

### Description
* Swaps user agent headers for non-browser environments.
* Retains `x-amz-user-agent` for browser as it's similar to v2 behavior https://github.com/aws/aws-sdk-js/blob/bfb22c7b474e72791f16ef0fcb5db7794a0207a3/lib/http.js#L114-L117

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
