### PR TITLE
feat: support Sigv4 for non AWS services

### DIFF
--- a/clients/client-accessanalyzer/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/AccessAnalyzerClient.ts
@@ -226,7 +226,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-acm-pca/ACMPCAClient.ts
+++ b/clients/client-acm-pca/ACMPCAClient.ts
@@ -226,7 +226,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-acm/ACMClient.ts
+++ b/clients/client-acm/ACMClient.ts
@@ -187,7 +187,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-alexa-for-business/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/AlexaForBusinessClient.ts
@@ -514,7 +514,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-amp/AmpClient.ts
+++ b/clients/client-amp/AmpClient.ts
@@ -136,7 +136,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-amplify/AmplifyClient.ts
+++ b/clients/client-amplify/AmplifyClient.ts
@@ -259,7 +259,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-amplifybackend/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/AmplifyBackendClient.ts
@@ -205,7 +205,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-api-gateway/APIGatewayClient.ts
+++ b/clients/client-api-gateway/APIGatewayClient.ts
@@ -587,7 +587,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
@@ -124,7 +124,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-apigatewayv2/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/ApiGatewayV2Client.ts
@@ -373,7 +373,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-app-mesh/AppMeshClient.ts
+++ b/clients/client-app-mesh/AppMeshClient.ts
@@ -283,7 +283,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-appconfig/AppConfigClient.ts
+++ b/clients/client-appconfig/AppConfigClient.ts
@@ -265,7 +265,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-appflow/AppflowClient.ts
+++ b/clients/client-appflow/AppflowClient.ts
@@ -196,7 +196,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-appintegrations/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/AppIntegrationsClient.ts
@@ -172,7 +172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
@@ -172,7 +172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
@@ -238,7 +238,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-application-insights/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/ApplicationInsightsClient.ts
@@ -223,7 +223,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-appstream/AppStreamClient.ts
+++ b/clients/client-appstream/AppStreamClient.ts
@@ -316,7 +316,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-appsync/AppSyncClient.ts
+++ b/clients/client-appsync/AppSyncClient.ts
@@ -256,7 +256,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-athena/AthenaClient.ts
+++ b/clients/client-athena/AthenaClient.ts
@@ -247,7 +247,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-auditmanager/AuditManagerClient.ts
+++ b/clients/client-auditmanager/AuditManagerClient.ts
@@ -361,7 +361,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-auto-scaling/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/AutoScalingClient.ts
@@ -421,7 +421,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-backup/BackupClient.ts
+++ b/clients/client-backup/BackupClient.ts
@@ -358,7 +358,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-batch/BatchClient.ts
+++ b/clients/client-batch/BatchClient.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-braket/BraketClient.ts
+++ b/clients/client-braket/BraketClient.ts
@@ -148,7 +148,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-budgets/BudgetsClient.ts
+++ b/clients/client-budgets/BudgetsClient.ts
@@ -208,7 +208,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-chime/ChimeClient.ts
+++ b/clients/client-chime/ChimeClient.ts
@@ -988,7 +988,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloud9/Cloud9Client.ts
+++ b/clients/client-cloud9/Cloud9Client.ts
@@ -181,7 +181,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-clouddirectory/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/CloudDirectoryClient.ts
@@ -394,7 +394,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudformation/CloudFormationClient.ts
+++ b/clients/client-cloudformation/CloudFormationClient.ts
@@ -352,7 +352,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudfront/CloudFrontClient.ts
+++ b/clients/client-cloudfront/CloudFrontClient.ts
@@ -511,7 +511,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
@@ -166,7 +166,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudhsm/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/CloudHSMClient.ts
@@ -184,7 +184,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
@@ -121,7 +121,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudsearch/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/CloudSearchClient.ts
@@ -235,7 +235,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudtrail/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/CloudTrailClient.ts
@@ -178,7 +178,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
@@ -319,7 +319,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
@@ -280,7 +280,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cloudwatch/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/CloudWatchClient.ts
@@ -259,7 +259,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codeartifact/CodeartifactClient.ts
+++ b/clients/client-codeartifact/CodeartifactClient.ts
@@ -286,7 +286,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codebuild/CodeBuildClient.ts
+++ b/clients/client-codebuild/CodeBuildClient.ts
@@ -292,7 +292,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codecommit/CodeCommitClient.ts
+++ b/clients/client-codecommit/CodeCommitClient.ts
@@ -493,7 +493,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codedeploy/CodeDeployClient.ts
+++ b/clients/client-codedeploy/CodeDeployClient.ts
@@ -361,7 +361,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
@@ -187,7 +187,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
@@ -223,7 +223,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codepipeline/CodePipelineClient.ts
+++ b/clients/client-codepipeline/CodePipelineClient.ts
@@ -295,7 +295,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codestar-connections/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/CodeStarConnectionsClient.ts
@@ -157,7 +157,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codestar-notifications/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/CodestarNotificationsClient.ts
@@ -175,7 +175,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-codestar/CodeStarClient.ts
+++ b/clients/client-codestar/CodeStarClient.ts
@@ -181,7 +181,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -581,7 +581,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cognito-identity/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/CognitoIdentityClient.ts
@@ -215,7 +215,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cognito-sync/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/CognitoSyncClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-comprehend/ComprehendClient.ts
+++ b/clients/client-comprehend/ComprehendClient.ts
@@ -442,7 +442,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-comprehendmedical/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/ComprehendMedicalClient.ts
@@ -229,7 +229,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-compute-optimizer/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/ComputeOptimizerClient.ts
@@ -184,7 +184,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-config-service/ConfigServiceClient.ts
+++ b/clients/client-config-service/ConfigServiceClient.ts
@@ -598,7 +598,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-connect-contact-lens/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/ConnectContactLensClient.ts
@@ -128,7 +128,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-connect/ConnectClient.ts
+++ b/clients/client-connect/ConnectClient.ts
@@ -610,7 +610,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-connectparticipant/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/ConnectParticipantClient.ts
@@ -160,7 +160,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
@@ -142,7 +142,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-cost-explorer/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/CostExplorerClient.ts
@@ -274,7 +274,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-customer-profiles/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/CustomerProfilesClient.ts
@@ -241,7 +241,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-data-pipeline/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/DataPipelineClient.ts
@@ -187,7 +187,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
@@ -409,7 +409,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-databrew/DataBrewClient.ts
+++ b/clients/client-databrew/DataBrewClient.ts
@@ -250,7 +250,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-dataexchange/DataExchangeClient.ts
+++ b/clients/client-dataexchange/DataExchangeClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-datasync/DataSyncClient.ts
+++ b/clients/client-datasync/DataSyncClient.ts
@@ -259,7 +259,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-dax/DAXClient.ts
+++ b/clients/client-dax/DAXClient.ts
@@ -205,7 +205,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-detective/DetectiveClient.ts
+++ b/clients/client-detective/DetectiveClient.ts
@@ -172,7 +172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-device-farm/DeviceFarmClient.ts
+++ b/clients/client-device-farm/DeviceFarmClient.ts
@@ -445,7 +445,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-devops-guru/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/DevOpsGuruClient.ts
@@ -226,7 +226,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-direct-connect/DirectConnectClient.ts
+++ b/clients/client-direct-connect/DirectConnectClient.ts
@@ -418,7 +418,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-directory-service/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/DirectoryServiceClient.ts
@@ -385,7 +385,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-dlm/DLMClient.ts
+++ b/clients/client-dlm/DLMClient.ts
@@ -157,7 +157,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-docdb/DocDBClient.ts
+++ b/clients/client-docdb/DocDBClient.ts
@@ -331,7 +331,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
@@ -130,7 +130,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -319,7 +319,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ebs/EBSClient.ts
+++ b/clients/client-ebs/EBSClient.ts
@@ -136,7 +136,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
@@ -123,7 +123,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ec2/EC2Client.ts
+++ b/clients/client-ec2/EC2Client.ts
@@ -2509,7 +2509,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ecr-public/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/ECRPUBLICClient.ts
@@ -226,7 +226,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ecr/ECRClient.ts
+++ b/clients/client-ecr/ECRClient.ts
@@ -274,7 +274,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ecs/ECSClient.ts
+++ b/clients/client-ecs/ECSClient.ts
@@ -352,7 +352,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-efs/EFSClient.ts
+++ b/clients/client-efs/EFSClient.ts
@@ -229,7 +229,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-eks/EKSClient.ts
+++ b/clients/client-eks/EKSClient.ts
@@ -259,7 +259,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
@@ -376,7 +376,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-elastic-inference/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/ElasticInferenceClient.ts
@@ -148,7 +148,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
@@ -256,7 +256,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
@@ -277,7 +277,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
@@ -175,7 +175,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-elasticache/ElastiCacheClient.ts
+++ b/clients/client-elasticache/ElastiCacheClient.ts
@@ -445,7 +445,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
@@ -322,7 +322,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-emr-containers/EMRContainersClient.ts
+++ b/clients/client-emr-containers/EMRContainersClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-emr/EMRClient.ts
+++ b/clients/client-emr/EMRClient.ts
@@ -334,7 +334,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-eventbridge/EventBridgeClient.ts
+++ b/clients/client-eventbridge/EventBridgeClient.ts
@@ -319,7 +319,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-finspace-data/FinspaceDataClient.ts
+++ b/clients/client-finspace-data/FinspaceDataClient.ts
@@ -130,7 +130,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-finspace/FinspaceClient.ts
+++ b/clients/client-finspace/FinspaceClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-firehose/FirehoseClient.ts
+++ b/clients/client-firehose/FirehoseClient.ts
@@ -178,7 +178,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-fis/FisClient.ts
+++ b/clients/client-fis/FisClient.ts
@@ -178,7 +178,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-fms/FMSClient.ts
+++ b/clients/client-fms/FMSClient.ts
@@ -229,7 +229,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-forecast/ForecastClient.ts
+++ b/clients/client-forecast/ForecastClient.ts
@@ -265,7 +265,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-forecastquery/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/ForecastqueryClient.ts
@@ -119,7 +119,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-frauddetector/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/FraudDetectorClient.ts
@@ -337,7 +337,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-fsx/FSxClient.ts
+++ b/clients/client-fsx/FSxClient.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-gamelift/GameLiftClient.ts
+++ b/clients/client-gamelift/GameLiftClient.ts
@@ -574,7 +574,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-glacier/GlacierClient.ts
+++ b/clients/client-glacier/GlacierClient.ts
@@ -267,7 +267,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-global-accelerator/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/GlobalAcceleratorClient.ts
@@ -352,7 +352,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-glue/GlueClient.ts
+++ b/clients/client-glue/GlueClient.ts
@@ -730,7 +730,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-greengrass/GreengrassClient.ts
+++ b/clients/client-greengrass/GreengrassClient.ts
@@ -622,7 +622,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-greengrassv2/GreengrassV2Client.ts
+++ b/clients/client-greengrassv2/GreengrassV2Client.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-groundstation/GroundStationClient.ts
+++ b/clients/client-groundstation/GroundStationClient.ts
@@ -220,7 +220,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-guardduty/GuardDutyClient.ts
+++ b/clients/client-guardduty/GuardDutyClient.ts
@@ -364,7 +364,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-health/HealthClient.ts
+++ b/clients/client-health/HealthClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-healthlake/HealthLakeClient.ts
+++ b/clients/client-healthlake/HealthLakeClient.ts
@@ -157,7 +157,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-honeycode/HoneycodeClient.ts
+++ b/clients/client-honeycode/HoneycodeClient.ts
@@ -175,7 +175,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iam/IAMClient.ts
+++ b/clients/client-iam/IAMClient.ts
@@ -817,7 +817,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-identitystore/IdentitystoreClient.ts
+++ b/clients/client-identitystore/IdentitystoreClient.ts
@@ -130,7 +130,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-imagebuilder/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/ImagebuilderClient.ts
@@ -343,7 +343,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-inspector/InspectorClient.ts
+++ b/clients/client-inspector/InspectorClient.ts
@@ -307,7 +307,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
@@ -169,7 +169,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
@@ -178,7 +178,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -142,7 +142,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot-events-data/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/IoTEventsDataClient.ts
@@ -133,7 +133,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot-events/IoTEventsClient.ts
+++ b/clients/client-iot-events/IoTEventsClient.ts
@@ -205,7 +205,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
@@ -139,7 +139,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot-wireless/IoTWirelessClient.ts
+++ b/clients/client-iot-wireless/IoTWirelessClient.ts
@@ -379,7 +379,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iot/IoTClient.ts
+++ b/clients/client-iot/IoTClient.ts
@@ -1183,7 +1183,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iotanalytics/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/IoTAnalyticsClient.ts
@@ -244,7 +244,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
+++ b/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
@@ -172,7 +172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iotfleethub/IoTFleetHubClient.ts
+++ b/clients/client-iotfleethub/IoTFleetHubClient.ts
@@ -148,7 +148,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
@@ -142,7 +142,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iotsitewise/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/IoTSiteWiseClient.ts
@@ -346,7 +346,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
@@ -286,7 +286,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ivs/IvsClient.ts
+++ b/clients/client-ivs/IvsClient.ts
@@ -220,7 +220,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kafka/KafkaClient.ts
+++ b/clients/client-kafka/KafkaClient.ts
@@ -256,7 +256,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kendra/KendraClient.ts
+++ b/clients/client-kendra/KendraClient.ts
@@ -220,7 +220,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
@@ -280,7 +280,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
@@ -214,7 +214,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
@@ -142,7 +142,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
@@ -119,7 +119,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -129,7 +129,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kinesis-video/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/KinesisVideoClient.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kinesis/KinesisClient.ts
+++ b/clients/client-kinesis/KinesisClient.ts
@@ -244,7 +244,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-kms/KMSClient.ts
+++ b/clients/client-kms/KMSClient.ts
@@ -301,7 +301,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lakeformation/LakeFormationClient.ts
+++ b/clients/client-lakeformation/LakeFormationClient.ts
@@ -214,7 +214,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lambda/LambdaClient.ts
+++ b/clients/client-lambda/LambdaClient.ts
@@ -394,7 +394,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
@@ -265,7 +265,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lex-models-v2/LexModelsV2Client.ts
+++ b/clients/client-lex-models-v2/LexModelsV2Client.ts
@@ -244,7 +244,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
@@ -133,7 +133,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
+++ b/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
@@ -148,7 +148,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-license-manager/LicenseManagerClient.ts
+++ b/clients/client-license-manager/LicenseManagerClient.ts
@@ -295,7 +295,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lightsail/LightsailClient.ts
+++ b/clients/client-lightsail/LightsailClient.ts
@@ -754,7 +754,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-location/LocationClient.ts
+++ b/clients/client-location/LocationClient.ts
@@ -268,7 +268,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lookoutequipment/LookoutEquipmentClient.ts
+++ b/clients/client-lookoutequipment/LookoutEquipmentClient.ts
@@ -220,7 +220,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lookoutmetrics/LookoutMetricsClient.ts
+++ b/clients/client-lookoutmetrics/LookoutMetricsClient.ts
@@ -226,7 +226,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-lookoutvision/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/LookoutVisionClient.ts
@@ -181,7 +181,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-machine-learning/MachineLearningClient.ts
+++ b/clients/client-machine-learning/MachineLearningClient.ts
@@ -235,7 +235,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-macie/MacieClient.ts
+++ b/clients/client-macie/MacieClient.ts
@@ -151,7 +151,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-macie2/Macie2Client.ts
+++ b/clients/client-macie2/Macie2Client.ts
@@ -379,7 +379,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-managedblockchain/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/ManagedBlockchainClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
@@ -136,7 +136,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
@@ -123,7 +123,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
@@ -119,7 +119,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
@@ -130,7 +130,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mediaconnect/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/MediaConnectClient.ts
@@ -220,7 +220,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mediaconvert/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/MediaConvertClient.ts
@@ -202,7 +202,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-medialive/MediaLiveClient.ts
+++ b/clients/client-medialive/MediaLiveClient.ts
@@ -346,7 +346,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mediapackage-vod/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/MediaPackageVodClient.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mediapackage/MediaPackageClient.ts
+++ b/clients/client-mediapackage/MediaPackageClient.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mediastore-data/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/MediaStoreDataClient.ts
@@ -133,7 +133,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mediastore/MediaStoreClient.ts
+++ b/clients/client-mediastore/MediaStoreClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mediatailor/MediaTailorClient.ts
+++ b/clients/client-mediatailor/MediaTailorClient.ts
@@ -244,7 +244,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mgn/MgnClient.ts
+++ b/clients/client-mgn/MgnClient.ts
@@ -238,7 +238,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-migration-hub/MigrationHubClient.ts
+++ b/clients/client-migration-hub/MigrationHubClient.ts
@@ -217,7 +217,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-migrationhub-config/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/MigrationHubConfigClient.ts
@@ -133,7 +133,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mobile/MobileClient.ts
+++ b/clients/client-mobile/MobileClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mq/MqClient.ts
+++ b/clients/client-mq/MqClient.ts
@@ -205,7 +205,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mturk/MTurkClient.ts
+++ b/clients/client-mturk/MTurkClient.ts
@@ -298,7 +298,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-mwaa/MWAAClient.ts
+++ b/clients/client-mwaa/MWAAClient.ts
@@ -157,7 +157,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-neptune/NeptuneClient.ts
+++ b/clients/client-neptune/NeptuneClient.ts
@@ -454,7 +454,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-network-firewall/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/NetworkFirewallClient.ts
@@ -253,7 +253,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-networkmanager/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/NetworkManagerClient.ts
@@ -268,7 +268,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-nimble/NimbleClient.ts
+++ b/clients/client-nimble/NimbleClient.ts
@@ -334,7 +334,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-opsworks/OpsWorksClient.ts
+++ b/clients/client-opsworks/OpsWorksClient.ts
@@ -418,7 +418,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-opsworkscm/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/OpsWorksCMClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-organizations/OrganizationsClient.ts
+++ b/clients/client-organizations/OrganizationsClient.ts
@@ -346,7 +346,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-outposts/OutpostsClient.ts
+++ b/clients/client-outposts/OutpostsClient.ts
@@ -154,7 +154,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-personalize-events/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/PersonalizeEventsClient.ts
@@ -121,7 +121,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
@@ -123,7 +123,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-personalize/PersonalizeClient.ts
+++ b/clients/client-personalize/PersonalizeClient.ts
@@ -301,7 +301,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-pi/PIClient.ts
+++ b/clients/client-pi/PIClient.ts
@@ -123,7 +123,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-pinpoint-email/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/PinpointEmailClient.ts
@@ -349,7 +349,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -163,7 +163,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-pinpoint/PinpointClient.ts
+++ b/clients/client-pinpoint/PinpointClient.ts
@@ -562,7 +562,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-polly/PollyClient.ts
+++ b/clients/client-polly/PollyClient.ts
@@ -154,7 +154,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-pricing/PricingClient.ts
+++ b/clients/client-pricing/PricingClient.ts
@@ -124,7 +124,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-qldb-session/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/QLDBSessionClient.ts
@@ -119,7 +119,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-quicksight/QuickSightClient.ts
+++ b/clients/client-quicksight/QuickSightClient.ts
@@ -529,7 +529,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ram/RAMClient.ts
+++ b/clients/client-ram/RAMClient.ts
@@ -238,7 +238,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-rds-data/RDSDataClient.ts
+++ b/clients/client-rds-data/RDSDataClient.ts
@@ -142,7 +142,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-rds/RDSClient.ts
+++ b/clients/client-rds/RDSClient.ts
@@ -835,7 +835,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-redshift-data/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/RedshiftDataClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-redshift/RedshiftClient.ts
+++ b/clients/client-redshift/RedshiftClient.ts
@@ -670,7 +670,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-rekognition/RekognitionClient.ts
+++ b/clients/client-rekognition/RekognitionClient.ts
@@ -337,7 +337,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
@@ -151,7 +151,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-resource-groups/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/ResourceGroupsClient.ts
@@ -172,7 +172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-robomaker/RoboMakerClient.ts
+++ b/clients/client-robomaker/RoboMakerClient.ts
@@ -403,7 +403,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-route-53-domains/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/Route53DomainsClient.ts
@@ -259,7 +259,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-route-53/Route53Client.ts
+++ b/clients/client-route-53/Route53Client.ts
@@ -445,7 +445,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-route53resolver/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/Route53ResolverClient.ts
@@ -442,7 +442,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-s3-control/S3ControlClient.ts
+++ b/clients/client-s3-control/S3ControlClient.ts
@@ -357,7 +357,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -562,7 +562,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-s3outposts/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/S3OutpostsClient.ts
@@ -121,7 +121,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
@@ -133,7 +133,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
@@ -123,7 +123,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
@@ -121,7 +121,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
@@ -119,7 +119,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sagemaker/SageMakerClient.ts
+++ b/clients/client-sagemaker/SageMakerClient.ts
@@ -1150,7 +1150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-savingsplans/SavingsplansClient.ts
+++ b/clients/client-savingsplans/SavingsplansClient.ts
@@ -163,7 +163,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-schemas/SchemasClient.ts
+++ b/clients/client-schemas/SchemasClient.ts
@@ -229,7 +229,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-secrets-manager/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/SecretsManagerClient.ts
@@ -205,7 +205,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-securityhub/SecurityHubClient.ts
+++ b/clients/client-securityhub/SecurityHubClient.ts
@@ -343,7 +343,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
@@ -184,7 +184,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
@@ -214,7 +214,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-service-catalog/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/ServiceCatalogClient.ts
@@ -565,7 +565,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-service-quotas/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/ServiceQuotasClient.ts
@@ -217,7 +217,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-servicediscovery/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/ServiceDiscoveryClient.ts
@@ -205,7 +205,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ses/SESClient.ts
+++ b/clients/client-ses/SESClient.ts
@@ -481,7 +481,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sesv2/SESv2Client.ts
+++ b/clients/client-sesv2/SESv2Client.ts
@@ -532,7 +532,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sfn/SFNClient.ts
+++ b/clients/client-sfn/SFNClient.ts
@@ -199,7 +199,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-shield/ShieldClient.ts
+++ b/clients/client-shield/ShieldClient.ts
@@ -277,7 +277,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-signer/SignerClient.ts
+++ b/clients/client-signer/SignerClient.ts
@@ -193,7 +193,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sms/SMSClient.ts
+++ b/clients/client-sms/SMSClient.ts
@@ -283,7 +283,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-snowball/SnowballClient.ts
+++ b/clients/client-snowball/SnowballClient.ts
@@ -214,7 +214,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sns/SNSClient.ts
+++ b/clients/client-sns/SNSClient.ts
@@ -265,7 +265,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -187,7 +187,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ssm/SSMClient.ts
+++ b/clients/client-ssm/SSMClient.ts
@@ -793,7 +793,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sso-admin/SSOAdminClient.ts
+++ b/clients/client-sso-admin/SSOAdminClient.ts
@@ -292,7 +292,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -123,7 +123,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -123,7 +123,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-storage-gateway/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/StorageGatewayClient.ts
@@ -535,7 +535,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -143,7 +143,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-support/SupportClient.ts
+++ b/clients/client-support/SupportClient.ts
@@ -187,7 +187,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-swf/SWFClient.ts
+++ b/clients/client-swf/SWFClient.ts
@@ -313,7 +313,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-synthetics/SyntheticsClient.ts
+++ b/clients/client-synthetics/SyntheticsClient.ts
@@ -166,7 +166,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-textract/TextractClient.ts
+++ b/clients/client-textract/TextractClient.ts
@@ -148,7 +148,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -121,7 +121,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -166,7 +166,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
@@ -144,7 +144,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-transcribe/TranscribeClient.ts
+++ b/clients/client-transcribe/TranscribeClient.ts
@@ -262,7 +262,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-transfer/TransferClient.ts
+++ b/clients/client-transfer/TransferClient.ts
@@ -190,7 +190,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-translate/TranslateClient.ts
+++ b/clients/client-translate/TranslateClient.ts
@@ -172,7 +172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-waf-regional/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/WAFRegionalClient.ts
@@ -466,7 +466,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-waf/WAFClient.ts
+++ b/clients/client-waf/WAFClient.ts
@@ -448,7 +448,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-wafv2/WAFV2Client.ts
+++ b/clients/client-wafv2/WAFV2Client.ts
@@ -292,7 +292,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-wellarchitected/WellArchitectedClient.ts
+++ b/clients/client-wellarchitected/WellArchitectedClient.ts
@@ -238,7 +238,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-workdocs/WorkDocsClient.ts
+++ b/clients/client-workdocs/WorkDocsClient.ts
@@ -289,7 +289,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-worklink/WorkLinkClient.ts
+++ b/clients/client-worklink/WorkLinkClient.ts
@@ -277,7 +277,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-workmail/WorkMailClient.ts
+++ b/clients/client-workmail/WorkMailClient.ts
@@ -361,7 +361,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
@@ -126,7 +126,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-workspaces/WorkSpacesClient.ts
+++ b/clients/client-workspaces/WorkSpacesClient.ts
@@ -376,7 +376,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-xray/XRayClient.ts
+++ b/clients/client-xray/XRayClient.ts
@@ -223,7 +223,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
 import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isSigV4Service;
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_CONFIG;
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
@@ -26,6 +27,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
@@ -48,7 +50,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 /**
  * Configure clients with AWS auth configurations and plugin.
  */
