### PR TITLE
chore: don't update ssdk symbol visitor

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
@@ -42,7 +42,7 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
         return shape -> {
             Symbol symbol = symbolProvider.toSymbol(shape);
 
-            if (!shape.isServiceShape()) {
+            if (!shape.isServiceShape() || !settings.generateClient()) {
                 return symbol;
             }
 


### PR DESCRIPTION
This disables the symbol visitor decorator for server generation.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
