### PR TITLE
feat(endpoint-cache): add EndpointCache for Endpoint Discovery

### DIFF
--- a/packages/endpoint-cache/LICENSE
+++ b/packages/endpoint-cache/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/endpoint-cache/README.md
+++ b/packages/endpoint-cache/README.md
@@ -13,5 +13,4 @@ You probably shouldn't, at least directly.
 
 - uses `mnemonist/lru-cache` for storing the cache.
 - the `set` operation stores milliseconds elapsed since the UNIX epoch in Expires param based on CachePeriodInMinutes provided in Endpoint.
-- the `get` operation returns all un-expired endpoints with their Expires values.
-- the `getEndpoint` operation returns a randomly selected un-expired endpoint.
+- the `get` operation returns all endpoints with their Expires values.

--- a/packages/endpoint-cache/README.md
+++ b/packages/endpoint-cache/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/endpoint-cache
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/endpoint-cache/latest.svg)](https://www.npmjs.com/package/@aws-sdk/endpoint-cache)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/endpoint-cache.svg)](https://www.npmjs.com/package/@aws-sdk/endpoint-cache)

--- a/packages/endpoint-cache/README.md
+++ b/packages/endpoint-cache/README.md
@@ -13,4 +13,5 @@ You probably shouldn't, at least directly.
 
 - uses `mnemonist/lru-cache` for storing the cache.
 - the `set` operation stores milliseconds elapsed since the UNIX epoch in Expires param based on CachePeriodInMinutes provided in Endpoint.
-- the `get` operation returns a random un-expired endpoint.
+- the `get` operation returns all un-expired endpoints with their Expires values.
+- the `getEndpoint` operation returns a randomly selected un-expired endpoint.

--- a/packages/endpoint-cache/README.md
+++ b/packages/endpoint-cache/README.md
@@ -2,3 +2,9 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/endpoint-cache/latest.svg)](https://www.npmjs.com/package/@aws-sdk/endpoint-cache)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/endpoint-cache.svg)](https://www.npmjs.com/package/@aws-sdk/endpoint-cache)
+
+> An internal package
+
+## Usage
+
+You probably shouldn't, at least directly.

--- a/packages/endpoint-cache/README.md
+++ b/packages/endpoint-cache/README.md
@@ -13,4 +13,5 @@ You probably shouldn't, at least directly.
 
 - uses `mnemonist/lru-cache` for storing the cache.
 - the `set` operation stores milliseconds elapsed since the UNIX epoch in Expires param based on CachePeriodInMinutes provided in Endpoint.
-- the `get` operation returns all endpoints with their Expires values.
+- the `get` operation returns all un-expired endpoints with their Expires values.
+- the `getEndpoint` operation returns a randomly selected un-expired endpoint.

--- a/packages/endpoint-cache/README.md
+++ b/packages/endpoint-cache/README.md
@@ -8,3 +8,9 @@
 ## Usage
 
 You probably shouldn't, at least directly.
+
+## EndpointCache
+
+- uses `mnemonist/lru-cache` for storing the cache.
+- the `set` operation stores milliseconds elapsed since the UNIX epoch in Expires param based on CachePeriodInMinutes provided in Endpoint.
+- the `get` operation returns a random un-expired endpoint.

--- a/packages/endpoint-cache/jest.config.js
+++ b/packages/endpoint-cache/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -17,6 +17,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "mnemonist": "0.38.3",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aws-sdk/endpoint-cache",
+  "version": "3.0.0",
+  "scripts": {
+    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build": "yarn build:es && yarn build:cjs",
+    "test": "jest --passWithNoTests"
+  },
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "types": "./dist/types/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.4",
+    "@types/node": "^10.0.0",
+    "jest": "^26.1.0",
+    "typescript": "~4.2.4"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "types/*": [
+        "types/ts3.4/*"
+      ]
+    }
+  },
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/endpoint-cache",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/endpoint-cache"
+  }
+}

--- a/packages/endpoint-cache/src/Endpoint.ts
+++ b/packages/endpoint-cache/src/Endpoint.ts
@@ -1,0 +1,11 @@
+export interface Endpoint {
+  /**
+   * <p>An endpoint address.</p>
+   */
+  Address: string;
+
+  /**
+   * <p>The TTL for the endpoint, in minutes.</p>
+   */
+  CachePeriodInMinutes: number;
+}

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -103,25 +103,27 @@ describe(EndpointCache.name, () => {
       expect(set).toHaveBeenCalledWith(key, []);
     });
 