-// TODO: Think about AWS Auth supported for only some operations and not all, when not AWS service, with say @auth([])
 @SmithyInternalApi
 public final class AddAwsAuthPlugin implements TypeScriptIntegration {
     static final String STS_CLIENT_PREFIX = "sts-client-";
@@ -67,6 +68,12 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
         if (!isSigV4Service(service)) {
             return;
         }
+
+        if (!isAwsService(service)) {
+            writer.writeDocs("The service name to use as the signing service for AWS Auth\n@internal")
+                    .write("signingName?: string;\n");
+        }
+
         if (!areAllOptionalAuthOperations(model, service)) {
             writer.addImport("Credentials", "__Credentials", TypeScriptDependency.AWS_SDK_TYPES.packageName);
             writer.writeDocs("Default credentials provider; Not available in browser runtime.")
@@ -74,14 +81,24 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
         }
     }
 
+    // Only one of AwsAuth or SigV4Auth should be used
+    // AwsAuth - for AWS services
+    // SigV4Auth - for non AWS services
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_CONFIG)
                     .servicePredicate((m, s) -> isSigV4Service(s)
-                            && !areAllOptionalAuthOperations(m, s)
-                            && !testServiceId(s, "STS"))
+                            && isAwsService(s)
+                            && !testServiceId(s, "STS")
+                            && !areAllOptionalAuthOperations(m, s))
+                    .build(),
+            RuntimeClientPlugin.builder()
+                    .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "SigV4Auth", HAS_CONFIG)
+                    .servicePredicate((m, s) -> isSigV4Service(s)
+                            && !isAwsService(s)
+                            && !areAllOptionalAuthOperations(m, s))
                     .build(),
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.STS_MIDDLEWARE.dependency,
@@ -92,13 +109,31 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
                     // See operationUsesAwsAuth() below for AwsAuth Middleware customizations.
