### PR TITLE
fix(clients): typo in README difference -> different

### DIFF
--- a/clients/client-accessanalyzer/README.md
+++ b/clients/client-accessanalyzer/README.md
@@ -54,7 +54,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AccessAnalyzerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-acm-pca/README.md
+++ b/clients/client-acm-pca/README.md
@@ -58,7 +58,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ACMPCAClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-acm/README.md
+++ b/clients/client-acm/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ACMClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-alexa-for-business/README.md
+++ b/clients/client-alexa-for-business/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AlexaForBusinessClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-amp/README.md
+++ b/clients/client-amp/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AmpClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-amplify/README.md
+++ b/clients/client-amplify/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AmplifyClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-amplifybackend/README.md
+++ b/clients/client-amplifybackend/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AmplifyBackendClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-api-gateway/README.md
+++ b/clients/client-api-gateway/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new APIGatewayClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-apigatewaymanagementapi/README.md
+++ b/clients/client-apigatewaymanagementapi/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ApiGatewayManagementApiClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-apigatewayv2/README.md
+++ b/clients/client-apigatewayv2/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ApiGatewayV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-app-mesh/README.md
+++ b/clients/client-app-mesh/README.md
@@ -58,7 +58,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AppMeshClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-appconfig/README.md
+++ b/clients/client-appconfig/README.md
@@ -95,7 +95,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AppConfigClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-appflow/README.md
+++ b/clients/client-appflow/README.md
@@ -74,7 +74,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AppflowClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-appintegrations/README.md
+++ b/clients/client-appintegrations/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AppIntegrationsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-application-auto-scaling/README.md
+++ b/clients/client-application-auto-scaling/README.md
@@ -115,7 +115,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ApplicationAutoScalingClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-application-discovery-service/README.md
+++ b/clients/client-application-discovery-service/README.md
@@ -177,7 +177,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ApplicationDiscoveryServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-application-insights/README.md
+++ b/clients/client-application-insights/README.md
@@ -59,7 +59,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ApplicationInsightsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-appstream/README.md
+++ b/clients/client-appstream/README.md
@@ -67,7 +67,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AppStreamClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-appsync/README.md
+++ b/clients/client-appsync/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AppSyncClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-athena/README.md
+++ b/clients/client-athena/README.md
@@ -58,7 +58,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AthenaClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-auditmanager/README.md
+++ b/clients/client-auditmanager/README.md
@@ -76,7 +76,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AuditManagerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-auto-scaling-plans/README.md
+++ b/clients/client-auto-scaling-plans/README.md
@@ -79,7 +79,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AutoScalingPlansClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-auto-scaling/README.md
+++ b/clients/client-auto-scaling/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new AutoScalingClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-backup/README.md
+++ b/clients/client-backup/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new BackupClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-batch/README.md
+++ b/clients/client-batch/README.md
@@ -55,7 +55,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new BatchClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-braket/README.md
+++ b/clients/client-braket/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new BraketClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-budgets/README.md
+++ b/clients/client-budgets/README.md
@@ -88,7 +88,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new BudgetsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-chime/README.md
+++ b/clients/client-chime/README.md
@@ -85,7 +85,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ChimeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloud9/README.md
+++ b/clients/client-cloud9/README.md
@@ -104,7 +104,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new Cloud9Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-clouddirectory/README.md
+++ b/clients/client-clouddirectory/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudDirectoryClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudformation/README.md
+++ b/clients/client-cloudformation/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudFormationClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudfront/README.md
+++ b/clients/client-cloudfront/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudFrontClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudhsm-v2/README.md
+++ b/clients/client-cloudhsm-v2/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudHSMV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudhsm/README.md
+++ b/clients/client-cloudhsm/README.md
@@ -57,7 +57,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudHSMClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudsearch-domain/README.md
+++ b/clients/client-cloudsearch-domain/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudSearchDomainClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudsearch/README.md
+++ b/clients/client-cloudsearch/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudSearchClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudtrail/README.md
+++ b/clients/client-cloudtrail/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudTrailClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudwatch-events/README.md
+++ b/clients/client-cloudwatch-events/README.md
@@ -66,7 +66,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudWatchEventsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudwatch-logs/README.md
+++ b/clients/client-cloudwatch-logs/README.md
@@ -79,7 +79,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudWatchLogsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cloudwatch/README.md
+++ b/clients/client-cloudwatch/README.md
@@ -60,7 +60,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CloudWatchClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codeartifact/README.md
+++ b/clients/client-codeartifact/README.md
@@ -299,7 +299,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeartifactClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codebuild/README.md
+++ b/clients/client-codebuild/README.md
@@ -57,7 +57,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeBuildClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codecommit/README.md
+++ b/clients/client-codecommit/README.md
@@ -437,7 +437,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeCommitClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codedeploy/README.md
+++ b/clients/client-codedeploy/README.md
@@ -146,7 +146,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeDeployClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codeguru-reviewer/README.md
+++ b/clients/client-codeguru-reviewer/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeGuruReviewerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codeguruprofiler/README.md
+++ b/clients/client-codeguruprofiler/README.md
@@ -68,7 +68,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeGuruProfilerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codepipeline/README.md
+++ b/clients/client-codepipeline/README.md
@@ -241,7 +241,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodePipelineClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codestar-connections/README.md
+++ b/clients/client-codestar-connections/README.md
@@ -126,7 +126,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeStarConnectionsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codestar-notifications/README.md
+++ b/clients/client-codestar-notifications/README.md
@@ -130,7 +130,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodestarNotificationsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-codestar/README.md
+++ b/clients/client-codestar/README.md
@@ -136,7 +136,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CodeStarClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cognito-identity-provider/README.md
+++ b/clients/client-cognito-identity-provider/README.md
@@ -54,7 +54,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CognitoIdentityProviderClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cognito-identity/README.md
+++ b/clients/client-cognito-identity/README.md
@@ -60,7 +60,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CognitoIdentityClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cognito-sync/README.md
+++ b/clients/client-cognito-sync/README.md
@@ -59,7 +59,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CognitoSyncClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-comprehend/README.md
+++ b/clients/client-comprehend/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ComprehendClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-comprehendmedical/README.md
+++ b/clients/client-comprehendmedical/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ComprehendMedicalClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-compute-optimizer/README.md
+++ b/clients/client-compute-optimizer/README.md
@@ -58,7 +58,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ComputeOptimizerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-config-service/README.md
+++ b/clients/client-config-service/README.md
@@ -69,7 +69,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ConfigServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-connect-contact-lens/README.md
+++ b/clients/client-connect-contact-lens/README.md
@@ -58,7 +58,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ConnectContactLensClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-connect/README.md
+++ b/clients/client-connect/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ConnectClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-connectparticipant/README.md
+++ b/clients/client-connectparticipant/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ConnectParticipantClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cost-and-usage-report-service/README.md
+++ b/clients/client-cost-and-usage-report-service/README.md
@@ -69,7 +69,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CostAndUsageReportServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-cost-explorer/README.md
+++ b/clients/client-cost-explorer/README.md
@@ -59,7 +59,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CostExplorerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-customer-profiles/README.md
+++ b/clients/client-customer-profiles/README.md
@@ -56,7 +56,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new CustomerProfilesClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-data-pipeline/README.md
+++ b/clients/client-data-pipeline/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DataPipelineClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-database-migration-service/README.md
+++ b/clients/client-database-migration-service/README.md
@@ -59,7 +59,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DatabaseMigrationServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-databrew/README.md
+++ b/clients/client-databrew/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DataBrewClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-dataexchange/README.md
+++ b/clients/client-dataexchange/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DataExchangeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-datasync/README.md
+++ b/clients/client-datasync/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DataSyncClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-dax/README.md
+++ b/clients/client-dax/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DAXClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-detective/README.md
+++ b/clients/client-detective/README.md
@@ -91,7 +91,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DetectiveClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-device-farm/README.md
+++ b/clients/client-device-farm/README.md
@@ -60,7 +60,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DeviceFarmClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-devops-guru/README.md
+++ b/clients/client-devops-guru/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DevOpsGuruClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-direct-connect/README.md
+++ b/clients/client-direct-connect/README.md
@@ -57,7 +57,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DirectConnectClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-directory-service/README.md
+++ b/clients/client-directory-service/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DirectoryServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-dlm/README.md
+++ b/clients/client-dlm/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DLMClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-docdb/README.md
+++ b/clients/client-docdb/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DocDBClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-dynamodb-streams/README.md
+++ b/clients/client-dynamodb-streams/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DynamoDBStreamsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-dynamodb/README.md
+++ b/clients/client-dynamodb/README.md
@@ -63,7 +63,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new DynamoDBClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ebs/README.md
+++ b/clients/client-ebs/README.md
@@ -64,7 +64,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EBSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ec2-instance-connect/README.md
+++ b/clients/client-ec2-instance-connect/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EC2InstanceConnectClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ec2/README.md
+++ b/clients/client-ec2/README.md
@@ -72,7 +72,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EC2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-ecr-public/README.md
+++ b/clients/client-ecr-public/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ECRPUBLICClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ecr/README.md
+++ b/clients/client-ecr/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ECRClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ecs/README.md
+++ b/clients/client-ecs/README.md
@@ -59,7 +59,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ECSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-efs/README.md
+++ b/clients/client-efs/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EFSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-eks/README.md
+++ b/clients/client-eks/README.md
@@ -55,7 +55,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EKSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-elastic-beanstalk/README.md
+++ b/clients/client-elastic-beanstalk/README.md
@@ -59,7 +59,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ElasticBeanstalkClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-elastic-inference/README.md
+++ b/clients/client-elastic-inference/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ElasticInferenceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-elastic-load-balancing-v2/README.md
+++ b/clients/client-elastic-load-balancing-v2/README.md
@@ -84,7 +84,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ElasticLoadBalancingV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-elastic-load-balancing/README.md
+++ b/clients/client-elastic-load-balancing/README.md
@@ -66,7 +66,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ElasticLoadBalancingClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-elastic-transcoder/README.md
+++ b/clients/client-elastic-transcoder/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ElasticTranscoderClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-elasticache/README.md
+++ b/clients/client-elasticache/README.md
@@ -56,7 +56,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ElastiCacheClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-elasticsearch-service/README.md
+++ b/clients/client-elasticsearch-service/README.md
@@ -59,7 +59,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ElasticsearchServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-emr-containers/README.md
+++ b/clients/client-emr-containers/README.md
@@ -67,7 +67,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EMRContainersClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-emr/README.md
+++ b/clients/client-emr/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EMRClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-eventbridge/README.md
+++ b/clients/client-eventbridge/README.md
@@ -66,7 +66,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EventBridgeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-firehose/README.md
+++ b/clients/client-firehose/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new FirehoseClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-fis/README.md
+++ b/clients/client-fis/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new FisClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-fms/README.md
+++ b/clients/client-fms/README.md
@@ -54,7 +54,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new FMSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-forecast/README.md
+++ b/clients/client-forecast/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ForecastClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-forecastquery/README.md
+++ b/clients/client-forecastquery/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ForecastqueryClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-frauddetector/README.md
+++ b/clients/client-frauddetector/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new FraudDetectorClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-fsx/README.md
+++ b/clients/client-fsx/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new FSxClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-gamelift/README.md
+++ b/clients/client-gamelift/README.md
@@ -104,7 +104,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GameLiftClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-glacier/README.md
+++ b/clients/client-glacier/README.md
@@ -83,7 +83,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GlacierClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-global-accelerator/README.md
+++ b/clients/client-global-accelerator/README.md
@@ -194,7 +194,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GlobalAcceleratorClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-glue/README.md
+++ b/clients/client-glue/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GlueClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-greengrass/README.md
+++ b/clients/client-greengrass/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GreengrassClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-greengrassv2/README.md
+++ b/clients/client-greengrassv2/README.md
@@ -56,7 +56,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GreengrassV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-groundstation/README.md
+++ b/clients/client-groundstation/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GroundStationClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-guardduty/README.md
+++ b/clients/client-guardduty/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new GuardDutyClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-health/README.md
+++ b/clients/client-health/README.md
@@ -83,7 +83,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new HealthClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-healthlake/README.md
+++ b/clients/client-healthlake/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new HealthLakeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-honeycode/README.md
+++ b/clients/client-honeycode/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new HoneycodeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iam/README.md
+++ b/clients/client-iam/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IAMClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-identitystore/README.md
+++ b/clients/client-identitystore/README.md
@@ -44,7 +44,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IdentitystoreClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-imagebuilder/README.md
+++ b/clients/client-imagebuilder/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ImagebuilderClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-inspector/README.md
+++ b/clients/client-inspector/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new InspectorClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot-1click-devices-service/README.md
+++ b/clients/client-iot-1click-devices-service/README.md
@@ -54,7 +54,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoT1ClickDevicesServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot-1click-projects/README.md
+++ b/clients/client-iot-1click-projects/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoT1ClickProjectsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot-data-plane/README.md
+++ b/clients/client-iot-data-plane/README.md
@@ -57,7 +57,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTDataPlaneClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot-events-data/README.md
+++ b/clients/client-iot-events-data/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTEventsDataClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot-events/README.md
+++ b/clients/client-iot-events/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTEventsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot-jobs-data-plane/README.md
+++ b/clients/client-iot-jobs-data-plane/README.md
@@ -56,7 +56,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTJobsDataPlaneClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot-wireless/README.md
+++ b/clients/client-iot-wireless/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTWirelessClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iot/README.md
+++ b/clients/client-iot/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iotanalytics/README.md
+++ b/clients/client-iotanalytics/README.md
@@ -64,7 +64,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTAnalyticsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iotdeviceadvisor/README.md
+++ b/clients/client-iotdeviceadvisor/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IotDeviceAdvisorClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iotfleethub/README.md
+++ b/clients/client-iotfleethub/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTFleetHubClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iotsecuretunneling/README.md
+++ b/clients/client-iotsecuretunneling/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTSecureTunnelingClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iotsitewise/README.md
+++ b/clients/client-iotsitewise/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTSiteWiseClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-iotthingsgraph/README.md
+++ b/clients/client-iotthingsgraph/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IoTThingsGraphClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ivs/README.md
+++ b/clients/client-ivs/README.md
@@ -401,7 +401,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new IvsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kafka/README.md
+++ b/clients/client-kafka/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KafkaClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kendra/README.md
+++ b/clients/client-kendra/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KendraClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kinesis-analytics-v2/README.md
+++ b/clients/client-kinesis-analytics-v2/README.md
@@ -54,7 +54,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KinesisAnalyticsV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-kinesis-analytics/README.md
+++ b/clients/client-kinesis-analytics/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KinesisAnalyticsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kinesis-video-archived-media/README.md
+++ b/clients/client-kinesis-video-archived-media/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KinesisVideoArchivedMediaClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kinesis-video-media/README.md
+++ b/clients/client-kinesis-video-media/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KinesisVideoMediaClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kinesis-video-signaling/README.md
+++ b/clients/client-kinesis-video-signaling/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KinesisVideoSignalingClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kinesis-video/README.md
+++ b/clients/client-kinesis-video/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KinesisVideoClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kinesis/README.md
+++ b/clients/client-kinesis/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KinesisClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-kms/README.md
+++ b/clients/client-kms/README.md
@@ -135,7 +135,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new KMSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lakeformation/README.md
+++ b/clients/client-lakeformation/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LakeFormationClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lambda/README.md
+++ b/clients/client-lambda/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LambdaClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lex-model-building-service/README.md
+++ b/clients/client-lex-model-building-service/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LexModelBuildingServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lex-models-v2/README.md
+++ b/clients/client-lex-models-v2/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LexModelsV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-lex-runtime-service/README.md
+++ b/clients/client-lex-runtime-service/README.md
@@ -57,7 +57,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LexRuntimeServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lex-runtime-v2/README.md
+++ b/clients/client-lex-runtime-v2/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LexRuntimeV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-license-manager/README.md
+++ b/clients/client-license-manager/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LicenseManagerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lightsail/README.md
+++ b/clients/client-lightsail/README.md
@@ -60,7 +60,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LightsailClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-location/README.md
+++ b/clients/client-location/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LocationClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lookoutequipment/README.md
+++ b/clients/client-lookoutequipment/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LookoutEquipmentClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lookoutmetrics/README.md
+++ b/clients/client-lookoutmetrics/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LookoutMetricsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-lookoutvision/README.md
+++ b/clients/client-lookoutvision/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new LookoutVisionClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-machine-learning/README.md
+++ b/clients/client-machine-learning/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MachineLearningClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-macie/README.md
+++ b/clients/client-macie/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MacieClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-macie2/README.md
+++ b/clients/client-macie2/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new Macie2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-managedblockchain/README.md
+++ b/clients/client-managedblockchain/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ManagedBlockchainClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-marketplace-catalog/README.md
+++ b/clients/client-marketplace-catalog/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MarketplaceCatalogClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-marketplace-commerce-analytics/README.md
+++ b/clients/client-marketplace-commerce-analytics/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MarketplaceCommerceAnalyticsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-marketplace-entitlement-service/README.md
+++ b/clients/client-marketplace-entitlement-service/README.md
@@ -69,7 +69,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MarketplaceEntitlementServiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-marketplace-metering/README.md
+++ b/clients/client-marketplace-metering/README.md
@@ -103,7 +103,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MarketplaceMeteringClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mediaconnect/README.md
+++ b/clients/client-mediaconnect/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaConnectClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mediaconvert/README.md
+++ b/clients/client-mediaconvert/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaConvertClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-medialive/README.md
+++ b/clients/client-medialive/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaLiveClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mediapackage-vod/README.md
+++ b/clients/client-mediapackage-vod/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaPackageVodClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mediapackage/README.md
+++ b/clients/client-mediapackage/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaPackageClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mediastore-data/README.md
+++ b/clients/client-mediastore-data/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaStoreDataClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mediastore/README.md
+++ b/clients/client-mediastore/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaStoreClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mediatailor/README.md
+++ b/clients/client-mediatailor/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MediaTailorClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mgn/README.md
+++ b/clients/client-mgn/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MgnClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-migration-hub/README.md
+++ b/clients/client-migration-hub/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MigrationHubClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-migrationhub-config/README.md
+++ b/clients/client-migrationhub-config/README.md
@@ -71,7 +71,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MigrationHubConfigClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mobile/README.md
+++ b/clients/client-mobile/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MobileClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mq/README.md
+++ b/clients/client-mq/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MqClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mturk/README.md
+++ b/clients/client-mturk/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MTurkClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-mwaa/README.md
+++ b/clients/client-mwaa/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new MWAAClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-neptune/README.md
+++ b/clients/client-neptune/README.md
@@ -64,7 +64,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new NeptuneClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-network-firewall/README.md
+++ b/clients/client-network-firewall/README.md
@@ -122,7 +122,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new NetworkFirewallClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-networkmanager/README.md
+++ b/clients/client-networkmanager/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new NetworkManagerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-opsworks/README.md
+++ b/clients/client-opsworks/README.md
@@ -161,7 +161,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new OpsWorksClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-opsworkscm/README.md
+++ b/clients/client-opsworkscm/README.md
@@ -134,7 +134,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new OpsWorksCMClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-organizations/README.md
+++ b/clients/client-organizations/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new OrganizationsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-outposts/README.md
+++ b/clients/client-outposts/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new OutpostsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-personalize-events/README.md
+++ b/clients/client-personalize-events/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PersonalizeEventsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-personalize-runtime/README.md
+++ b/clients/client-personalize-runtime/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PersonalizeRuntimeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-personalize/README.md
+++ b/clients/client-personalize/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PersonalizeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-pi/README.md
+++ b/clients/client-pi/README.md
@@ -67,7 +67,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PIClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-pinpoint-email/README.md
+++ b/clients/client-pinpoint-email/README.md
@@ -75,7 +75,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PinpointEmailClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-pinpoint-sms-voice/README.md
+++ b/clients/client-pinpoint-sms-voice/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PinpointSMSVoiceClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-pinpoint/README.md
+++ b/clients/client-pinpoint/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PinpointClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-polly/README.md
+++ b/clients/client-polly/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PollyClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-pricing/README.md
+++ b/clients/client-pricing/README.md
@@ -69,7 +69,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new PricingClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-qldb-session/README.md
+++ b/clients/client-qldb-session/README.md
@@ -66,7 +66,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new QLDBSessionClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-qldb/README.md
+++ b/clients/client-qldb/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new QLDBClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-quicksight/README.md
+++ b/clients/client-quicksight/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new QuickSightClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ram/README.md
+++ b/clients/client-ram/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RAMClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-rds-data/README.md
+++ b/clients/client-rds-data/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RDSDataClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-rds/README.md
+++ b/clients/client-rds/README.md
@@ -103,7 +103,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RDSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-redshift-data/README.md
+++ b/clients/client-redshift-data/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RedshiftDataClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-redshift/README.md
+++ b/clients/client-redshift/README.md
@@ -68,7 +68,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RedshiftClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-rekognition/README.md
+++ b/clients/client-rekognition/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RekognitionClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-resource-groups-tagging-api/README.md
+++ b/clients/client-resource-groups-tagging-api/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ResourceGroupsTaggingAPIClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-resource-groups/README.md
+++ b/clients/client-resource-groups/README.md
@@ -81,7 +81,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ResourceGroupsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-robomaker/README.md
+++ b/clients/client-robomaker/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RoboMakerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-route-53-domains/README.md
+++ b/clients/client-route-53-domains/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new Route53DomainsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-route-53/README.md
+++ b/clients/client-route-53/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new Route53Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-route53resolver/README.md
+++ b/clients/client-route53resolver/README.md
@@ -75,7 +75,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new Route53ResolverClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-s3-control/README.md
+++ b/clients/client-s3-control/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new S3ControlClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-s3/README.md
+++ b/clients/client-s3/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new S3Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-s3outposts/README.md
+++ b/clients/client-s3outposts/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new S3OutpostsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sagemaker-a2i-runtime/README.md
+++ b/clients/client-sagemaker-a2i-runtime/README.md
@@ -75,7 +75,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SageMakerA2IRuntimeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sagemaker-edge/README.md
+++ b/clients/client-sagemaker-edge/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SagemakerEdgeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sagemaker-featurestore-runtime/README.md
+++ b/clients/client-sagemaker-featurestore-runtime/README.md
@@ -78,7 +78,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SageMakerFeatureStoreRuntimeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sagemaker-runtime/README.md
+++ b/clients/client-sagemaker-runtime/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SageMakerRuntimeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sagemaker/README.md
+++ b/clients/client-sagemaker/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SageMakerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-savingsplans/README.md
+++ b/clients/client-savingsplans/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SavingsplansClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-schemas/README.md
+++ b/clients/client-schemas/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SchemasClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-secrets-manager/README.md
+++ b/clients/client-secrets-manager/README.md
@@ -102,7 +102,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SecretsManagerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-securityhub/README.md
+++ b/clients/client-securityhub/README.md
@@ -100,7 +100,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SecurityHubClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-serverlessapplicationrepository/README.md
+++ b/clients/client-serverlessapplicationrepository/README.md
@@ -71,7 +71,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ServerlessApplicationRepositoryClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-service-catalog-appregistry/README.md
+++ b/clients/client-service-catalog-appregistry/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ServiceCatalogAppRegistryClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-service-catalog/README.md
+++ b/clients/client-service-catalog/README.md
@@ -53,7 +53,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ServiceCatalogClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-service-quotas/README.md
+++ b/clients/client-service-quotas/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ServiceQuotasClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-servicediscovery/README.md
+++ b/clients/client-servicediscovery/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ServiceDiscoveryClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ses/README.md
+++ b/clients/client-ses/README.md
@@ -55,7 +55,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SESClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sesv2/README.md
+++ b/clients/client-sesv2/README.md
@@ -66,7 +66,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SESv2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-sfn/README.md
+++ b/clients/client-sfn/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SFNClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-shield/README.md
+++ b/clients/client-shield/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ShieldClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-signer/README.md
+++ b/clients/client-signer/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SignerClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sms/README.md
+++ b/clients/client-sms/README.md
@@ -63,7 +63,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SMSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-snowball/README.md
+++ b/clients/client-snowball/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SnowballClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sns/README.md
+++ b/clients/client-sns/README.md
@@ -60,7 +60,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SNSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sqs/README.md
+++ b/clients/client-sqs/README.md
@@ -114,7 +114,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SQSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-ssm/README.md
+++ b/clients/client-ssm/README.md
@@ -60,7 +60,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SSMClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sso-admin/README.md
+++ b/clients/client-sso-admin/README.md
@@ -44,7 +44,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SSOAdminClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sso-oidc/README.md
+++ b/clients/client-sso-oidc/README.md
@@ -63,7 +63,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SSOOIDCClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sso/README.md
+++ b/clients/client-sso/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SSOClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-storage-gateway/README.md
+++ b/clients/client-storage-gateway/README.md
@@ -117,7 +117,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new StorageGatewayClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-sts/README.md
+++ b/clients/client-sts/README.md
@@ -51,7 +51,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new STSClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-support/README.md
+++ b/clients/client-support/README.md
@@ -123,7 +123,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SupportClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-swf/README.md
+++ b/clients/client-swf/README.md
@@ -61,7 +61,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SWFClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-synthetics/README.md
+++ b/clients/client-synthetics/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new SyntheticsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-textract/README.md
+++ b/clients/client-textract/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new TextractClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-timestream-query/README.md
+++ b/clients/client-timestream-query/README.md
@@ -48,7 +48,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new TimestreamQueryClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-timestream-write/README.md
+++ b/clients/client-timestream-write/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new TimestreamWriteClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-transcribe-streaming/README.md
+++ b/clients/client-transcribe-streaming/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new TranscribeStreamingClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-transcribe/README.md
+++ b/clients/client-transcribe/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new TranscribeClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-transfer/README.md
+++ b/clients/client-transfer/README.md
@@ -54,7 +54,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new TransferClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-translate/README.md
+++ b/clients/client-translate/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new TranslateClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-waf-regional/README.md
+++ b/clients/client-waf-regional/README.md
@@ -56,7 +56,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WAFRegionalClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-waf/README.md
+++ b/clients/client-waf/README.md
@@ -56,7 +56,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WAFClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-wafv2/README.md
+++ b/clients/client-wafv2/README.md
@@ -102,7 +102,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WAFV2Client({ region: "REGION" });
 
 const params = {

--- a/clients/client-wellarchitected/README.md
+++ b/clients/client-wellarchitected/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WellArchitectedClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-workdocs/README.md
+++ b/clients/client-workdocs/README.md
@@ -78,7 +78,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WorkDocsClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-worklink/README.md
+++ b/clients/client-worklink/README.md
@@ -52,7 +52,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WorkLinkClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-workmail/README.md
+++ b/clients/client-workmail/README.md
@@ -81,7 +81,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WorkMailClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-workmailmessageflow/README.md
+++ b/clients/client-workmailmessageflow/README.md
@@ -50,7 +50,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WorkMailMessageFlowClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-workspaces/README.md
+++ b/clients/client-workspaces/README.md
@@ -49,7 +49,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new WorkSpacesClient({ region: "REGION" });
 
 const params = {

--- a/clients/client-xray/README.md
+++ b/clients/client-xray/README.md
@@ -47,7 +47,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new XRayClient({ region: "REGION" });
 
 const params = {

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
@@ -44,7 +44,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new ${serviceId}Client({ region: "REGION" });
 
 const params = { /** input parameters */ };

--- a/protocol_tests/aws-ec2/README.md
+++ b/protocol_tests/aws-ec2/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new EC2ProtocolClient({ region: "REGION" });
 
 const params = {

--- a/protocol_tests/aws-json/README.md
+++ b/protocol_tests/aws-json/README.md
@@ -44,7 +44,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new JsonProtocolClient({ region: "REGION" });
 
 const params = {

--- a/protocol_tests/aws-query/README.md
+++ b/protocol_tests/aws-query/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new QueryProtocolClient({ region: "REGION" });
 
 const params = {

--- a/protocol_tests/aws-restjson/README.md
+++ b/protocol_tests/aws-restjson/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RestJsonProtocolClient({ region: "REGION" });
 
 const params = {

--- a/protocol_tests/aws-restxml/README.md
+++ b/protocol_tests/aws-restxml/README.md
@@ -46,7 +46,7 @@ To send a request, you:
 - If you are using a custom http handler, you may call `destroy()` to close open connections.
 
 ```js
-// a client can be shared by difference commands.
+// a client can be shared by different commands.
 const client = new RestXmlProtocolClient({ region: "REGION" });
 
 const params = {


### PR DESCRIPTION
### Issue
Closes: https://github.com/aws/aws-sdk-js-v3/pull/2298

### Description
fix typo in README difference -> different

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