-    it("returns one of the un-expired endpoints", () => {
-      expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.get(key));
-      verifyHasAndGetCalls();
-      expect(set).not.toHaveBeenCalled();
-    });
-
-    it("returns un-expired endpoint", () => {
-      jest.spyOn(Date, "now").mockImplementation(() => now + 90 * 1000);
-      expect(endpointCache.get(key)).toEqual(mockEndpoints[1].Address);
-      verifyHasAndGetCalls();
-      expect(set).not.toHaveBeenCalled();
-    });
-
-    [0, 1].forEach((index) => {
-      it(`returns un-expired endpoint at index ${index}`, () => {
-        jest.spyOn(Math, "floor").mockImplementation(() => index);
-        expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.get(key));
+    describe("getEndpoint", () => {
+      it("returns one of the un-expired endpoints", () => {
+        expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
         verifyHasAndGetCalls();
         expect(set).not.toHaveBeenCalled();
+      });
+
+      it("returns un-expired endpoint", () => {
+        jest.spyOn(Date, "now").mockImplementation(() => now + 90 * 1000);
+        expect(endpointCache.getEndpoint(key)).toEqual(mockEndpoints[1].Address);
+        verifyHasAndGetCalls();
+        expect(set).not.toHaveBeenCalled();
+      });
+
+      [0, 1].forEach((index) => {
+        it(`returns un-expired endpoint at index ${index}`, () => {
+          jest.spyOn(Math, "floor").mockImplementation(() => index);
+          expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
+          verifyHasAndGetCalls();
+          expect(set).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -1,0 +1,113 @@
+import { LRUCache } from "mnemonist";
+
+import { Endpoint } from "./Endpoint";
+import { EndpointCache } from "./EndpointCache";
+
+jest.mock("mnemonist");
+
+describe(EndpointCache.name, () => {
+  const now = Date.now();
+  const set = jest.fn();
+  const get = jest.fn();
+  const has = jest.fn();
+  const clear = jest.fn();
+
+  const mockEndpoints = [
+    { Address: "addressA", CachePeriodInMinutes: 1 },
+    { Address: "addressB", CachePeriodInMinutes: 2 },
+  ];
+
+  const getEndpointsWithExpiry = (endpoints: Endpoint[]) =>
+    endpoints.map(({ Address = "", CachePeriodInMinutes = 1 }) => ({
+      Address,
+      Expires: now + CachePeriodInMinutes * 60 * 1000,
+    }));
+
+  const getMaxCachePeriodInMins = (endpoints: Endpoint[]) =>
+    Math.max(...endpoints.map((endpoint) => endpoint.CachePeriodInMinutes));
+
+  beforeEach(() => {
+    ((LRUCache as unknown) as jest.Mock).mockReturnValueOnce({
+      set,
+      get,
+      has,
+      clear,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes capacity to LRUCache", () => {
+    const capacity = 100;
+    new EndpointCache(capacity);
+    expect(LRUCache).toHaveBeenCalledTimes(1);
+    expect(LRUCache).toHaveBeenCalledWith(capacity);
+  });
+
+  describe("get", () => {
+    let endpointCache;
+    const key = "key";
+
+    beforeEach(() => {
+      has.mockReturnValue(true);
+      get.mockReturnValue(getEndpointsWithExpiry(mockEndpoints));
+      jest.spyOn(Date, "now").mockImplementation(() => now);
+      endpointCache = new EndpointCache(100);
+    });
+
+    const verifyHasAndGetCalls = () => {
+      expect(has).toHaveBeenCalledTimes(1);
+      expect(has).toHaveBeenCalledWith(key);
+      expect(get).toHaveBeenCalledTimes(1);
+      expect(get).toHaveBeenCalledWith(key);
+    };
+
+    it("returns undefined if cache doesn't have key", () => {
+      has.mockReturnValueOnce(false);
+      expect(endpointCache.get(key)).toBeUndefined();
+      expect(has).toHaveBeenCalledTimes(1);
+      expect(has).toHaveBeenCalledWith(key);
+      expect(get).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined if cache returns undefined for key", () => {
+      get.mockReturnValueOnce(undefined);
+      expect(endpointCache.get(key)).toBeUndefined();
+      verifyHasAndGetCalls();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined if endpoints have expired", () => {
+      const maxCachePeriod = getMaxCachePeriodInMins(mockEndpoints);
+      jest.spyOn(Date, "now").mockImplementation(() => now + (maxCachePeriod + 1) * 60 * 1000);
+      expect(endpointCache.get(key)).toBeUndefined();
+      verifyHasAndGetCalls();
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith(key, []);
+    });
+
+    it("returns one of the un-expired endpoints", () => {
+      expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.get(key));
+      verifyHasAndGetCalls();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it("returns un-expired endpoint", () => {
+      jest.spyOn(Date, "now").mockImplementation(() => now + 90 * 1000);
+      expect(endpointCache.get(key)).toEqual(mockEndpoints[1].Address);
+      verifyHasAndGetCalls();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    [0, 1].forEach((index) => {
+      it(`returns un-expired endpoint at index ${index}`, () => {
+        jest.spyOn(Math, "floor").mockImplementation(() => index);
+        expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.get(key));
+        verifyHasAndGetCalls();
+        expect(set).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -144,20 +144,6 @@ describe(EndpointCache.name, () => {
         }))
       );
     });
-
-    it("sets Address to empty string if not passed", () => {
-      const mockEnpointsNoAddr = [{ CachePeriodInMinutes: 1 }];
-      endpointCache.set(key, mockEnpointsNoAddr);
-      expect(set).toHaveBeenCalledTimes(1);
-      expect(set).toHaveBeenCalledWith(key, [{ Address: "", Expires: now + 60 * 1000 }]);
-    });
-
-    it("sets Expires in one minute if CachePeriodInMinutes is not passed", () => {
-      const mockEnpointsNoAddr = [{ Address: "address" }];
-      endpointCache.set(key, mockEnpointsNoAddr);
-      expect(set).toHaveBeenCalledTimes(1);
-      expect(set).toHaveBeenCalledWith(key, [{ Address: "address", Expires: now + 60 * 1000 }]);
-    });
   });
 
   it("delete", () => {

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -6,6 +6,10 @@ import { EndpointCache } from "./EndpointCache";
 jest.mock("mnemonist");
 
 describe(EndpointCache.name, () => {
+  let endpointCache;
+  const capacity = 100;
+  const key = "key";
+
   const now = Date.now();
   const set = jest.fn();
   const get = jest.fn();
@@ -33,6 +37,7 @@ describe(EndpointCache.name, () => {
       has,
       clear,
     });
+    endpointCache = new EndpointCache(capacity);
   });
 
   afterEach(() => {
@@ -40,21 +45,15 @@ describe(EndpointCache.name, () => {
   });
 
   it("passes capacity to LRUCache", () => {
-    const capacity = 100;
-    new EndpointCache(capacity);
     expect(LRUCache).toHaveBeenCalledTimes(1);
     expect(LRUCache).toHaveBeenCalledWith(capacity);
   });
 
   describe("get", () => {
-    let endpointCache;
-    const key = "key";
-
     beforeEach(() => {
       has.mockReturnValue(true);
       get.mockReturnValue(getEndpointsWithExpiry(mockEndpoints));
       jest.spyOn(Date, "now").mockImplementation(() => now);
-      endpointCache = new EndpointCache(100);
     });
 
     const verifyHasAndGetCalls = () => {
@@ -112,12 +111,8 @@ describe(EndpointCache.name, () => {
   });
 
   describe("set", () => {
-    let endpointCache;
-    const key = "key";
-
     beforeEach(() => {
       jest.spyOn(Date, "now").mockImplementation(() => now);
-      endpointCache = new EndpointCache(100);
     });
 
     it("converts CachePeriodInMinutes to Expires before caching", () => {
@@ -145,5 +140,22 @@ describe(EndpointCache.name, () => {
       expect(set).toHaveBeenCalledTimes(1);
       expect(set).toHaveBeenCalledWith(key, [{ Address: "address", Expires: now + 60 * 1000 }]);
     });
+  });
+
+  it("remove", () => {
+    endpointCache.remove(key);
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith(key, []);
+  });
+
+  it("has", () => {
+    endpointCache.has(key);
+    expect(has).toHaveBeenCalledTimes(1);
+    expect(has).toHaveBeenCalledWith(key);
+  });
+
+  it("clear", () => {
+    endpointCache.clear();
+    expect(clear).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -28,6 +28,9 @@ describe(EndpointCache.name, () => {
       Expires: now + CachePeriodInMinutes * 60 * 1000,
     }));
 
+  const getMaxCachePeriodInMins = (endpoints: Endpoint[]) =>
+    Math.max(...endpoints.map((endpoint) => endpoint.CachePeriodInMinutes));
+
   beforeEach(() => {
     ((LRUCache as unknown) as jest.Mock).mockReturnValueOnce({
       set,
@@ -57,41 +60,71 @@ describe(EndpointCache.name, () => {
       jest.spyOn(Date, "now").mockImplementation(() => now);
     });
 
-    describe("returns undefined", () => {
-      it("if cache doesn't have key", () => {
-        has.mockReturnValueOnce(false);
-        expect(endpointCache.get(key)).toBeUndefined();
-        expect(has).toHaveBeenCalledWith(key);
-        expect(peek).not.toHaveBeenCalled();
-        expect(get).not.toHaveBeenCalled();
-        expect(set).not.toHaveBeenCalled();
-      });
+    const verifyHasAndGetCalls = () => {
+      expect(has).toHaveBeenCalledTimes(1);
+      expect(has).toHaveBeenCalledWith(key);
+      expect(get).toHaveBeenCalledTimes(1);
+      expect(get).toHaveBeenCalledWith(key);
+    };
 
-      it("if cache has empty array", () => {
-        peek.mockReturnValueOnce([]);
-        expect(endpointCache.get(key)).toBeUndefined();
-        expect(has).toHaveBeenCalledWith(key);
-        expect(peek).toHaveBeenCalledWith(key);
-        expect(get).not.toHaveBeenCalled();
-        expect(set).not.toHaveBeenCalled();
-      });
-
-      it("if cache returns undefined for key", () => {
-        get.mockReturnValueOnce(undefined);
-        expect(endpointCache.get(key)).toBeUndefined();
-        expect(has).toHaveBeenCalledWith(key);
-        expect(peek).toHaveBeenCalledWith(key);
-        expect(get).toHaveBeenCalledWith(key);
-        expect(set).not.toHaveBeenCalled();
-      });
+    it("returns undefined if cache doesn't have key", () => {
+      has.mockReturnValueOnce(false);
+      expect(endpointCache.get(key)).toBeUndefined();
+      expect(has).toHaveBeenCalledTimes(1);
+      expect(has).toHaveBeenCalledWith(key);
+      expect(peek).not.toHaveBeenCalled();
+      expect(get).not.toHaveBeenCalled();
     });
 
-    it("returns endpoints if available", () => {
-      expect(endpointCache.get(key)).toEqual(getEndpointsWithExpiry(mockEndpoints));
+    it("returns undefined if cache has empty array", () => {
+      has.mockReturnValueOnce(true);
+      peek.mockReturnValueOnce([]);
+      expect(endpointCache.get(key)).toBeUndefined();
+      expect(has).toHaveBeenCalledTimes(1);
       expect(has).toHaveBeenCalledWith(key);
+      expect(peek).toHaveBeenCalledTimes(1);
       expect(peek).toHaveBeenCalledWith(key);
-      expect(get).toHaveBeenCalledWith(key);
+      expect(get).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined if cache returns undefined for key", () => {
+      get.mockReturnValueOnce(undefined);
+      expect(endpointCache.get(key)).toBeUndefined();
+      verifyHasAndGetCalls();
       expect(set).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined if endpoints have expired", () => {
+      const maxCachePeriod = getMaxCachePeriodInMins(mockEndpoints);
+      jest.spyOn(Date, "now").mockImplementation(() => now + (maxCachePeriod + 1) * 60 * 1000);
+      expect(endpointCache.get(key)).toBeUndefined();
+      verifyHasAndGetCalls();
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith(key, []);
+    });
+
+    describe("getEndpoint", () => {
+      it("returns one of the un-expired endpoints", () => {
+        expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
+        verifyHasAndGetCalls();
+        expect(set).not.toHaveBeenCalled();
+      });
+
+      it("returns un-expired endpoint", () => {
+        jest.spyOn(Date, "now").mockImplementation(() => now + 90 * 1000);
+        expect(endpointCache.getEndpoint(key)).toEqual(mockEndpoints[1].Address);
+        verifyHasAndGetCalls();
+        expect(set).not.toHaveBeenCalled();
+      });
+
+      [0, 1].forEach((index) => {
+        it(`returns un-expired endpoint at index ${index}`, () => {
+          jest.spyOn(Math, "floor").mockImplementation(() => index);
+          expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
+          verifyHasAndGetCalls();
+          expect(set).not.toHaveBeenCalled();
+        });
+      });
     });
   });
 

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -28,9 +28,6 @@ describe(EndpointCache.name, () => {
       Expires: now + CachePeriodInMinutes * 60 * 1000,
     }));
 
-  const getMaxCachePeriodInMins = (endpoints: Endpoint[]) =>
-    Math.max(...endpoints.map((endpoint) => endpoint.CachePeriodInMinutes));
-
   beforeEach(() => {
     ((LRUCache as unknown) as jest.Mock).mockReturnValueOnce({
       set,
@@ -60,71 +57,41 @@ describe(EndpointCache.name, () => {
       jest.spyOn(Date, "now").mockImplementation(() => now);
     });
 
-    const verifyHasAndGetCalls = () => {
-      expect(has).toHaveBeenCalledTimes(1);
-      expect(has).toHaveBeenCalledWith(key);
-      expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith(key);
-    };
+    describe("returns undefined", () => {
+      it("if cache doesn't have key", () => {
+        has.mockReturnValueOnce(false);
+        expect(endpointCache.get(key)).toBeUndefined();
+        expect(has).toHaveBeenCalledWith(key);
+        expect(peek).not.toHaveBeenCalled();
+        expect(get).not.toHaveBeenCalled();
+        expect(set).not.toHaveBeenCalled();
+      });
 
-    it("returns undefined if cache doesn't have key", () => {
-      has.mockReturnValueOnce(false);
-      expect(endpointCache.get(key)).toBeUndefined();
-      expect(has).toHaveBeenCalledTimes(1);
-      expect(has).toHaveBeenCalledWith(key);
-      expect(peek).not.toHaveBeenCalled();
-      expect(get).not.toHaveBeenCalled();
+      it("if cache has empty array", () => {
+        peek.mockReturnValueOnce([]);
+        expect(endpointCache.get(key)).toBeUndefined();
+        expect(has).toHaveBeenCalledWith(key);
+        expect(peek).toHaveBeenCalledWith(key);
+        expect(get).not.toHaveBeenCalled();
+        expect(set).not.toHaveBeenCalled();
+      });
+
+      it("if cache returns undefined for key", () => {
+        get.mockReturnValueOnce(undefined);
+        expect(endpointCache.get(key)).toBeUndefined();
+        expect(has).toHaveBeenCalledWith(key);
+        expect(peek).toHaveBeenCalledWith(key);
+        expect(get).toHaveBeenCalledWith(key);
+        expect(set).not.toHaveBeenCalled();
+      });
     });
 
-    it("returns undefined if cache has empty array", () => {
-      has.mockReturnValueOnce(true);
-      peek.mockReturnValueOnce([]);
-      expect(endpointCache.get(key)).toBeUndefined();
-      expect(has).toHaveBeenCalledTimes(1);
+    it("returns endpoints if available", () => {
+      expect(endpointCache.get(key)).toEqual(getEndpointsWithExpiry(mockEndpoints));
       expect(has).toHaveBeenCalledWith(key);
-      expect(peek).toHaveBeenCalledTimes(1);
       expect(peek).toHaveBeenCalledWith(key);
-      expect(get).not.toHaveBeenCalled();
-    });
-
-    it("returns undefined if cache returns undefined for key", () => {
-      get.mockReturnValueOnce(undefined);
-      expect(endpointCache.get(key)).toBeUndefined();
-      verifyHasAndGetCalls();
+      expect(get).toHaveBeenCalledWith(key);
       expect(set).not.toHaveBeenCalled();
-    });
-
-    it("returns undefined if endpoints have expired", () => {
-      const maxCachePeriod = getMaxCachePeriodInMins(mockEndpoints);
-      jest.spyOn(Date, "now").mockImplementation(() => now + (maxCachePeriod + 1) * 60 * 1000);
-      expect(endpointCache.get(key)).toBeUndefined();
-      verifyHasAndGetCalls();
-      expect(set).toHaveBeenCalledTimes(1);
-      expect(set).toHaveBeenCalledWith(key, []);
-    });
-
-    describe("getEndpoint", () => {
-      it("returns one of the un-expired endpoints", () => {
-        expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
-        verifyHasAndGetCalls();
-        expect(set).not.toHaveBeenCalled();
-      });
-
-      it("returns un-expired endpoint", () => {
-        jest.spyOn(Date, "now").mockImplementation(() => now + 90 * 1000);
-        expect(endpointCache.getEndpoint(key)).toEqual(mockEndpoints[1].Address);
-        verifyHasAndGetCalls();
-        expect(set).not.toHaveBeenCalled();
-      });
-
-      [0, 1].forEach((index) => {
-        it(`returns un-expired endpoint at index ${index}`, () => {
-          jest.spyOn(Math, "floor").mockImplementation(() => index);
-          expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
-          verifyHasAndGetCalls();
-          expect(set).not.toHaveBeenCalled();
-        });
-      });
     });
   });
 

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -110,4 +110,40 @@ describe(EndpointCache.name, () => {
       });
     });
   });
+
+  describe("set", () => {
+    let endpointCache;
+    const key = "key";
+
+    beforeEach(() => {
+      jest.spyOn(Date, "now").mockImplementation(() => now);
+      endpointCache = new EndpointCache(100);
+    });
+
+    it("converts CachePeriodInMinutes to Expires before caching", () => {
+      endpointCache.set(key, mockEndpoints);
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith(
+        key,
+        mockEndpoints.map(({ Address, CachePeriodInMinutes }) => ({
+          Address,
+          Expires: now + CachePeriodInMinutes * 60 * 1000,
+        }))
+      );
+    });
+
+    it("sets Address to empty string if not passed", () => {
+      const mockEnpointsNoAddr = [{ CachePeriodInMinutes: 1 }];
+      endpointCache.set(key, mockEnpointsNoAddr);
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith(key, [{ Address: "", Expires: now + 60 * 1000 }]);
+    });
+
+    it("sets Expires in one minute if CachePeriodInMinutes is not passed", () => {
+      const mockEnpointsNoAddr = [{ Address: "address" }];
+      endpointCache.set(key, mockEnpointsNoAddr);
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith(key, [{ Address: "address", Expires: now + 60 * 1000 }]);
+    });
+  });
 });

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -142,8 +142,8 @@ describe(EndpointCache.name, () => {
     });
   });
 
-  it("remove", () => {
-    endpointCache.remove(key);
+  it("delete", () => {
+    endpointCache.delete(key);
     expect(set).toHaveBeenCalledTimes(1);
     expect(set).toHaveBeenCalledWith(key, []);
   });

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -14,7 +14,22 @@ export class EndpointCache {
   }
 
   /**
-   * Returns endpoints for the given key.
+   * Returns an un-expired endpoint for the given key.
+   *
+   * @param endpointsWithExpiry
+   * @returns
+   */
+  getEndpoint(key: string) {
+    const endpointsWithExpiry = this.get(key);
+    if (!endpointsWithExpiry || endpointsWithExpiry.length === 0) {
+      return undefined;
+    }
+    const endpoints = endpointsWithExpiry.map((endpoint) => endpoint.Address);
+    return endpoints[Math.floor(Math.random() * endpoints.length)];
+  }
+
+  /**
+   * Returns un-expired endpoints for the given key.
    *
    * @param key
    * @returns
@@ -24,12 +39,15 @@ export class EndpointCache {
       return;
     }
 
-    const endpointsWithExpiry = this.cache.get(key);
-    if (!endpointsWithExpiry) {
+    const value = this.cache.get(key);
+    if (!value) {
       return;
     }
 
+    const now = Date.now();
+    const endpointsWithExpiry = value.filter((endpoint) => now < endpoint.Expires);
     if (endpointsWithExpiry.length === 0) {
+      this.delete(key);
       return undefined;
     }
 

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -83,7 +83,17 @@ export class EndpointCache {
    * @returns {boolean}
    */
   has(key: string): boolean {
-    return this.cache.has(key);
+    if (!this.cache.has(key)) {
+      return false;
+    }
+
+    // Remove call for peek, once remove/delete support is added upstream
+    // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
+    const endpoints = this.cache.peek(key);
+    if (!endpoints) {
+      return false;
+    }
+    return endpoints.length > 0;
   }
 
   /**

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -16,14 +16,17 @@ export class EndpointCache {
   private getEndpoint(endpointsWithExpiry: EndpointWithExpiry[]) {
     const now = Date.now();
     const endpoints = endpointsWithExpiry
-      .filter((endpoint) => now > endpoint.Expires)
+      .filter((endpoint) => now < endpoint.Expires)
       .map((endpoint) => endpoint.Address);
     return endpoints[Math.floor(Math.random() * endpoints.length)];
   }
 
   get(key: string) {
-    const endpointsWithExpiry = this.cache.get(key);
+    if (!this.has(key)) {
+      return;
+    }
 
+    const endpointsWithExpiry = this.cache.get(key);
     if (!endpointsWithExpiry) {
       return;
     }
@@ -41,7 +44,7 @@ export class EndpointCache {
       key,
       endpoints.map(({ Address = "", CachePeriodInMinutes = 1 }) => ({
         Address,
-        Expires: now + CachePeriodInMinutes * 60 * 100,
+        Expires: now + CachePeriodInMinutes * 60 * 1000,
       }))
     );
   }

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -52,6 +52,10 @@ export class EndpointCache {
     this.cache.set(key, []);
   }
 
+  has(key: string) {
+    return this.cache.has(key);
+  }
+
   clear() {
     this.cache.clear();
   }

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -14,22 +14,7 @@ export class EndpointCache {
   }
 
   /**
-   * Returns an un-expired endpoint for the given key.
-   *
-   * @param endpointsWithExpiry
-   * @returns
-   */
-  getEndpoint(key: string) {
-    const endpointsWithExpiry = this.get(key);
-    if (!endpointsWithExpiry || endpointsWithExpiry.length === 0) {
-      return undefined;
-    }
-    const endpoints = endpointsWithExpiry.map((endpoint) => endpoint.Address);
-    return endpoints[Math.floor(Math.random() * endpoints.length)];
-  }
-
-  /**
-   * Returns un-expired endpoints for the given key.
+   * Returns endpoints for the given key.
    *
    * @param key
    * @returns
@@ -39,15 +24,12 @@ export class EndpointCache {
       return;
     }
 
-    const value = this.cache.get(key);
-    if (!value) {
+    const endpointsWithExpiry = this.cache.get(key);
+    if (!endpointsWithExpiry) {
       return;
     }
 
-    const now = Date.now();
-    const endpointsWithExpiry = value.filter((endpoint) => now < endpoint.Expires);
     if (endpointsWithExpiry.length === 0) {
-      this.delete(key);
       return undefined;
     }
 

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -68,7 +68,7 @@ export class EndpointCache {
     const now = Date.now();
     this.cache.set(
       key,
-      endpoints.map(({ Address = "", CachePeriodInMinutes = 1 }) => ({
+      endpoints.map(({ Address, CachePeriodInMinutes }) => ({
         Address,
         Expires: now + CachePeriodInMinutes * 60 * 1000,
       }))

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -39,7 +39,7 @@ export class EndpointCache {
 
     const endpoint = this.getEndpoint(endpointsWithExpiry);
     if (endpoint === undefined) {
-      this.remove(key);
+      this.delete(key);
     }
     return endpoint;
   }
@@ -66,12 +66,12 @@ export class EndpointCache {
   }
 
   /**
-   * Removes the value for the given key in the cache.
+   * Deletes the value for the given key in the cache.
    *
    * @param {string} key
    */
-  remove(key: string) {
-    // Replace with remove call once support is added upstream
+  delete(key: string) {
+    // Replace with remove/delete call once support is added upstream
     // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
     this.cache.set(key, []);
   }

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -1,0 +1,9 @@
+import { LRUCache } from "mnemonist";
+
+export class EndpointCache {
+  private readonly cache: LRUCache<string, string>;
+
+  constructor(capacity: number) {
+    this.cache = new LRUCache(capacity);
+  }
+}

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -1,9 +1,29 @@
 import { LRUCache } from "mnemonist";
 
 export class EndpointCache {
-  private readonly cache: LRUCache<string, string>;
+  // ToDo: remove `| undefined` once LRUCache.remove(key) is available.
+  // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
+  private readonly cache: LRUCache<string, string | undefined>;
 
   constructor(capacity: number) {
     this.cache = new LRUCache(capacity);
+  }
+
+  get(key: string) {
+    return this.cache.get(key);
+  }
+
+  set(key: string, value: string) {
+    this.cache.set(key, value);
+  }
+
+  remove(key: string) {
+    // Replace with remove call once support is added upstream
+    // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
+    this.cache.set(key, undefined);
+  }
+
+  clear() {
+    this.cache.clear();
   }
 }

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -1,9 +1,13 @@
 import { LRUCache } from "mnemonist";
 
+import { Endpoint } from "./Endpoint";
+
+interface EndpointWithExpiry extends Pick<Endpoint, "Address"> {
+  Expires: number;
+}
+
 export class EndpointCache {
-  // ToDo: remove `| undefined` once LRUCache.remove(key) is available.
-  // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
-  private readonly cache: LRUCache<string, string | undefined>;
+  private readonly cache: LRUCache<string, EndpointWithExpiry[]>;
 
   constructor(capacity: number) {
     this.cache = new LRUCache(capacity);
@@ -13,14 +17,21 @@ export class EndpointCache {
     return this.cache.get(key);
   }
 
-  set(key: string, value: string) {
-    this.cache.set(key, value);
+  set(key: string, endpoints: Endpoint[]) {
+    const now = Date.now();
+    this.cache.set(
+      key,
+      endpoints.map(({ Address = "", CachePeriodInMinutes = 1 }) => ({
+        Address,
+        Expires: now + CachePeriodInMinutes * 60 * 100,
+      }))
+    );
   }
 
   remove(key: string) {
     // Replace with remove call once support is added upstream
     // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
-    this.cache.set(key, undefined);
+    this.cache.set(key, []);
   }
 
   clear() {

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -13,8 +13,26 @@ export class EndpointCache {
     this.cache = new LRUCache(capacity);
   }
 
+  private getEndpoint(endpointsWithExpiry: EndpointWithExpiry[]) {
+    const now = Date.now();
+    const endpoints = endpointsWithExpiry
+      .filter((endpoint) => now > endpoint.Expires)
+      .map((endpoint) => endpoint.Address);
+    return endpoints[Math.floor(Math.random() * endpoints.length)];
+  }
+
   get(key: string) {
-    return this.cache.get(key);
+    const endpointsWithExpiry = this.cache.get(key);
+
+    if (!endpointsWithExpiry) {
+      return;
+    }
+
+    const endpoint = this.getEndpoint(endpointsWithExpiry);
+    if (endpoint === undefined) {
+      this.remove(key);
+    }
+    return endpoint;
   }
 
   set(key: string, endpoints: Endpoint[]) {

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -21,6 +21,12 @@ export class EndpointCache {
     return endpoints[Math.floor(Math.random() * endpoints.length)];
   }
 
+  /**
+   * Returns an un-expired endpoint for the given key.
+   *
+   * @param key
+   * @returns
+   */
   get(key: string) {
     if (!this.has(key)) {
       return;
@@ -38,6 +44,16 @@ export class EndpointCache {
     return endpoint;
   }
 
+  /**
+   * Stores the endpoints passed for the key in cache.
+   * If not defined, uses empty string for the Address in endpoint.
+   * If not defined, uses one minute for CachePeriodInMinutes in endpoint.
+   * Stores milliseconds elapsed since the UNIX epoch in Expires param based
+   * on value provided in CachePeriodInMinutes.
+   *
+   * @param key
+   * @param endpoints
+   */
   set(key: string, endpoints: Endpoint[]) {
     const now = Date.now();
     this.cache.set(
@@ -49,16 +65,30 @@ export class EndpointCache {
     );
   }
 
+  /**
+   * Removes the value for the given key in the cache.
+   *
+   * @param {string} key
+   */
   remove(key: string) {
     // Replace with remove call once support is added upstream
     // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
     this.cache.set(key, []);
   }
 
-  has(key: string) {
+  /**
+   * Checks whether the key exists in cache.
+   *
+   * @param {string} key
+   * @returns {boolean}
+   */
+  has(key: string): boolean {
     return this.cache.has(key);
   }
 
+  /**
+   * Clears the cache.
+   */
   clear() {
     this.cache.clear();
   }

--- a/packages/endpoint-cache/src/index.ts
+++ b/packages/endpoint-cache/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./Endpoint";
+export * from "./EndpointCache";

--- a/packages/endpoint-cache/tsconfig.cjs.json
+++ b/packages/endpoint-cache/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/endpoint-cache/tsconfig.es.json
+++ b/packages/endpoint-cache/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8255,6 +8255,13 @@ mkdirp@0.5.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mnemonist@0.38.3:
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
+  integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
+  dependencies:
+    obliterator "^1.6.1"
+
 mocha@^8.0.1:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.3.2.tgz#53406f195fa86fbdebe71f8b1c6fb23221d69fcc"
@@ -8746,6 +8753,11 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/2211

### Description
adds EndpointCache for Endpoint Discovery:
* uses `mnemonist/lru-cache` for storing the cache.
* the `set` operation stores milliseconds elapsed since the UNIX epoch in Expires param based on CachePeriodInMinutes provided in Endpoint.
* the `get` operation returns a random un-expired endpoint. 

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