-                    .servicePredicate(
-                        (m, s) -> !testServiceId(s, "STS") && isSigV4Service(s) && !hasOptionalAuthOperation(m, s)
+                    .servicePredicate((m, s) -> isSigV4Service(s)
+                            && isAwsService(s)
+                            && !testServiceId(s, "STS")
+                            && !hasOptionalAuthOperation(m, s)
+                    ).build(),
+            RuntimeClientPlugin.builder()
+                    .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "SigV4Auth", HAS_MIDDLEWARE)
+                    // See operationUsesAwsAuth() below for AwsAuth Middleware customizations.
+                    .servicePredicate((m, s) -> isSigV4Service(s)
+                            && !isAwsService(s)
+                            && !hasOptionalAuthOperation(m, s)
                     ).build(),
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
-                    .operationPredicate(AddAwsAuthPlugin::operationUsesAwsAuth)
+                    .operationPredicate((m, s, o) -> isSigV4Service(s)
+                            && isAwsService(s)
+                            && operationUsesAwsAuth(m, s, o))
+                    .build(),
+            RuntimeClientPlugin.builder()
+                    .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "SigV4Auth", HAS_MIDDLEWARE)
+                    .operationPredicate((m, s, o) -> isSigV4Service(s)
+                            && !isAwsService(s)
+                            && operationUsesAwsAuth(m, s, o))
                     .build()
