### PR TITLE
docs(clients): descriptive client title

### DIFF
--- a/packages/client-documentation-generator/src/sdk-client-rename-project.ts
+++ b/packages/client-documentation-generator/src/sdk-client-rename-project.ts
@@ -2,11 +2,14 @@ import { readFileSync } from "fs";
 import { Component, RendererComponent } from "typedoc/dist/lib/output/components";
 import { RendererEvent } from "typedoc/dist/lib/output/events";
 
+import { getCurrentClientDirectory } from "./utils";
+
 /**
  * Correct the package name in the navigator.
  */
 @Component({ name: "SdkClientRenameProject" })
 export class SdkClientRenameProjectPlugin extends RendererComponent {
+  private projectName: string | undefined = undefined;
   initialize() {
     this.listenTo(this.owner, {
       [RendererEvent.BEGIN]: this.onRenderedBegin,
@@ -14,10 +17,19 @@ export class SdkClientRenameProjectPlugin extends RendererComponent {
   }
 
   onRenderedBegin(event: RendererEvent) {
-    const { fullFileName } = event.project.files.filter((sourceFile) =>
-      sourceFile.fileName.endsWith("/package.json")
-    )[0];
-    const { name } = JSON.parse(readFileSync(fullFileName).toString());
-    event.project.name = name;
+    if (!this.projectName) {
+      const clientDirectory = getCurrentClientDirectory(event);
+      const metadataDir = clientDirectory.files.filter((sourceFile) =>
+        sourceFile.fileName.endsWith("/package.json")
+      )?.[0]?.fullFileName;
+      const { name } = metadataDir || JSON.parse(readFileSync(metadataDir).toString());
+      const serviceIdReflection = clientDirectory.files
+        ?.filter((sourceFile) => sourceFile.fileName.endsWith("/runtimeConfig.shared.ts"))?.[0]
+        .reflections.filter((reflection) => reflection.name === "serviceId")?.[0];
+      this.projectName = serviceIdReflection /* serviceIdReflection.defaultValue looks like '"S3"' */
+        ? `${(serviceIdReflection as any).defaultValue.match(/"(.*)"/)[1]} Client - AWS SDK for JavaScript v3`
+        : name;
+    }
+    event.project.name = this.projectName;
   }
 }

--- a/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -10,6 +10,8 @@ import { Component, RendererComponent } from "typedoc/dist/lib/output/components
 import { PageEvent } from "typedoc/dist/lib/output/events";
 import { NavigationItem } from "typedoc/dist/lib/output/models/NavigationItem";
 
+import { getCurrentClientDirectory } from "./utils";
+
 /**
  * Group the ToC for easier observability.
  */
@@ -164,10 +166,7 @@ export class SdkClientTocPlugin extends RendererComponent {
     while (projectModel.constructor.name !== "ProjectReflection" && !projectModel.kindOf(ReflectionKind.SomeModule)) {
       projectModel = projectModel.parent as ProjectReflection;
     }
-    const clientsDirectory = (projectModel as ProjectReflection).directory.directories["clients"].directories;
-    const dir = Object.values(clientsDirectory).filter((directory) =>
-      directory?.files.find((file) => file.name.endsWith("Client.ts"))
-    )[0];
-    return dirname(dir?.files.find((file) => file.name.endsWith("Client.ts")).fullFileName);
+    const clientsDirectory = getCurrentClientDirectory({ project: projectModel as ProjectReflection });
+    return dirname(clientsDirectory?.files.find((file) => file.name.endsWith("Client.ts")).fullFileName);
   }
 }

--- a/packages/client-documentation-generator/src/utils.ts
+++ b/packages/client-documentation-generator/src/utils.ts
@@ -1,0 +1,8 @@
+import { ProjectReflection, SourceDirectory } from "typedoc/dist/lib/models";
+
+export const getCurrentClientDirectory = (event: { project: ProjectReflection }): SourceDirectory => {
+  const clientsDirectory = event.project.directory.directories["clients"].directories;
+  return Object.values(clientsDirectory).filter((directory) =>
+    directory?.files.find((file) => file.name.endsWith("Client.ts"))
+  )[0];
+};


### PR DESCRIPTION
### Description
Currently the google search doesn't show link
<img width="649" alt="Screen Shot 2021-04-29 at 1 25 39 PM" src="https://user-images.githubusercontent.com/7614947/116614153-6a0f4300-a8ee-11eb-8b2a-9cd94faf3466.png">


with this change, each client will have a more descriptive title:
![Screen Shot 2021-04-29 at 12 06 56 PM](https://user-images.githubusercontent.com/7614947/116614064-4ba94780-a8ee-11eb-8071-25dea8fe18e7.png)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
