### PR TITLE
fix(clients): use interface for new clients input

### DIFF
--- a/clients/client-amp/AmpClient.ts
+++ b/clients/client-amp/AmpClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type AmpClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type AmpClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -175,8 +175,12 @@ export type AmpClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of AmpClient class constructor that set the region, credentials and other options.
+ */
+export interface AmpClientConfig extends AmpClientConfigType {}
 
-export type AmpClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type AmpClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -184,6 +188,10 @@ export type AmpClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of AmpClient class. This is resolved and normalized from the {@link AmpClientConfig | constructor configuration interface}.
+ */
+export interface AmpClientResolvedConfig extends AmpClientResolvedConfigType {}
 
 /**
  * Amazon Managed Service for Prometheus
@@ -194,6 +202,9 @@ export class AmpClient extends __Client<
   ServiceOutputTypes,
   AmpClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of AmpClient class. This is resolved and normalized from the {@link AmpClientConfig | constructor configuration interface}.
+   */
   readonly config: AmpClientResolvedConfig;
 
   constructor(configuration: AmpClientConfig) {

--- a/clients/client-fis/FisClient.ts
+++ b/clients/client-fis/FisClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type FisClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type FisClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -217,8 +217,12 @@ export type FisClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of FisClient class constructor that set the region, credentials and other options.
+ */
+export interface FisClientConfig extends FisClientConfigType {}
 
-export type FisClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type FisClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -226,6 +230,10 @@ export type FisClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of FisClient class. This is resolved and normalized from the {@link FisClientConfig | constructor configuration interface}.
+ */
+export interface FisClientResolvedConfig extends FisClientResolvedConfigType {}
 
 /**
  * <p>AWS Fault Injection Simulator is a managed service that enables you to perform fault injection
@@ -237,6 +245,9 @@ export class FisClient extends __Client<
   ServiceOutputTypes,
   FisClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of FisClient class. This is resolved and normalized from the {@link FisClientConfig | constructor configuration interface}.
+   */
   readonly config: FisClientResolvedConfig;
 
   constructor(configuration: FisClientConfig) {

--- a/clients/client-greengrassv2/GreengrassV2Client.ts
+++ b/clients/client-greengrassv2/GreengrassV2Client.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type GreengrassV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type GreengrassV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -238,8 +238,12 @@ export type GreengrassV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of GreengrassV2Client class constructor that set the region, credentials and other options.
+ */
+export interface GreengrassV2ClientConfig extends GreengrassV2ClientConfigType {}
 
-export type GreengrassV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type GreengrassV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -247,6 +251,10 @@ export type GreengrassV2ClientResolvedConfig = __SmithyResolvedConfiguration<__H
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of GreengrassV2Client class. This is resolved and normalized from the {@link GreengrassV2ClientConfig | constructor configuration interface}.
+ */
+export interface GreengrassV2ClientResolvedConfig extends GreengrassV2ClientResolvedConfigType {}
 
 /**
  * <p>AWS IoT Greengrass brings local compute, messaging, data management, sync, and ML inference capabilities
@@ -267,6 +275,9 @@ export class GreengrassV2Client extends __Client<
   ServiceOutputTypes,
   GreengrassV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of GreengrassV2Client class. This is resolved and normalized from the {@link GreengrassV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: GreengrassV2ClientResolvedConfig;
 
   constructor(configuration: GreengrassV2ClientConfig) {

--- a/clients/client-iot-wireless/IoTWirelessClient.ts
+++ b/clients/client-iot-wireless/IoTWirelessClient.ts
@@ -410,7 +410,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTWirelessClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTWirelessClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -418,8 +418,12 @@ export type IoTWirelessClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTWirelessClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTWirelessClientConfig extends IoTWirelessClientConfigType {}
 
-export type IoTWirelessClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTWirelessClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -427,6 +431,10 @@ export type IoTWirelessClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTWirelessClient class. This is resolved and normalized from the {@link IoTWirelessClientConfig | constructor configuration interface}.
+ */
+export interface IoTWirelessClientResolvedConfig extends IoTWirelessClientResolvedConfigType {}
 
 /**
  * <p>AWS IoT Wireless API documentation</p>
@@ -437,6 +445,9 @@ export class IoTWirelessClient extends __Client<
   ServiceOutputTypes,
   IoTWirelessClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTWirelessClient class. This is resolved and normalized from the {@link IoTWirelessClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTWirelessClientResolvedConfig;
 
   constructor(configuration: IoTWirelessClientConfig) {

--- a/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
+++ b/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IotDeviceAdvisorClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IotDeviceAdvisorClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -211,8 +211,12 @@ export type IotDeviceAdvisorClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IotDeviceAdvisorClient class constructor that set the region, credentials and other options.
+ */
+export interface IotDeviceAdvisorClientConfig extends IotDeviceAdvisorClientConfigType {}
 
-export type IotDeviceAdvisorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IotDeviceAdvisorClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -220,6 +224,10 @@ export type IotDeviceAdvisorClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IotDeviceAdvisorClient class. This is resolved and normalized from the {@link IotDeviceAdvisorClientConfig | constructor configuration interface}.
+ */
+export interface IotDeviceAdvisorClientResolvedConfig extends IotDeviceAdvisorClientResolvedConfigType {}
 
 /**
  * <p>AWS IoT Core Device Advisor is a cloud-based, fully managed test capability for validating IoT devices during device software development. Device Advisor provides pre-built tests that you can use to validate IoT devices for reliable and secure connectivity with AWS IoT Core before deploying devices to production. By using Device Advisor, you can confirm that your devices can connect to AWS IoT Core, follow security best practices and, if applicable, receive software updates from IoT Device Management. You can also download signed qualification reports to submit to the AWS Partner Network to get your device qualified for the AWS Partner Device Catalog without the need to send your device in and wait for it to be tested.</p>
@@ -230,6 +238,9 @@ export class IotDeviceAdvisorClient extends __Client<
   ServiceOutputTypes,
   IotDeviceAdvisorClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IotDeviceAdvisorClient class. This is resolved and normalized from the {@link IotDeviceAdvisorClientConfig | constructor configuration interface}.
+   */
   readonly config: IotDeviceAdvisorClientResolvedConfig;
 
   constructor(configuration: IotDeviceAdvisorClientConfig) {

--- a/clients/client-iotfleethub/IoTFleetHubClient.ts
+++ b/clients/client-iotfleethub/IoTFleetHubClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type IoTFleetHubClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type IoTFleetHubClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -187,8 +187,12 @@ export type IoTFleetHubClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of IoTFleetHubClient class constructor that set the region, credentials and other options.
+ */
+export interface IoTFleetHubClientConfig extends IoTFleetHubClientConfigType {}
 
-export type IoTFleetHubClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type IoTFleetHubClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -196,6 +200,10 @@ export type IoTFleetHubClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of IoTFleetHubClient class. This is resolved and normalized from the {@link IoTFleetHubClientConfig | constructor configuration interface}.
+ */
+export interface IoTFleetHubClientResolvedConfig extends IoTFleetHubClientResolvedConfigType {}
 
 /**
  * <p>With Fleet Hub for AWS IoT Device Management you can build stand-alone web applications for monitoring the health of your device fleets.</p>
@@ -209,6 +217,9 @@ export class IoTFleetHubClient extends __Client<
   ServiceOutputTypes,
   IoTFleetHubClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of IoTFleetHubClient class. This is resolved and normalized from the {@link IoTFleetHubClientConfig | constructor configuration interface}.
+   */
   readonly config: IoTFleetHubClientResolvedConfig;
 
   constructor(configuration: IoTFleetHubClientConfig) {

--- a/clients/client-lex-models-v2/LexModelsV2Client.ts
+++ b/clients/client-lex-models-v2/LexModelsV2Client.ts
@@ -275,7 +275,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LexModelsV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LexModelsV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -283,8 +283,12 @@ export type LexModelsV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LexModelsV2Client class constructor that set the region, credentials and other options.
+ */
+export interface LexModelsV2ClientConfig extends LexModelsV2ClientConfigType {}
 
-export type LexModelsV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LexModelsV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -292,6 +296,10 @@ export type LexModelsV2ClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LexModelsV2Client class. This is resolved and normalized from the {@link LexModelsV2ClientConfig | constructor configuration interface}.
+ */
+export interface LexModelsV2ClientResolvedConfig extends LexModelsV2ClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -302,6 +310,9 @@ export class LexModelsV2Client extends __Client<
   ServiceOutputTypes,
   LexModelsV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LexModelsV2Client class. This is resolved and normalized from the {@link LexModelsV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: LexModelsV2ClientResolvedConfig;
 
   constructor(configuration: LexModelsV2ClientConfig) {

--- a/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
+++ b/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
@@ -189,7 +189,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   eventStreamSerdeProvider?: __EventStreamSerdeProvider;
 }
 
-export type LexRuntimeV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LexRuntimeV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -199,8 +199,12 @@ export type LexRuntimeV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   EventStreamInputConfig &
   UserAgentInputConfig &
   EventStreamSerdeInputConfig;
+/**
+ * The configuration interface of LexRuntimeV2Client class constructor that set the region, credentials and other options.
+ */
+export interface LexRuntimeV2ClientConfig extends LexRuntimeV2ClientConfigType {}
 
-export type LexRuntimeV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LexRuntimeV2ClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -210,6 +214,10 @@ export type LexRuntimeV2ClientResolvedConfig = __SmithyResolvedConfiguration<__H
   EventStreamResolvedConfig &
   UserAgentResolvedConfig &
   EventStreamSerdeResolvedConfig;
+/**
+ * The resolved configuration interface of LexRuntimeV2Client class. This is resolved and normalized from the {@link LexRuntimeV2ClientConfig | constructor configuration interface}.
+ */
+export interface LexRuntimeV2ClientResolvedConfig extends LexRuntimeV2ClientResolvedConfigType {}
 
 /**
  * <p></p>
@@ -220,6 +228,9 @@ export class LexRuntimeV2Client extends __Client<
   ServiceOutputTypes,
   LexRuntimeV2ClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LexRuntimeV2Client class. This is resolved and normalized from the {@link LexRuntimeV2ClientConfig | constructor configuration interface}.
+   */
   readonly config: LexRuntimeV2ClientResolvedConfig;
 
   constructor(configuration: LexRuntimeV2ClientConfig) {

--- a/clients/client-location/LocationClient.ts
+++ b/clients/client-location/LocationClient.ts
@@ -299,7 +299,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LocationClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LocationClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -307,8 +307,12 @@ export type LocationClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LocationClient class constructor that set the region, credentials and other options.
+ */
+export interface LocationClientConfig extends LocationClientConfigType {}
 
-export type LocationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LocationClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -316,6 +320,10 @@ export type LocationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LocationClient class. This is resolved and normalized from the {@link LocationClientConfig | constructor configuration interface}.
+ */
+export interface LocationClientResolvedConfig extends LocationClientResolvedConfigType {}
 
 /**
  * Suite of geospatial services including Maps, Places, Tracking, and Geofencing
@@ -326,6 +334,9 @@ export class LocationClient extends __Client<
   ServiceOutputTypes,
   LocationClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LocationClient class. This is resolved and normalized from the {@link LocationClientConfig | constructor configuration interface}.
+   */
   readonly config: LocationClientResolvedConfig;
 
   constructor(configuration: LocationClientConfig) {

--- a/clients/client-lookoutequipment/LookoutEquipmentClient.ts
+++ b/clients/client-lookoutequipment/LookoutEquipmentClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LookoutEquipmentClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LookoutEquipmentClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -259,8 +259,12 @@ export type LookoutEquipmentClientConfig = Partial<__SmithyConfiguration<__HttpH
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LookoutEquipmentClient class constructor that set the region, credentials and other options.
+ */
+export interface LookoutEquipmentClientConfig extends LookoutEquipmentClientConfigType {}
 
-export type LookoutEquipmentClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LookoutEquipmentClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -268,6 +272,10 @@ export type LookoutEquipmentClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LookoutEquipmentClient class. This is resolved and normalized from the {@link LookoutEquipmentClientConfig | constructor configuration interface}.
+ */
+export interface LookoutEquipmentClientResolvedConfig extends LookoutEquipmentClientResolvedConfigType {}
 
 /**
  * <p>Amazon Lookout for Equipment is a machine learning service that uses advanced analytics to identify
@@ -279,6 +287,9 @@ export class LookoutEquipmentClient extends __Client<
   ServiceOutputTypes,
   LookoutEquipmentClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LookoutEquipmentClient class. This is resolved and normalized from the {@link LookoutEquipmentClientConfig | constructor configuration interface}.
+   */
   readonly config: LookoutEquipmentClientResolvedConfig;
 
   constructor(configuration: LookoutEquipmentClientConfig) {

--- a/clients/client-lookoutmetrics/LookoutMetricsClient.ts
+++ b/clients/client-lookoutmetrics/LookoutMetricsClient.ts
@@ -257,7 +257,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type LookoutMetricsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type LookoutMetricsClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -265,8 +265,12 @@ export type LookoutMetricsClientConfig = Partial<__SmithyConfiguration<__HttpHan
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of LookoutMetricsClient class constructor that set the region, credentials and other options.
+ */
+export interface LookoutMetricsClientConfig extends LookoutMetricsClientConfigType {}
 
-export type LookoutMetricsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type LookoutMetricsClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -274,6 +278,10 @@ export type LookoutMetricsClientResolvedConfig = __SmithyResolvedConfiguration<_
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of LookoutMetricsClient class. This is resolved and normalized from the {@link LookoutMetricsClientConfig | constructor configuration interface}.
+ */
+export interface LookoutMetricsClientResolvedConfig extends LookoutMetricsClientResolvedConfigType {}
 
 /**
  * <p>This is the <i>Amazon Lookout for Metrics API Reference</i>. For an introduction to the service
@@ -286,6 +294,9 @@ export class LookoutMetricsClient extends __Client<
   ServiceOutputTypes,
   LookoutMetricsClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of LookoutMetricsClient class. This is resolved and normalized from the {@link LookoutMetricsClientConfig | constructor configuration interface}.
+   */
   readonly config: LookoutMetricsClientResolvedConfig;
 
   constructor(configuration: LookoutMetricsClientConfig) {

--- a/clients/client-mgn/MgnClient.ts
+++ b/clients/client-mgn/MgnClient.ts
@@ -269,7 +269,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MgnClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MgnClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -277,8 +277,12 @@ export type MgnClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MgnClient class constructor that set the region, credentials and other options.
+ */
+export interface MgnClientConfig extends MgnClientConfigType {}
 
-export type MgnClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MgnClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -286,6 +290,10 @@ export type MgnClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MgnClient class. This is resolved and normalized from the {@link MgnClientConfig | constructor configuration interface}.
+ */
+export interface MgnClientResolvedConfig extends MgnClientResolvedConfigType {}
 
 /**
  * <p>The Application Migration Service service.</p>
@@ -296,6 +304,9 @@ export class MgnClient extends __Client<
   ServiceOutputTypes,
   MgnClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MgnClient class. This is resolved and normalized from the {@link MgnClientConfig | constructor configuration interface}.
+   */
   readonly config: MgnClientResolvedConfig;
 
   constructor(configuration: MgnClientConfig) {

--- a/clients/client-mwaa/MWAAClient.ts
+++ b/clients/client-mwaa/MWAAClient.ts
@@ -188,7 +188,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type MWAAClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type MWAAClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -196,8 +196,12 @@ export type MWAAClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOption
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of MWAAClient class constructor that set the region, credentials and other options.
+ */
+export interface MWAAClientConfig extends MWAAClientConfigType {}
 
-export type MWAAClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type MWAAClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -205,6 +209,10 @@ export type MWAAClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandl
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of MWAAClient class. This is resolved and normalized from the {@link MWAAClientConfig | constructor configuration interface}.
+ */
+export interface MWAAClientResolvedConfig extends MWAAClientResolvedConfigType {}
 
 /**
  * <fullname>Amazon Managed Workflows for Apache Airflow</fullname>
@@ -216,6 +224,9 @@ export class MWAAClient extends __Client<
   ServiceOutputTypes,
   MWAAClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of MWAAClient class. This is resolved and normalized from the {@link MWAAClientConfig | constructor configuration interface}.
+   */
   readonly config: MWAAClientResolvedConfig;
 
   constructor(configuration: MWAAClientConfig) {

--- a/clients/client-wellarchitected/WellArchitectedClient.ts
+++ b/clients/client-wellarchitected/WellArchitectedClient.ts
@@ -269,7 +269,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 }
 
-export type WellArchitectedClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
+type WellArchitectedClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &
   ClientDefaults &
   RegionInputConfig &
   EndpointsInputConfig &
@@ -277,8 +277,12 @@ export type WellArchitectedClientConfig = Partial<__SmithyConfiguration<__HttpHa
   HostHeaderInputConfig &
   AwsAuthInputConfig &
   UserAgentInputConfig;
+/**
+ * The configuration interface of WellArchitectedClient class constructor that set the region, credentials and other options.
+ */
+export interface WellArchitectedClientConfig extends WellArchitectedClientConfigType {}
 
-export type WellArchitectedClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
+type WellArchitectedClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
   RegionResolvedConfig &
   EndpointsResolvedConfig &
@@ -286,6 +290,10 @@ export type WellArchitectedClientResolvedConfig = __SmithyResolvedConfiguration<
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
   UserAgentResolvedConfig;
+/**
+ * The resolved configuration interface of WellArchitectedClient class. This is resolved and normalized from the {@link WellArchitectedClientConfig | constructor configuration interface}.
+ */
+export interface WellArchitectedClientResolvedConfig extends WellArchitectedClientResolvedConfigType {}
 
 /**
  * <fullname>AWS Well-Architected Tool</fullname>
@@ -302,6 +310,9 @@ export class WellArchitectedClient extends __Client<
   ServiceOutputTypes,
   WellArchitectedClientResolvedConfig
 > {
+  /**
+   * The resolved configuration of WellArchitectedClient class. This is resolved and normalized from the {@link WellArchitectedClientConfig | constructor configuration interface}.
+   */
   readonly config: WellArchitectedClientResolvedConfig;
 
   constructor(configuration: WellArchitectedClientConfig) {


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2270 and https://github.com/aws/aws-sdk-js-v3/pull/2258

### Description
Uses interface for new clients input.
* New clients were added in https://github.com/aws/aws-sdk-js-v3/pull/2258
* The updated interface was not added for new clients https://github.com/aws/aws-sdk-js-v3/pull/2270

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