+
         );
     }
 
@@ -114,6 +149,16 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
             return Collections.emptyMap();
         }
         switch (target) {
+            case SHARED:
+                if (isAwsService(service)) {
+                    return Collections.emptyMap();
+                }
+                String signingService = service.getTrait(SigV4Trait.class).get().getName();
+                return MapUtils.of(
+                    "signingName", writer -> {
+                        writer.write("signingName: $S,", signingService);
+                    }
+                );
             case BROWSER:
                 return MapUtils.of(
                     "credentialDefaultProvider", writer -> {
@@ -208,7 +253,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
         }
 
         // optionalAuth trait doesn't require authentication.
-        if (isSigV4Service(service) && hasOptionalAuthOperation(model, service)) {
+        if (hasOptionalAuthOperation(model, service)) {
             return !operation.hasTrait(OptionalAuthTrait.class);
         }
         return false;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -95,13 +95,10 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                     .write("serviceId?: string;\n");
         }
         if (isSigV4Service(settings, model)) {
-            if (isAwsService(settings, model)) {
-                writer.writeDocs("The AWS region to which this client will send requests")
-                        .write("region?: string | __Provider<string>;\n");
-            } else {
-                writer.writeDocs("The AWS region to use as signing region for AWS Auth")
-                        .write("region?: string | __Provider<string>;\n");
-            }
+            writer.writeDocs(isAwsService(settings, model)
+                                ? "The AWS region to which this client will send requests"
+                                : "The AWS region to use as signing region for AWS Auth")
+                    .write("region?: string | __Provider<string>;\n");
         }
         writer.writeDocs("Value for how many times a request will be made at most in case of retry.")
                 .write("maxAttempts?: number | __Provider<number>;\n");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -95,8 +95,13 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                     .write("serviceId?: string;\n");
         }
         if (isSigV4Service(settings, model)) {
-            writer.writeDocs("The AWS region to which this client will send requests or use as signingRegion")
-                    .write("region?: string | __Provider<string>;\n");
+            if (isAwsService(settings, model)) {
+                writer.writeDocs("The AWS region to which this client will send requests")
+                        .write("region?: string | __Provider<string>;\n");
+            } else {
+                writer.writeDocs("The AWS region to use as signing region for AWS Auth")
+                        .write("region?: string | __Provider<string>;\n");
+            }
         }
         writer.writeDocs("Value for how many times a request will be made at most in case of retry.")
                 .write("maxAttempts?: number | __Provider<number>;\n");
@@ -163,7 +168,6 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                 return defaultConfigs;
             case NODE:
                 if (isSigV4Service) {
-                    // TODO: For non-AWS service, figure out how the region should be configured.
                     defaultConfigs.put("region", writer -> {
                         writer.addDependency(AwsDependency.NODE_CONFIG_PROVIDER);
                         writer.addImport("loadConfig", "loadNodeConfig",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -48,7 +48,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
-                        .servicePredicate((m, s) -> isSigV4Service(s))
+                        .servicePredicate((m, s) -> isAwsService(s) || isSigV4Service(s))
                         .build(),
                 // Only one of Endpoints or CustomEndpoints should be used
                 RuntimeClientPlugin.builder()

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isAwsService;
+import static software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils.isSigV4Service;
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_CONFIG;
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
@@ -47,7 +48,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.CONFIG_RESOLVER.dependency, "Region", HAS_CONFIG)
-                        .servicePredicate((m, s) -> isAwsService(s))
+                        .servicePredicate((m, s) -> isSigV4Service(s))
                         .build(),
                 // Only one of Endpoints or CustomEndpoints should be used
                 RuntimeClientPlugin.builder()

--- a/packages/middleware-signing/src/configuration.spec.ts
+++ b/packages/middleware-signing/src/configuration.spec.ts
@@ -1,55 +1,109 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
 
-import { resolveAwsAuthConfig } from "./configurations";
+import { resolveAwsAuthConfig, resolveSigV4AuthConfig } from "./configurations";
 
-describe("resolveAwsAuthConfig", () => {
-  const inputParams = {
-    credentialDefaultProvider: () => () => Promise.resolve({ accessKeyId: "key", secretAccessKey: "secret" }),
-    region: jest.fn().mockImplementation(() => Promise.resolve("us-foo-1")),
-    regionInfoProvider: () => Promise.resolve({ hostname: "foo.com", partition: "aws" }),
-    serviceId: "foo",
-    sha256: jest.fn().mockReturnValue({
-      update: jest.fn(),
-      digest: jest.fn().mockReturnValue("SHA256 hash"),
-    }),
-    credentials: jest.fn().mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
-  };
+describe("AuthConfig", () => {
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should memoize custom credential provider", async () => {
-    const { signer: signerProvider } = resolveAwsAuthConfig(inputParams);
-    const signer = await signerProvider();
-    const request = new HttpRequest({});
-    const repeats = 10;
-    for (let i = 0; i < repeats; i++) {
-      await signer.sign(request);
-    }
-    expect(inputParams.credentials).toBeCalledTimes(1);
-  });
-
-  it("should refresh custom credential provider if expired", async () => {
-    const FOUR_MINUTES_AND_59_SEC = 299 * 1000;
-    const input = {
-      ...inputParams,
-      credentials: jest
-        .fn()
-        .mockResolvedValueOnce({
-          accessKeyId: "key",
-          secretAccessKey: "secret",
-          expiration: new Date(Date.now() + FOUR_MINUTES_AND_59_SEC),
-        })
-        .mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
+  describe("resolveAwsAuthConfig", () => {
+    const inputParams = {
+      credentialDefaultProvider: () => () => Promise.resolve({ accessKeyId: "key", secretAccessKey: "secret" }),
+      region: jest.fn().mockImplementation(() => Promise.resolve("us-foo-1")),
+      regionInfoProvider: () => Promise.resolve({ hostname: "foo.com", partition: "aws" }),
+      serviceId: "foo",
+      sha256: jest.fn().mockReturnValue({
+        update: jest.fn(),
+        digest: jest.fn().mockReturnValue("SHA256 hash"),
+      }),
+      credentials: jest.fn().mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
     };
-    const { signer: signerProvider } = resolveAwsAuthConfig(input);
-    const signer = await signerProvider();
-    const request = new HttpRequest({});
-    const repeats = 10;
-    for (let i = 0; i < repeats; i++) {
-      await signer.sign(request);
-    }
-    expect(input.credentials).toBeCalledTimes(2);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should memoize custom credential provider", async () => {
+      const { signer: signerProvider } = resolveAwsAuthConfig(inputParams);
+      const signer = await signerProvider();
+      const request = new HttpRequest({});
+      const repeats = 10;
+      for (let i = 0; i < repeats; i++) {
+        await signer.sign(request);
+      }
+      expect(inputParams.credentials).toBeCalledTimes(1);
+    });
+
+    it("should refresh custom credential provider if expired", async () => {
+      const FOUR_MINUTES_AND_59_SEC = 299 * 1000;
+      const input = {
+        ...inputParams,
+        credentials: jest
+          .fn()
+          .mockResolvedValueOnce({
+            accessKeyId: "key",
+            secretAccessKey: "secret",
+            expiration: new Date(Date.now() + FOUR_MINUTES_AND_59_SEC),
+          })
+          .mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
+      };
+      const { signer: signerProvider } = resolveAwsAuthConfig(input);
+      const signer = await signerProvider();
+      const request = new HttpRequest({});
+      const repeats = 10;
+      for (let i = 0; i < repeats; i++) {
+        await signer.sign(request);
+      }
+      expect(input.credentials).toBeCalledTimes(2);
+    });
+  });
+
+  describe("resolveSigV4AuthConfig", () => {
+    const inputParams = {
+      credentialDefaultProvider: () => () => Promise.resolve({ accessKeyId: "key", secretAccessKey: "secret" }),
+      region: jest.fn().mockImplementation(() => Promise.resolve("us-foo-1")),
+      signingName: "foo",
+      sha256: jest.fn().mockReturnValue({
+        update: jest.fn(),
+        digest: jest.fn().mockReturnValue("SHA256 hash"),
+      }),
+      credentials: jest.fn().mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should memoize custom credential provider", async () => {
+      const { signer: signerProvider } = resolveSigV4AuthConfig(inputParams);
+      const signer = await signerProvider();
+      const request = new HttpRequest({});
+      const repeats = 10;
+      for (let i = 0; i < repeats; i++) {
+        await signer.sign(request);
+      }
+      expect(inputParams.credentials).toBeCalledTimes(1);
+    });
+
+    it("should refresh custom credential provider if expired", async () => {
+      const FOUR_MINUTES_AND_59_SEC = 299 * 1000;
+      const input = {
+        ...inputParams,
+        credentials: jest
+          .fn()
+          .mockResolvedValueOnce({
+            accessKeyId: "key",
+            secretAccessKey: "secret",
+            expiration: new Date(Date.now() + FOUR_MINUTES_AND_59_SEC),
+          })
+          .mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
+      };
+      const { signer: signerProvider } = resolveSigV4AuthConfig(input);
+      const signer = await signerProvider();
+      const request = new HttpRequest({});
+      const repeats = 10;
+      for (let i = 0; i < repeats; i++) {
+        await signer.sign(request);
+      }
+      expect(input.credentials).toBeCalledTimes(2);
+    });
   });
 });

--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -5,6 +5,10 @@ import { Credentials, HashConstructor, Provider, RegionInfo, RegionInfoProvider,
 // 5 minutes buffer time the refresh the credential before it really expires
 const CREDENTIAL_EXPIRE_WINDOW = 300000;
 
+// AwsAuth v/s SigV4Auth
+// AwsAuth: specific to SigV4 auth for AWS services
+// SigV4Auth: SigV4 auth for non-AWS services
+
 export interface AwsAuthInputConfig {
   /**
    * The credentials used to sign requests.
@@ -32,6 +36,29 @@ export interface AwsAuthInputConfig {
    */
   signingRegion?: string;
 }
+
+export interface SigV4AuthInputConfig {
+  /**
+   * The credentials used to sign requests.
+   */
+  credentials?: Credentials | Provider<Credentials>;
+
+  /**
+   * The signer to use when signing requests.
+   */
+  signer?: RequestSigner | Provider<RequestSigner>;
+
+  /**
+   * Whether to escape request path when signing the request.
+   */
+  signingEscapePath?: boolean;
+
+  /**
+   * An offset value in milliseconds to apply to all signing times.
+   */
+  systemClockOffset?: number;
+}
+
 interface PreviouslyResolved {
   credentialDefaultProvider: (input: any) => Provider<Credentials>;
   region: string | Provider<string>;
@@ -40,12 +67,22 @@ interface PreviouslyResolved {
   serviceId: string;
   sha256: HashConstructor;
 }
+
+interface SigV4PreviouslyResolved {
+  credentialDefaultProvider: (input: any) => Provider<Credentials>;
+  region: string | Provider<string>;
+  signingName: string;
+  sha256: HashConstructor;
+}
+
 export interface AwsAuthResolvedConfig {
   credentials: Provider<Credentials>;
   signer: Provider<RequestSigner>;
   signingEscapePath: boolean;
   systemClockOffset: number;
 }
+
+export interface SigV4AuthResolvedConfig extends AwsAuthResolvedConfig {}
 
 export const resolveAwsAuthConfig = <T>(
   input: T & AwsAuthInputConfig & PreviouslyResolved
@@ -80,6 +117,37 @@ export const resolveAwsAuthConfig = <T>(
             uriEscapePath: signingEscapePath,
           });
         });
+  }
+
+  return {
+    ...input,
+    systemClockOffset,
+    signingEscapePath,
+    credentials: normalizedCreds,
+    signer,
+  };
+};
+
+// TODO: reduce code duplication
+export const resolveSigV4AuthConfig = <T>(
+  input: T & SigV4AuthInputConfig & SigV4PreviouslyResolved
+): T & SigV4AuthResolvedConfig => {
+  const normalizedCreds = input.credentials
+    ? normalizeCredentialProvider(input.credentials)
+    : input.credentialDefaultProvider(input as any);
+  const { signingEscapePath = true, systemClockOffset = input.systemClockOffset || 0, sha256 } = input;
+  let signer: Provider<RequestSigner>;
+  if (input.signer) {
+    //if signer is supplied by user, normalize it to a function returning a promise for signer.
+    signer = normalizeProvider(input.signer);
+  } else {
+    signer = normalizeProvider(new SignatureV4({
+      credentials: normalizedCreds,
+      region: input.region,
+      service: input.signingName,
+      sha256,
+      uriEscapePath: signingEscapePath,
+    }));
   }
 
   return {

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -58,3 +58,5 @@ export const getAwsAuthPlugin = (options: AwsAuthResolvedConfig): Pluggable<any,
     clientStack.addRelativeTo(awsAuthMiddleware(options), awsAuthMiddlewareOptions);
   },
 });
+
+export const getSigV4AuthPlugin = getAwsAuthPlugin;

--- a/protocol_tests/aws-json/JsonProtocolClient.ts
+++ b/protocol_tests/aws-json/JsonProtocolClient.ts
@@ -160,7 +160,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -2352,8 +2352,8 @@ it("RestJsonInputAndOutputWithNumericHeaders:Response", async () => {
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, {
       "x-float": "1.1",
-      "x-byte": "1",
       "x-long": "123",
+      "x-byte": "1",
       "x-integer": "123",
       "x-integerlist": "1, 2, 3",
       "x-double": "1.1",
@@ -5897,8 +5897,8 @@ it("RestJsonTimestampFormatHeaders:Response", async () => {
     requestHandler: new ResponseDeserializationTestHandler(true, 200, {
       "x-targetepochseconds": "1576540098",
       "x-memberdatetime": "2019-12-16T23:48:18Z",
-      "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
       "x-memberepochseconds": "1576540098",
+      "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
       "x-targethttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
       "x-memberhttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
       "x-targetdatetime": "2019-12-16T23:48:18Z",

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -2352,8 +2352,8 @@ it("RestJsonInputAndOutputWithNumericHeaders:Response", async () => {
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, {
       "x-float": "1.1",
-      "x-long": "123",
       "x-byte": "1",
+      "x-long": "123",
       "x-integer": "123",
       "x-integerlist": "1, 2, 3",
       "x-double": "1.1",
@@ -5897,8 +5897,8 @@ it("RestJsonTimestampFormatHeaders:Response", async () => {
     requestHandler: new ResponseDeserializationTestHandler(true, 200, {
       "x-targetepochseconds": "1576540098",
       "x-memberdatetime": "2019-12-16T23:48:18Z",
-      "x-memberepochseconds": "1576540098",
       "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
+      "x-memberepochseconds": "1576540098",
       "x-targethttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
       "x-memberhttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
       "x-targetdatetime": "2019-12-16T23:48:18Z",

--- a/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
@@ -2315,8 +2315,8 @@ it("InputAndOutputWithNumericHeaders:Response", async () => {
       200,
       {
         "x-float": "1.1",
-        "x-byte": "1",
         "x-long": "123",
+        "x-byte": "1",
         "x-integer": "123",
         "x-integerlist": "1, 2, 3",
         "x-double": "1.1",
@@ -3585,8 +3585,8 @@ it("TimestampFormatHeaders:Response", async () => {
       {
         "x-targetepochseconds": "1576540098",
         "x-memberdatetime": "2019-12-16T23:48:18Z",
-        "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-memberepochseconds": "1576540098",
+        "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-targethttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-memberhttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-targetdatetime": "2019-12-16T23:48:18Z",

--- a/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
@@ -2315,8 +2315,8 @@ it("InputAndOutputWithNumericHeaders:Response", async () => {
       200,
       {
         "x-float": "1.1",
-        "x-long": "123",
         "x-byte": "1",
+        "x-long": "123",
         "x-integer": "123",
         "x-integerlist": "1, 2, 3",
         "x-double": "1.1",
@@ -3585,8 +3585,8 @@ it("TimestampFormatHeaders:Response", async () => {
       {
         "x-targetepochseconds": "1576540098",
         "x-memberdatetime": "2019-12-16T23:48:18Z",
-        "x-memberepochseconds": "1576540098",
         "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
+        "x-memberepochseconds": "1576540098",
         "x-targethttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-memberhttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-targetdatetime": "2019-12-16T23:48:18Z",


### PR DESCRIPTION
### Description
This has changes to `middleware-signing` and `codegen` to support generating clients for non AWS services that have SigV4 auth.

### Testing
I generated client for the bootleg demo service we are working on and with SigV4 enabled on the service, confirmed the client is able to successfully call it. See https://github.com/adamthom-amzn/smithy-typescript-ssdk-demo/pull/20 for testing details.

I ran `yarn generate-clients`. There is only a change is comment for all generated clients, but it is actually going back to what it was few weeks back before my earlier changes for supporting non AWS services changed the comment slightly.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
