### PR TITLE
chore(clients): write content-type header for missing operations

### DIFF
--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -1766,7 +1766,9 @@ export const serializeAws_restJson1GetAccountCommand = async (
   input: GetAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/account";
   let body: any;
   body = "";

--- a/clients/client-auditmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/protocols/Aws_restJson1.ts
@@ -694,7 +694,9 @@ export const serializeAws_restJson1DeregisterAccountCommand = async (
   input: DeregisterAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/account/deregisterAccount";
   let body: any;
   body = "";
@@ -773,7 +775,9 @@ export const serializeAws_restJson1GetAccountStatusCommand = async (
   input: GetAccountStatusCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/account/status";
   let body: any;
   body = "";
@@ -1211,7 +1215,9 @@ export const serializeAws_restJson1GetOrganizationAdminAccountCommand = async (
   input: GetOrganizationAdminAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/account/organizationAdminAccount";
   let body: any;
   body = "";
@@ -1231,7 +1237,9 @@ export const serializeAws_restJson1GetServicesInScopeCommand = async (
   input: GetServicesInScopeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/services";
   let body: any;
   body = "";

--- a/clients/client-backup/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1.ts
@@ -562,7 +562,9 @@ export const serializeAws_restJson1DescribeGlobalSettingsCommand = async (
   input: DescribeGlobalSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/global-settings";
   let body: any;
   body = "";
@@ -647,7 +649,9 @@ export const serializeAws_restJson1DescribeRegionSettingsCommand = async (
   input: DescribeRegionSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/account-settings";
   let body: any;
   body = "";
@@ -975,7 +979,9 @@ export const serializeAws_restJson1GetSupportedResourceTypesCommand = async (
   input: GetSupportedResourceTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/supported-resource-types";
   let body: any;
   body = "";

--- a/clients/client-chime/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1.ts
@@ -3688,7 +3688,9 @@ export const serializeAws_restJson1GetGlobalSettingsCommand = async (
   input: GetGlobalSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/settings";
   let body: any;
   body = "";
@@ -3736,7 +3738,9 @@ export const serializeAws_restJson1GetMessagingSessionEndpointCommand = async (
   input: GetMessagingSessionEndpointCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/endpoints/messaging-session";
   let body: any;
   body = "";
@@ -3819,7 +3823,9 @@ export const serializeAws_restJson1GetPhoneNumberSettingsCommand = async (
   input: GetPhoneNumberSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/settings/phone-number";
   let body: any;
   body = "";

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -497,6 +497,9 @@ export const serializeAws_restXmlCreateCachePolicyCommand = async (
   };
   let resolvedPath = "/2020-05-31/cache-policy";
   let body: any;
+  if (input.CachePolicyConfig !== undefined) {
+    body = serializeAws_restXmlCachePolicyConfig(input.CachePolicyConfig, context);
+  }
   let contents: any;
   if (input.CachePolicyConfig !== undefined) {
     contents = serializeAws_restXmlCachePolicyConfig(input.CachePolicyConfig, context);
@@ -525,6 +528,12 @@ export const serializeAws_restXmlCreateCloudFrontOriginAccessIdentityCommand = a
   };
   let resolvedPath = "/2020-05-31/origin-access-identity/cloudfront";
   let body: any;
+  if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
+    body = serializeAws_restXmlCloudFrontOriginAccessIdentityConfig(
+      input.CloudFrontOriginAccessIdentityConfig,
+      context
+    );
+  }
   let contents: any;
   if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
     contents = serializeAws_restXmlCloudFrontOriginAccessIdentityConfig(
@@ -556,6 +565,9 @@ export const serializeAws_restXmlCreateDistributionCommand = async (
   };
   let resolvedPath = "/2020-05-31/distribution";
   let body: any;
+  if (input.DistributionConfig !== undefined) {
+    body = serializeAws_restXmlDistributionConfig(input.DistributionConfig, context);
+  }
   let contents: any;
   if (input.DistributionConfig !== undefined) {
     contents = serializeAws_restXmlDistributionConfig(input.DistributionConfig, context);
@@ -587,6 +599,9 @@ export const serializeAws_restXmlCreateDistributionWithTagsCommand = async (
     WithTags: "",
   };
   let body: any;
+  if (input.DistributionConfigWithTags !== undefined) {
+    body = serializeAws_restXmlDistributionConfigWithTags(input.DistributionConfigWithTags, context);
+  }
   let contents: any;
   if (input.DistributionConfigWithTags !== undefined) {
     contents = serializeAws_restXmlDistributionConfigWithTags(input.DistributionConfigWithTags, context);
@@ -616,6 +631,9 @@ export const serializeAws_restXmlCreateFieldLevelEncryptionConfigCommand = async
   };
   let resolvedPath = "/2020-05-31/field-level-encryption";
   let body: any;
+  if (input.FieldLevelEncryptionConfig !== undefined) {
+    body = serializeAws_restXmlFieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
+  }
   let contents: any;
   if (input.FieldLevelEncryptionConfig !== undefined) {
     contents = serializeAws_restXmlFieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
@@ -644,6 +662,9 @@ export const serializeAws_restXmlCreateFieldLevelEncryptionProfileCommand = asyn
   };
   let resolvedPath = "/2020-05-31/field-level-encryption-profile";
   let body: any;
+  if (input.FieldLevelEncryptionProfileConfig !== undefined) {
+    body = serializeAws_restXmlFieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
+  }
   let contents: any;
   if (input.FieldLevelEncryptionProfileConfig !== undefined) {
     contents = serializeAws_restXmlFieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
@@ -720,6 +741,9 @@ export const serializeAws_restXmlCreateInvalidationCommand = async (
     throw new Error("No value provided for input HTTP label: DistributionId.");
   }
   let body: any;
+  if (input.InvalidationBatch !== undefined) {
+    body = serializeAws_restXmlInvalidationBatch(input.InvalidationBatch, context);
+  }
   let contents: any;
   if (input.InvalidationBatch !== undefined) {
     contents = serializeAws_restXmlInvalidationBatch(input.InvalidationBatch, context);
@@ -748,6 +772,9 @@ export const serializeAws_restXmlCreateKeyGroupCommand = async (
   };
   let resolvedPath = "/2020-05-31/key-group";
   let body: any;
+  if (input.KeyGroupConfig !== undefined) {
+    body = serializeAws_restXmlKeyGroupConfig(input.KeyGroupConfig, context);
+  }
   let contents: any;
   if (input.KeyGroupConfig !== undefined) {
     contents = serializeAws_restXmlKeyGroupConfig(input.KeyGroupConfig, context);
@@ -785,6 +812,9 @@ export const serializeAws_restXmlCreateMonitoringSubscriptionCommand = async (
     throw new Error("No value provided for input HTTP label: DistributionId.");
   }
   let body: any;
+  if (input.MonitoringSubscription !== undefined) {
+    body = serializeAws_restXmlMonitoringSubscription(input.MonitoringSubscription, context);
+  }
   let contents: any;
   if (input.MonitoringSubscription !== undefined) {
     contents = serializeAws_restXmlMonitoringSubscription(input.MonitoringSubscription, context);
@@ -813,6 +843,9 @@ export const serializeAws_restXmlCreateOriginRequestPolicyCommand = async (
   };
   let resolvedPath = "/2020-05-31/origin-request-policy";
   let body: any;
+  if (input.OriginRequestPolicyConfig !== undefined) {
+    body = serializeAws_restXmlOriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
+  }
   let contents: any;
   if (input.OriginRequestPolicyConfig !== undefined) {
     contents = serializeAws_restXmlOriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
@@ -841,6 +874,9 @@ export const serializeAws_restXmlCreatePublicKeyCommand = async (
   };
   let resolvedPath = "/2020-05-31/public-key";
   let body: any;
+  if (input.PublicKeyConfig !== undefined) {
+    body = serializeAws_restXmlPublicKeyConfig(input.PublicKeyConfig, context);
+  }
   let contents: any;
   if (input.PublicKeyConfig !== undefined) {
     contents = serializeAws_restXmlPublicKeyConfig(input.PublicKeyConfig, context);
@@ -918,6 +954,9 @@ export const serializeAws_restXmlCreateStreamingDistributionCommand = async (
   };
   let resolvedPath = "/2020-05-31/streaming-distribution";
   let body: any;
+  if (input.StreamingDistributionConfig !== undefined) {
+    body = serializeAws_restXmlStreamingDistributionConfig(input.StreamingDistributionConfig, context);
+  }
   let contents: any;
   if (input.StreamingDistributionConfig !== undefined) {
     contents = serializeAws_restXmlStreamingDistributionConfig(input.StreamingDistributionConfig, context);
@@ -949,6 +988,9 @@ export const serializeAws_restXmlCreateStreamingDistributionWithTagsCommand = as
     WithTags: "",
   };
   let body: any;
+  if (input.StreamingDistributionConfigWithTags !== undefined) {
+    body = serializeAws_restXmlStreamingDistributionConfigWithTags(input.StreamingDistributionConfigWithTags, context);
+  }
   let contents: any;
   if (input.StreamingDistributionConfigWithTags !== undefined) {
     contents = serializeAws_restXmlStreamingDistributionConfigWithTags(
@@ -2542,6 +2584,9 @@ export const serializeAws_restXmlTagResourceCommand = async (
     ...(input.Resource !== undefined && { Resource: input.Resource }),
   };
   let body: any;
+  if (input.Tags !== undefined) {
+    body = serializeAws_restXmlTags(input.Tags, context);
+  }
   let contents: any;
   if (input.Tags !== undefined) {
     contents = serializeAws_restXmlTags(input.Tags, context);
@@ -2620,6 +2665,9 @@ export const serializeAws_restXmlUntagResourceCommand = async (
     ...(input.Resource !== undefined && { Resource: input.Resource }),
   };
   let body: any;
+  if (input.TagKeys !== undefined) {
+    body = serializeAws_restXmlTagKeys(input.TagKeys, context);
+  }
   let contents: any;
   if (input.TagKeys !== undefined) {
     contents = serializeAws_restXmlTagKeys(input.TagKeys, context);
@@ -2659,6 +2707,9 @@ export const serializeAws_restXmlUpdateCachePolicyCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.CachePolicyConfig !== undefined) {
+    body = serializeAws_restXmlCachePolicyConfig(input.CachePolicyConfig, context);
+  }
   let contents: any;
   if (input.CachePolicyConfig !== undefined) {
     contents = serializeAws_restXmlCachePolicyConfig(input.CachePolicyConfig, context);
@@ -2697,6 +2748,12 @@ export const serializeAws_restXmlUpdateCloudFrontOriginAccessIdentityCommand = a
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
+    body = serializeAws_restXmlCloudFrontOriginAccessIdentityConfig(
+      input.CloudFrontOriginAccessIdentityConfig,
+      context
+    );
+  }
   let contents: any;
   if (input.CloudFrontOriginAccessIdentityConfig !== undefined) {
     contents = serializeAws_restXmlCloudFrontOriginAccessIdentityConfig(
@@ -2738,6 +2795,9 @@ export const serializeAws_restXmlUpdateDistributionCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.DistributionConfig !== undefined) {
+    body = serializeAws_restXmlDistributionConfig(input.DistributionConfig, context);
+  }
   let contents: any;
   if (input.DistributionConfig !== undefined) {
     contents = serializeAws_restXmlDistributionConfig(input.DistributionConfig, context);
@@ -2776,6 +2836,9 @@ export const serializeAws_restXmlUpdateFieldLevelEncryptionConfigCommand = async
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.FieldLevelEncryptionConfig !== undefined) {
+    body = serializeAws_restXmlFieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
+  }
   let contents: any;
   if (input.FieldLevelEncryptionConfig !== undefined) {
     contents = serializeAws_restXmlFieldLevelEncryptionConfig(input.FieldLevelEncryptionConfig, context);
@@ -2814,6 +2877,9 @@ export const serializeAws_restXmlUpdateFieldLevelEncryptionProfileCommand = asyn
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.FieldLevelEncryptionProfileConfig !== undefined) {
+    body = serializeAws_restXmlFieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
+  }
   let contents: any;
   if (input.FieldLevelEncryptionProfileConfig !== undefined) {
     contents = serializeAws_restXmlFieldLevelEncryptionProfileConfig(input.FieldLevelEncryptionProfileConfig, context);
@@ -2897,6 +2963,9 @@ export const serializeAws_restXmlUpdateKeyGroupCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.KeyGroupConfig !== undefined) {
+    body = serializeAws_restXmlKeyGroupConfig(input.KeyGroupConfig, context);
+  }
   let contents: any;
   if (input.KeyGroupConfig !== undefined) {
     contents = serializeAws_restXmlKeyGroupConfig(input.KeyGroupConfig, context);
@@ -2935,6 +3004,9 @@ export const serializeAws_restXmlUpdateOriginRequestPolicyCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.OriginRequestPolicyConfig !== undefined) {
+    body = serializeAws_restXmlOriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
+  }
   let contents: any;
   if (input.OriginRequestPolicyConfig !== undefined) {
     contents = serializeAws_restXmlOriginRequestPolicyConfig(input.OriginRequestPolicyConfig, context);
@@ -2973,6 +3045,9 @@ export const serializeAws_restXmlUpdatePublicKeyCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.PublicKeyConfig !== undefined) {
+    body = serializeAws_restXmlPublicKeyConfig(input.PublicKeyConfig, context);
+  }
   let contents: any;
   if (input.PublicKeyConfig !== undefined) {
     contents = serializeAws_restXmlPublicKeyConfig(input.PublicKeyConfig, context);
@@ -3064,6 +3139,9 @@ export const serializeAws_restXmlUpdateStreamingDistributionCommand = async (
     throw new Error("No value provided for input HTTP label: Id.");
   }
   let body: any;
+  if (input.StreamingDistributionConfig !== undefined) {
+    body = serializeAws_restXmlStreamingDistributionConfig(input.StreamingDistributionConfig, context);
+  }
   let contents: any;
   if (input.StreamingDistributionConfig !== undefined) {
     contents = serializeAws_restXmlStreamingDistributionConfig(input.StreamingDistributionConfig, context);

--- a/clients/client-devops-guru/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/protocols/Aws_restJson1.ts
@@ -168,7 +168,9 @@ export const serializeAws_restJson1DescribeAccountHealthCommand = async (
   input: DescribeAccountHealthCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/accounts/health";
   let body: any;
   body = "";
@@ -326,7 +328,9 @@ export const serializeAws_restJson1DescribeServiceIntegrationCommand = async (
   input: DescribeServiceIntegrationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/service-integrations";
   let body: any;
   body = "";

--- a/clients/client-elastic-inference/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1.ts
@@ -103,7 +103,9 @@ export const serializeAws_restJson1DescribeAcceleratorTypesCommand = async (
   input: DescribeAcceleratorTypesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/describe-accelerator-types";
   let body: any;
   body = "";

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
@@ -513,7 +513,9 @@ export const serializeAws_restJson1DeleteElasticsearchServiceRoleCommand = async
   input: DeleteElasticsearchServiceRoleCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/2015-01-01/es/role";
   let body: any;
   body = "";
@@ -1062,7 +1064,9 @@ export const serializeAws_restJson1ListDomainNamesCommand = async (
   input: ListDomainNamesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/2015-01-01/domain";
   let body: any;
   body = "";

--- a/clients/client-greengrass/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1.ts
@@ -1344,7 +1344,9 @@ export const serializeAws_restJson1DisassociateServiceRoleFromAccountCommand = a
   input: DisassociateServiceRoleFromAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/greengrass/servicerole";
   let body: any;
   body = "";
@@ -2022,7 +2024,9 @@ export const serializeAws_restJson1GetServiceRoleForAccountCommand = async (
   input: GetServiceRoleForAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/greengrass/servicerole";
   let body: any;
   body = "";

--- a/clients/client-guardduty/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1.ts
@@ -1124,7 +1124,9 @@ export const serializeAws_restJson1GetInvitationsCountCommand = async (
   input: GetInvitationsCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/invitation/count";
   let body: any;
   body = "";

--- a/clients/client-iot-events/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1.ts
@@ -324,7 +324,9 @@ export const serializeAws_restJson1DescribeLoggingOptionsCommand = async (
   input: DescribeLoggingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/logging";
   let body: any;
   body = "";

--- a/clients/client-iot/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1.ts
@@ -1306,7 +1306,9 @@ export const serializeAws_restJson1ClearDefaultAuthorizerCommand = async (
   input: ClearDefaultAuthorizerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/default-authorizer";
   let body: any;
   body = "";
@@ -2952,7 +2954,9 @@ export const serializeAws_restJson1DeleteRegistrationCodeCommand = async (
   input: DeleteRegistrationCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/registrationcode";
   let body: any;
   body = "";
@@ -3299,7 +3303,9 @@ export const serializeAws_restJson1DescribeAccountAuditConfigurationCommand = as
   input: DescribeAccountAuditConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/audit/configuration";
   let body: any;
   body = "";
@@ -3571,7 +3577,9 @@ export const serializeAws_restJson1DescribeDefaultAuthorizerCommand = async (
   input: DescribeDefaultAuthorizerCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/default-authorizer";
   let body: any;
   body = "";
@@ -3698,7 +3706,9 @@ export const serializeAws_restJson1DescribeEventConfigurationsCommand = async (
   input: DescribeEventConfigurationsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/event-configurations";
   let body: any;
   body = "";
@@ -4396,7 +4406,9 @@ export const serializeAws_restJson1GetIndexingConfigurationCommand = async (
   input: GetIndexingConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/indexing/config";
   let body: any;
   body = "";
@@ -4444,7 +4456,9 @@ export const serializeAws_restJson1GetLoggingOptionsCommand = async (
   input: GetLoggingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/loggingOptions";
   let body: any;
   body = "";
@@ -4587,7 +4601,9 @@ export const serializeAws_restJson1GetRegistrationCodeCommand = async (
   input: GetRegistrationCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/registrationcode";
   let body: any;
   body = "";
@@ -4697,7 +4713,9 @@ export const serializeAws_restJson1GetV2LoggingOptionsCommand = async (
   input: GetV2LoggingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/v2LoggingOptions";
   let body: any;
   body = "";

--- a/clients/client-iotanalytics/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1.ts
@@ -632,7 +632,9 @@ export const serializeAws_restJson1DescribeLoggingOptionsCommand = async (
   input: DescribeLoggingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/logging";
   let body: any;
   body = "";

--- a/clients/client-iotsitewise/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/protocols/Aws_restJson1.ts
@@ -1103,7 +1103,9 @@ export const serializeAws_restJson1DescribeDefaultEncryptionConfigurationCommand
   input: DescribeDefaultEncryptionConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/configuration/account/encryption";
   let body: any;
   body = "";
@@ -1202,7 +1204,9 @@ export const serializeAws_restJson1DescribeLoggingOptionsCommand = async (
   input: DescribeLoggingOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/logging";
   let body: any;
   body = "";

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -826,7 +826,9 @@ export const serializeAws_restJson1GetAccountSettingsCommand = async (
   input: GetAccountSettingsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/2016-08-19/account-settings";
   let body: any;
   body = "";

--- a/clients/client-lex-runtime-v2/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/protocols/Aws_restJson1.ts
@@ -1884,6 +1884,12 @@ const serializeAws_restJson1Value = (input: Value, context: __SerdeContext): any
   };
 };
 
+const deserializeAws_restJson1AccessDeniedException = (output: any, context: __SerdeContext): AccessDeniedException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+  } as any;
+};
+
 const deserializeAws_restJson1ActiveContext = (output: any, context: __SerdeContext): ActiveContext => {
   return {
     contextAttributes:
@@ -1948,6 +1954,12 @@ const deserializeAws_restJson1AudioResponseEvent = (output: any, context: __Serd
   } as any;
 };
 
+const deserializeAws_restJson1BadGatewayException = (output: any, context: __SerdeContext): BadGatewayException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+  } as any;
+};
+
 const deserializeAws_restJson1Button = (output: any, context: __SerdeContext): Button => {
   return {
     text: output.text !== undefined && output.text !== null ? output.text : undefined,
@@ -1969,6 +1981,21 @@ const deserializeAws_restJson1ButtonsList = (output: any, context: __SerdeContex
 const deserializeAws_restJson1ConfidenceScore = (output: any, context: __SerdeContext): ConfidenceScore => {
   return {
     score: output.score !== undefined && output.score !== null ? output.score : undefined,
+  } as any;
+};
+
+const deserializeAws_restJson1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+  } as any;
+};
+
+const deserializeAws_restJson1DependencyFailedException = (
+  output: any,
+  context: __SerdeContext
+): DependencyFailedException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
   } as any;
 };
 
@@ -2032,6 +2059,15 @@ const deserializeAws_restJson1IntentResultEvent = (output: any, context: __Serde
   } as any;
 };
 
+const deserializeAws_restJson1InternalServerException = (
+  output: any,
+  context: __SerdeContext
+): InternalServerException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+  } as any;
+};
+
 const deserializeAws_restJson1Interpretation = (output: any, context: __SerdeContext): Interpretation => {
   return {
     intent:
@@ -2091,6 +2127,15 @@ const deserializeAws_restJson1PlaybackInterruptionEvent = (
       output.causedByEventId !== undefined && output.causedByEventId !== null ? output.causedByEventId : undefined,
     eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
     eventReason: output.eventReason !== undefined && output.eventReason !== null ? output.eventReason : undefined,
+  } as any;
+};
+
+const deserializeAws_restJson1ResourceNotFoundException = (
+  output: any,
+  context: __SerdeContext
+): ResourceNotFoundException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
   } as any;
 };
 
@@ -2159,6 +2204,92 @@ const deserializeAws_restJson1Slots = (output: any, context: __SerdeContext): { 
   }, {});
 };
 
+const deserializeAws_restJson1StartConversationResponseEventStream = (
+  output: any,
+  context: __SerdeContext
+): StartConversationResponseEventStream => {
+  if (output.AccessDeniedException !== undefined && output.AccessDeniedException !== null) {
+    return {
+      AccessDeniedException: deserializeAws_restJson1AccessDeniedException(output.AccessDeniedException, context),
+    };
+  }
+  if (output.AudioResponseEvent !== undefined && output.AudioResponseEvent !== null) {
+    return {
+      AudioResponseEvent: deserializeAws_restJson1AudioResponseEvent(output.AudioResponseEvent, context),
+    };
+  }
+  if (output.BadGatewayException !== undefined && output.BadGatewayException !== null) {
+    return {
+      BadGatewayException: deserializeAws_restJson1BadGatewayException(output.BadGatewayException, context),
+    };
+  }
+  if (output.ConflictException !== undefined && output.ConflictException !== null) {
+    return {
+      ConflictException: deserializeAws_restJson1ConflictException(output.ConflictException, context),
+    };
+  }
+  if (output.DependencyFailedException !== undefined && output.DependencyFailedException !== null) {
+    return {
+      DependencyFailedException: deserializeAws_restJson1DependencyFailedException(
+        output.DependencyFailedException,
+        context
+      ),
+    };
+  }
+  if (output.HeartbeatEvent !== undefined && output.HeartbeatEvent !== null) {
+    return {
+      HeartbeatEvent: deserializeAws_restJson1HeartbeatEvent(output.HeartbeatEvent, context),
+    };
+  }
+  if (output.IntentResultEvent !== undefined && output.IntentResultEvent !== null) {
+    return {
+      IntentResultEvent: deserializeAws_restJson1IntentResultEvent(output.IntentResultEvent, context),
+    };
+  }
+  if (output.InternalServerException !== undefined && output.InternalServerException !== null) {
+    return {
+      InternalServerException: deserializeAws_restJson1InternalServerException(output.InternalServerException, context),
+    };
+  }
+  if (output.PlaybackInterruptionEvent !== undefined && output.PlaybackInterruptionEvent !== null) {
+    return {
+      PlaybackInterruptionEvent: deserializeAws_restJson1PlaybackInterruptionEvent(
+        output.PlaybackInterruptionEvent,
+        context
+      ),
+    };
+  }
+  if (output.ResourceNotFoundException !== undefined && output.ResourceNotFoundException !== null) {
+    return {
+      ResourceNotFoundException: deserializeAws_restJson1ResourceNotFoundException(
+        output.ResourceNotFoundException,
+        context
+      ),
+    };
+  }
+  if (output.TextResponseEvent !== undefined && output.TextResponseEvent !== null) {
+    return {
+      TextResponseEvent: deserializeAws_restJson1TextResponseEvent(output.TextResponseEvent, context),
+    };
+  }
+  if (output.ThrottlingException !== undefined && output.ThrottlingException !== null) {
+    return {
+      ThrottlingException: deserializeAws_restJson1ThrottlingException(output.ThrottlingException, context),
+    };
+  }
+  if (output.TranscriptEvent !== undefined && output.TranscriptEvent !== null) {
+    return {
+      TranscriptEvent: deserializeAws_restJson1TranscriptEvent(output.TranscriptEvent, context),
+    };
+  }
+  if (output.ValidationException !== undefined && output.ValidationException !== null) {
+    return {
+      ValidationException: deserializeAws_restJson1ValidationException(output.ValidationException, context),
+    };
+  }
+  return { $unknown: Object.entries(output)[0] };
+};
+
 const deserializeAws_restJson1StringList = (output: any, context: __SerdeContext): string[] => {
   return (output || [])
     .filter((e: any) => e != null)
@@ -2192,10 +2323,22 @@ const deserializeAws_restJson1TextResponseEvent = (output: any, context: __Serde
   } as any;
 };
 
+const deserializeAws_restJson1ThrottlingException = (output: any, context: __SerdeContext): ThrottlingException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+  } as any;
+};
+
 const deserializeAws_restJson1TranscriptEvent = (output: any, context: __SerdeContext): TranscriptEvent => {
   return {
     eventId: output.eventId !== undefined && output.eventId !== null ? output.eventId : undefined,
     transcript: output.transcript !== undefined && output.transcript !== null ? output.transcript : undefined,
+  } as any;
+};
+
+const deserializeAws_restJson1ValidationException = (output: any, context: __SerdeContext): ValidationException => {
+  return {
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
   } as any;
 };
 

--- a/clients/client-macie2/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/protocols/Aws_restJson1.ts
@@ -714,7 +714,9 @@ export const serializeAws_restJson1DescribeOrganizationConfigurationCommand = as
   input: DescribeOrganizationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/admin/configuration";
   let body: any;
   body = "";
@@ -734,7 +736,9 @@ export const serializeAws_restJson1DisableMacieCommand = async (
   input: DisableMacieCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/macie";
   let body: any;
   body = "";
@@ -777,7 +781,9 @@ export const serializeAws_restJson1DisassociateFromAdministratorAccountCommand =
   input: DisassociateFromAdministratorAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/administrator/disassociate";
   let body: any;
   body = "";
@@ -797,7 +803,9 @@ export const serializeAws_restJson1DisassociateFromMasterAccountCommand = async 
   input: DisassociateFromMasterAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/master/disassociate";
   let body: any;
   body = "";
@@ -898,7 +906,9 @@ export const serializeAws_restJson1GetAdministratorAccountCommand = async (
   input: GetAdministratorAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/administrator";
   let body: any;
   body = "";
@@ -942,7 +952,9 @@ export const serializeAws_restJson1GetClassificationExportConfigurationCommand =
   input: GetClassificationExportConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/classification-export-configuration";
   let body: any;
   body = "";
@@ -1045,7 +1057,9 @@ export const serializeAws_restJson1GetFindingsPublicationConfigurationCommand = 
   input: GetFindingsPublicationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/findings-publication-configuration";
   let body: any;
   body = "";
@@ -1098,7 +1112,9 @@ export const serializeAws_restJson1GetInvitationsCountCommand = async (
   input: GetInvitationsCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/invitations/count";
   let body: any;
   body = "";
@@ -1118,7 +1134,9 @@ export const serializeAws_restJson1GetMacieSessionCommand = async (
   input: GetMacieSessionCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/macie";
   let body: any;
   body = "";
@@ -1138,7 +1156,9 @@ export const serializeAws_restJson1GetMasterAccountCommand = async (
   input: GetMasterAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/master";
   let body: any;
   body = "";

--- a/clients/client-mgn/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/protocols/Aws_restJson1.ts
@@ -506,7 +506,9 @@ export const serializeAws_restJson1InitializeServiceCommand = async (
   input: InitializeServiceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/InitializeService";
   let body: any;
   body = "";

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
@@ -494,7 +494,9 @@ export const serializeAws_restJson1GetAccountCommand = async (
   input: GetAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/v1/email/account";
   let body: any;
   body = "";
@@ -648,7 +650,9 @@ export const serializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = as
   input: GetDeliverabilityDashboardOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/v1/email/deliverability-dashboard";
   let body: any;
   body = "";

--- a/clients/client-ram/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1.ts
@@ -333,7 +333,9 @@ export const serializeAws_restJson1EnableSharingWithAwsOrganizationCommand = asy
   input: EnableSharingWithAwsOrganizationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/enablesharingwithawsorganization";
   let body: any;
   body = "";

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -1303,7 +1303,9 @@ export const serializeAws_restXmlGetCheckerIpRangesCommand = async (
   input: GetCheckerIpRangesCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/2013-04-01/checkeripranges";
   let body: any;
   body = "";
@@ -1404,7 +1406,9 @@ export const serializeAws_restXmlGetHealthCheckCountCommand = async (
   input: GetHealthCheckCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/2013-04-01/healthcheckcount";
   let body: any;
   body = "";
@@ -1508,7 +1512,9 @@ export const serializeAws_restXmlGetHostedZoneCountCommand = async (
   input: GetHostedZoneCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/2013-04-01/hostedzonecount";
   let body: any;
   body = "";
@@ -1723,7 +1729,9 @@ export const serializeAws_restXmlGetTrafficPolicyInstanceCountCommand = async (
   input: GetTrafficPolicyInstanceCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/2013-04-01/trafficpolicyinstancecount";
   let body: any;
   body = "";

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -375,6 +375,9 @@ export const serializeAws_restXmlCreateBucketCommand = async (
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   let body: any;
+  if (input.CreateBucketConfiguration !== undefined) {
+    body = serializeAws_restXmlCreateBucketConfiguration(input.CreateBucketConfiguration, context);
+  }
   let contents: any;
   if (input.CreateBucketConfiguration !== undefined) {
     contents = serializeAws_restXmlCreateBucketConfiguration(input.CreateBucketConfiguration, context);
@@ -1966,6 +1969,9 @@ export const serializeAws_restXmlPutBucketLifecycleConfigurationCommand = async 
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   let body: any;
+  if (input.LifecycleConfiguration !== undefined) {
+    body = serializeAws_restXmlLifecycleConfiguration(input.LifecycleConfiguration, context);
+  }
   let contents: any;
   if (input.LifecycleConfiguration !== undefined) {
     contents = serializeAws_restXmlLifecycleConfiguration(input.LifecycleConfiguration, context);
@@ -2068,6 +2074,9 @@ export const serializeAws_restXmlPutBucketTaggingCommand = async (
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   let body: any;
+  if (input.Tagging !== undefined) {
+    body = serializeAws_restXmlTagging(input.Tagging, context);
+  }
   let contents: any;
   if (input.Tagging !== undefined) {
     contents = serializeAws_restXmlTagging(input.Tagging, context);
@@ -2162,6 +2171,9 @@ export const serializeAws_restXmlPutPublicAccessBlockCommand = async (
   };
   let resolvedPath = "/v20180820/configuration/publicAccessBlock";
   let body: any;
+  if (input.PublicAccessBlockConfiguration !== undefined) {
+    body = serializeAws_restXmlPublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);
+  }
   let contents: any;
   if (input.PublicAccessBlockConfiguration !== undefined) {
     contents = serializeAws_restXmlPublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -373,6 +373,7 @@ import {
   OutputLocation,
   OutputSerialization,
   ParquetInput,
+  Progress,
   ProgressEvent,
   RecordsEvent,
   RequestProgress,
@@ -381,6 +382,7 @@ import {
   ScanRange,
   SelectObjectContentEventStream,
   SelectParameters,
+  Stats,
   StatsEvent,
 } from "../models/models_1";
 import {
@@ -499,6 +501,9 @@ export const serializeAws_restXmlCompleteMultipartUploadCommand = async (
     ...(input.UploadId !== undefined && { uploadId: input.UploadId }),
   };
   let body: any;
+  if (input.MultipartUpload !== undefined) {
+    body = serializeAws_restXmlCompletedMultipartUpload(input.MultipartUpload, context);
+  }
   let contents: any;
   if (input.MultipartUpload !== undefined) {
     contents = serializeAws_restXmlCompletedMultipartUpload(input.MultipartUpload, context);
@@ -679,6 +684,9 @@ export const serializeAws_restXmlCreateBucketCommand = async (
     throw new Error("No value provided for input HTTP label: Bucket.");
   }
   let body: any;
+  if (input.CreateBucketConfiguration !== undefined) {
+    body = serializeAws_restXmlCreateBucketConfiguration(input.CreateBucketConfiguration, context);
+  }
   let contents: any;
   if (input.CreateBucketConfiguration !== undefined) {
     contents = serializeAws_restXmlCreateBucketConfiguration(input.CreateBucketConfiguration, context);
@@ -1356,6 +1364,9 @@ export const serializeAws_restXmlDeleteObjectsCommand = async (
     "x-id": "DeleteObjects",
   };
   let body: any;
+  if (input.Delete !== undefined) {
+    body = serializeAws_restXmlDelete(input.Delete, context);
+  }
   let contents: any;
   if (input.Delete !== undefined) {
     contents = serializeAws_restXmlDelete(input.Delete, context);
@@ -2861,7 +2872,9 @@ export const serializeAws_restXmlListBucketsCommand = async (
   input: ListBucketsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/";
   let body: any;
   body = "";
@@ -3125,6 +3138,9 @@ export const serializeAws_restXmlPutBucketAccelerateConfigurationCommand = async
     accelerate: "",
   };
   let body: any;
+  if (input.AccelerateConfiguration !== undefined) {
+    body = serializeAws_restXmlAccelerateConfiguration(input.AccelerateConfiguration, context);
+  }
   let contents: any;
   if (input.AccelerateConfiguration !== undefined) {
     contents = serializeAws_restXmlAccelerateConfiguration(input.AccelerateConfiguration, context);
@@ -3176,6 +3192,9 @@ export const serializeAws_restXmlPutBucketAclCommand = async (
     acl: "",
   };
   let body: any;
+  if (input.AccessControlPolicy !== undefined) {
+    body = serializeAws_restXmlAccessControlPolicy(input.AccessControlPolicy, context);
+  }
   let contents: any;
   if (input.AccessControlPolicy !== undefined) {
     contents = serializeAws_restXmlAccessControlPolicy(input.AccessControlPolicy, context);
@@ -3221,6 +3240,9 @@ export const serializeAws_restXmlPutBucketAnalyticsConfigurationCommand = async 
     ...(input.Id !== undefined && { id: input.Id }),
   };
   let body: any;
+  if (input.AnalyticsConfiguration !== undefined) {
+    body = serializeAws_restXmlAnalyticsConfiguration(input.AnalyticsConfiguration, context);
+  }
   let contents: any;
   if (input.AnalyticsConfiguration !== undefined) {
     contents = serializeAws_restXmlAnalyticsConfiguration(input.AnalyticsConfiguration, context);
@@ -3266,6 +3288,9 @@ export const serializeAws_restXmlPutBucketCorsCommand = async (
     cors: "",
   };
   let body: any;
+  if (input.CORSConfiguration !== undefined) {
+    body = serializeAws_restXmlCORSConfiguration(input.CORSConfiguration, context);
+  }
   let contents: any;
   if (input.CORSConfiguration !== undefined) {
     contents = serializeAws_restXmlCORSConfiguration(input.CORSConfiguration, context);
@@ -3311,6 +3336,9 @@ export const serializeAws_restXmlPutBucketEncryptionCommand = async (
     encryption: "",
   };
   let body: any;
+  if (input.ServerSideEncryptionConfiguration !== undefined) {
+    body = serializeAws_restXmlServerSideEncryptionConfiguration(input.ServerSideEncryptionConfiguration, context);
+  }
   let contents: any;
   if (input.ServerSideEncryptionConfiguration !== undefined) {
     contents = serializeAws_restXmlServerSideEncryptionConfiguration(input.ServerSideEncryptionConfiguration, context);
@@ -3353,6 +3381,9 @@ export const serializeAws_restXmlPutBucketIntelligentTieringConfigurationCommand
     ...(input.Id !== undefined && { id: input.Id }),
   };
   let body: any;
+  if (input.IntelligentTieringConfiguration !== undefined) {
+    body = serializeAws_restXmlIntelligentTieringConfiguration(input.IntelligentTieringConfiguration, context);
+  }
   let contents: any;
   if (input.IntelligentTieringConfiguration !== undefined) {
     contents = serializeAws_restXmlIntelligentTieringConfiguration(input.IntelligentTieringConfiguration, context);
@@ -3398,6 +3429,9 @@ export const serializeAws_restXmlPutBucketInventoryConfigurationCommand = async 
     ...(input.Id !== undefined && { id: input.Id }),
   };
   let body: any;
+  if (input.InventoryConfiguration !== undefined) {
+    body = serializeAws_restXmlInventoryConfiguration(input.InventoryConfiguration, context);
+  }
   let contents: any;
   if (input.InventoryConfiguration !== undefined) {
     contents = serializeAws_restXmlInventoryConfiguration(input.InventoryConfiguration, context);
@@ -3442,6 +3476,9 @@ export const serializeAws_restXmlPutBucketLifecycleConfigurationCommand = async 
     lifecycle: "",
   };
   let body: any;
+  if (input.LifecycleConfiguration !== undefined) {
+    body = serializeAws_restXmlBucketLifecycleConfiguration(input.LifecycleConfiguration, context);
+  }
   let contents: any;
   if (input.LifecycleConfiguration !== undefined) {
     contents = serializeAws_restXmlBucketLifecycleConfiguration(input.LifecycleConfiguration, context);
@@ -3487,6 +3524,9 @@ export const serializeAws_restXmlPutBucketLoggingCommand = async (
     logging: "",
   };
   let body: any;
+  if (input.BucketLoggingStatus !== undefined) {
+    body = serializeAws_restXmlBucketLoggingStatus(input.BucketLoggingStatus, context);
+  }
   let contents: any;
   if (input.BucketLoggingStatus !== undefined) {
     contents = serializeAws_restXmlBucketLoggingStatus(input.BucketLoggingStatus, context);
@@ -3532,6 +3572,9 @@ export const serializeAws_restXmlPutBucketMetricsConfigurationCommand = async (
     ...(input.Id !== undefined && { id: input.Id }),
   };
   let body: any;
+  if (input.MetricsConfiguration !== undefined) {
+    body = serializeAws_restXmlMetricsConfiguration(input.MetricsConfiguration, context);
+  }
   let contents: any;
   if (input.MetricsConfiguration !== undefined) {
     contents = serializeAws_restXmlMetricsConfiguration(input.MetricsConfiguration, context);
@@ -3576,6 +3619,9 @@ export const serializeAws_restXmlPutBucketNotificationConfigurationCommand = asy
     notification: "",
   };
   let body: any;
+  if (input.NotificationConfiguration !== undefined) {
+    body = serializeAws_restXmlNotificationConfiguration(input.NotificationConfiguration, context);
+  }
   let contents: any;
   if (input.NotificationConfiguration !== undefined) {
     contents = serializeAws_restXmlNotificationConfiguration(input.NotificationConfiguration, context);
@@ -3621,6 +3667,9 @@ export const serializeAws_restXmlPutBucketOwnershipControlsCommand = async (
     ownershipControls: "",
   };
   let body: any;
+  if (input.OwnershipControls !== undefined) {
+    body = serializeAws_restXmlOwnershipControls(input.OwnershipControls, context);
+  }
   let contents: any;
   if (input.OwnershipControls !== undefined) {
     contents = serializeAws_restXmlOwnershipControls(input.OwnershipControls, context);
@@ -3669,6 +3718,9 @@ export const serializeAws_restXmlPutBucketPolicyCommand = async (
     policy: "",
   };
   let body: any;
+  if (input.Policy !== undefined) {
+    body = input.Policy;
+  }
   let contents: any;
   if (input.Policy !== undefined) {
     contents = input.Policy;
@@ -3713,6 +3765,9 @@ export const serializeAws_restXmlPutBucketReplicationCommand = async (
     replication: "",
   };
   let body: any;
+  if (input.ReplicationConfiguration !== undefined) {
+    body = serializeAws_restXmlReplicationConfiguration(input.ReplicationConfiguration, context);
+  }
   let contents: any;
   if (input.ReplicationConfiguration !== undefined) {
     contents = serializeAws_restXmlReplicationConfiguration(input.ReplicationConfiguration, context);
@@ -3758,6 +3813,9 @@ export const serializeAws_restXmlPutBucketRequestPaymentCommand = async (
     requestPayment: "",
   };
   let body: any;
+  if (input.RequestPaymentConfiguration !== undefined) {
+    body = serializeAws_restXmlRequestPaymentConfiguration(input.RequestPaymentConfiguration, context);
+  }
   let contents: any;
   if (input.RequestPaymentConfiguration !== undefined) {
     contents = serializeAws_restXmlRequestPaymentConfiguration(input.RequestPaymentConfiguration, context);
@@ -3803,6 +3861,9 @@ export const serializeAws_restXmlPutBucketTaggingCommand = async (
     tagging: "",
   };
   let body: any;
+  if (input.Tagging !== undefined) {
+    body = serializeAws_restXmlTagging(input.Tagging, context);
+  }
   let contents: any;
   if (input.Tagging !== undefined) {
     contents = serializeAws_restXmlTagging(input.Tagging, context);
@@ -3849,6 +3910,9 @@ export const serializeAws_restXmlPutBucketVersioningCommand = async (
     versioning: "",
   };
   let body: any;
+  if (input.VersioningConfiguration !== undefined) {
+    body = serializeAws_restXmlVersioningConfiguration(input.VersioningConfiguration, context);
+  }
   let contents: any;
   if (input.VersioningConfiguration !== undefined) {
     contents = serializeAws_restXmlVersioningConfiguration(input.VersioningConfiguration, context);
@@ -3894,6 +3958,9 @@ export const serializeAws_restXmlPutBucketWebsiteCommand = async (
     website: "",
   };
   let body: any;
+  if (input.WebsiteConfiguration !== undefined) {
+    body = serializeAws_restXmlWebsiteConfiguration(input.WebsiteConfiguration, context);
+  }
   let contents: any;
   if (input.WebsiteConfiguration !== undefined) {
     contents = serializeAws_restXmlWebsiteConfiguration(input.WebsiteConfiguration, context);
@@ -4010,6 +4077,9 @@ export const serializeAws_restXmlPutObjectCommand = async (
     "x-id": "PutObject",
   };
   let body: any;
+  if (input.Body !== undefined) {
+    body = input.Body;
+  }
   let contents: any;
   if (input.Body !== undefined) {
     contents = input.Body;
@@ -4076,6 +4146,9 @@ export const serializeAws_restXmlPutObjectAclCommand = async (
     ...(input.VersionId !== undefined && { versionId: input.VersionId }),
   };
   let body: any;
+  if (input.AccessControlPolicy !== undefined) {
+    body = serializeAws_restXmlAccessControlPolicy(input.AccessControlPolicy, context);
+  }
   let contents: any;
   if (input.AccessControlPolicy !== undefined) {
     contents = serializeAws_restXmlAccessControlPolicy(input.AccessControlPolicy, context);
@@ -4138,6 +4211,9 @@ export const serializeAws_restXmlPutObjectLegalHoldCommand = async (
     ...(input.VersionId !== undefined && { versionId: input.VersionId }),
   };
   let body: any;
+  if (input.LegalHold !== undefined) {
+    body = serializeAws_restXmlObjectLockLegalHold(input.LegalHold, context);
+  }
   let contents: any;
   if (input.LegalHold !== undefined) {
     contents = serializeAws_restXmlObjectLockLegalHold(input.LegalHold, context);
@@ -4185,6 +4261,9 @@ export const serializeAws_restXmlPutObjectLockConfigurationCommand = async (
     "object-lock": "",
   };
   let body: any;
+  if (input.ObjectLockConfiguration !== undefined) {
+    body = serializeAws_restXmlObjectLockConfiguration(input.ObjectLockConfiguration, context);
+  }
   let contents: any;
   if (input.ObjectLockConfiguration !== undefined) {
     contents = serializeAws_restXmlObjectLockConfiguration(input.ObjectLockConfiguration, context);
@@ -4250,6 +4329,9 @@ export const serializeAws_restXmlPutObjectRetentionCommand = async (
     ...(input.VersionId !== undefined && { versionId: input.VersionId }),
   };
   let body: any;
+  if (input.Retention !== undefined) {
+    body = serializeAws_restXmlObjectLockRetention(input.Retention, context);
+  }
   let contents: any;
   if (input.Retention !== undefined) {
     contents = serializeAws_restXmlObjectLockRetention(input.Retention, context);
@@ -4312,6 +4394,9 @@ export const serializeAws_restXmlPutObjectTaggingCommand = async (
     ...(input.VersionId !== undefined && { versionId: input.VersionId }),
   };
   let body: any;
+  if (input.Tagging !== undefined) {
+    body = serializeAws_restXmlTagging(input.Tagging, context);
+  }
   let contents: any;
   if (input.Tagging !== undefined) {
     contents = serializeAws_restXmlTagging(input.Tagging, context);
@@ -4357,6 +4442,9 @@ export const serializeAws_restXmlPutPublicAccessBlockCommand = async (
     publicAccessBlock: "",
   };
   let body: any;
+  if (input.PublicAccessBlockConfiguration !== undefined) {
+    body = serializeAws_restXmlPublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);
+  }
   let contents: any;
   if (input.PublicAccessBlockConfiguration !== undefined) {
     contents = serializeAws_restXmlPublicAccessBlockConfiguration(input.PublicAccessBlockConfiguration, context);
@@ -4419,6 +4507,9 @@ export const serializeAws_restXmlRestoreObjectCommand = async (
     ...(input.VersionId !== undefined && { versionId: input.VersionId }),
   };
   let body: any;
+  if (input.RestoreRequest !== undefined) {
+    body = serializeAws_restXmlRestoreRequest(input.RestoreRequest, context);
+  }
   let contents: any;
   if (input.RestoreRequest !== undefined) {
     contents = serializeAws_restXmlRestoreRequest(input.RestoreRequest, context);
@@ -4589,6 +4680,9 @@ export const serializeAws_restXmlUploadPartCommand = async (
     ...(input.UploadId !== undefined && { uploadId: input.UploadId }),
   };
   let body: any;
+  if (input.Body !== undefined) {
+    body = input.Body;
+  }
   let contents: any;
   if (input.Body !== undefined) {
     contents = input.Body;
@@ -4793,6 +4887,9 @@ export const serializeAws_restXmlWriteGetObjectResponseCommand = async (
     "x-id": "WriteGetObjectResponse",
   };
   let body: any;
+  if (input.Body !== undefined) {
+    body = input.Body;
+  }
   let contents: any;
   if (input.Body !== undefined) {
     contents = input.Body;
@@ -12653,6 +12750,11 @@ const deserializeAws_restXmlCondition = (output: any, context: __SerdeContext): 
   return contents;
 };
 
+const deserializeAws_restXmlContinuationEvent = (output: any, context: __SerdeContext): ContinuationEvent => {
+  let contents: any = {};
+  return contents;
+};
+
 const deserializeAws_restXmlCopyObjectResult = (output: any, context: __SerdeContext): CopyObjectResult => {
   let contents: any = {
     ETag: undefined,
@@ -12897,6 +12999,11 @@ const deserializeAws_restXmlEncryptionConfiguration = (
   if (output["ReplicaKmsKeyID"] !== undefined) {
     contents.ReplicaKmsKeyID = output["ReplicaKmsKeyID"];
   }
+  return contents;
+};
+
+const deserializeAws_restXmlEndEvent = (output: any, context: __SerdeContext): EndEvent => {
+  let contents: any = {};
   return contents;
 };
 
@@ -13907,6 +14014,34 @@ const deserializeAws_restXmlPolicyStatus = (output: any, context: __SerdeContext
   return contents;
 };
 
+const deserializeAws_restXmlProgress = (output: any, context: __SerdeContext): Progress => {
+  let contents: any = {
+    BytesScanned: undefined,
+    BytesProcessed: undefined,
+    BytesReturned: undefined,
+  };
+  if (output["BytesScanned"] !== undefined) {
+    contents.BytesScanned = parseInt(output["BytesScanned"]);
+  }
+  if (output["BytesProcessed"] !== undefined) {
+    contents.BytesProcessed = parseInt(output["BytesProcessed"]);
+  }
+  if (output["BytesReturned"] !== undefined) {
+    contents.BytesReturned = parseInt(output["BytesReturned"]);
+  }
+  return contents;
+};
+
+const deserializeAws_restXmlProgressEvent = (output: any, context: __SerdeContext): ProgressEvent => {
+  let contents: any = {
+    Details: undefined,
+  };
+  if (output["Details"] !== undefined) {
+    contents.Details = deserializeAws_restXmlProgress(output["Details"], context);
+  }
+  return contents;
+};
+
 const deserializeAws_restXmlPublicAccessBlockConfiguration = (
   output: any,
   context: __SerdeContext
@@ -13966,6 +14101,16 @@ const deserializeAws_restXmlQueueConfigurationList = (output: any, context: __Se
       }
       return deserializeAws_restXmlQueueConfiguration(entry, context);
     });
+};
+
+const deserializeAws_restXmlRecordsEvent = (output: any, context: __SerdeContext): RecordsEvent => {
+  let contents: any = {
+    Payload: undefined,
+  };
+  if (output["Payload"] !== undefined) {
+    contents.Payload = context.base64Decoder(output["Payload"]);
+  }
+  return contents;
 };
 
 const deserializeAws_restXmlRedirect = (output: any, context: __SerdeContext): Redirect => {
@@ -14201,6 +14346,38 @@ const deserializeAws_restXmlS3KeyFilter = (output: any, context: __SerdeContext)
   return contents;
 };
 
+const deserializeAws_restXmlSelectObjectContentEventStream = (
+  output: any,
+  context: __SerdeContext
+): SelectObjectContentEventStream => {
+  if (output["Records"] !== undefined) {
+    return {
+      Records: deserializeAws_restXmlRecordsEvent(output["Records"], context),
+    };
+  }
+  if (output["Stats"] !== undefined) {
+    return {
+      Stats: deserializeAws_restXmlStatsEvent(output["Stats"], context),
+    };
+  }
+  if (output["Progress"] !== undefined) {
+    return {
+      Progress: deserializeAws_restXmlProgressEvent(output["Progress"], context),
+    };
+  }
+  if (output["Cont"] !== undefined) {
+    return {
+      Cont: deserializeAws_restXmlContinuationEvent(output["Cont"], context),
+    };
+  }
+  if (output["End"] !== undefined) {
+    return {
+      End: deserializeAws_restXmlEndEvent(output["End"], context),
+    };
+  }
+  return { $unknown: Object.entries(output)[0] };
+};
+
 const deserializeAws_restXmlServerSideEncryptionByDefault = (
   output: any,
   context: __SerdeContext
@@ -14310,6 +14487,34 @@ const deserializeAws_restXmlSseKmsEncryptedObjects = (output: any, context: __Se
 
 const deserializeAws_restXmlSSES3 = (output: any, context: __SerdeContext): SSES3 => {
   let contents: any = {};
+  return contents;
+};
+
+const deserializeAws_restXmlStats = (output: any, context: __SerdeContext): Stats => {
+  let contents: any = {
+    BytesScanned: undefined,
+    BytesProcessed: undefined,
+    BytesReturned: undefined,
+  };
+  if (output["BytesScanned"] !== undefined) {
+    contents.BytesScanned = parseInt(output["BytesScanned"]);
+  }
+  if (output["BytesProcessed"] !== undefined) {
+    contents.BytesProcessed = parseInt(output["BytesProcessed"]);
+  }
+  if (output["BytesReturned"] !== undefined) {
+    contents.BytesReturned = parseInt(output["BytesReturned"]);
+  }
+  return contents;
+};
+
+const deserializeAws_restXmlStatsEvent = (output: any, context: __SerdeContext): StatsEvent => {
+  let contents: any = {
+    Details: undefined,
+  };
+  if (output["Details"] !== undefined) {
+    contents.Details = deserializeAws_restXmlStats(output["Details"], context);
+  }
   return contents;
 };
 

--- a/clients/client-securityhub/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1.ts
@@ -874,7 +874,9 @@ export const serializeAws_restJson1DescribeOrganizationConfigurationCommand = as
   input: DescribeOrganizationConfigurationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/organization/configuration";
   let body: any;
   body = "";
@@ -1041,7 +1043,9 @@ export const serializeAws_restJson1DisableSecurityHubCommand = async (
   input: DisableSecurityHubCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/accounts";
   let body: any;
   body = "";
@@ -1061,7 +1065,9 @@ export const serializeAws_restJson1DisassociateFromAdministratorAccountCommand =
   input: DisassociateFromAdministratorAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/administrator/disassociate";
   let body: any;
   body = "";
@@ -1081,7 +1087,9 @@ export const serializeAws_restJson1DisassociateFromMasterAccountCommand = async 
   input: DisassociateFromMasterAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/master/disassociate";
   let body: any;
   body = "";
@@ -1201,7 +1209,9 @@ export const serializeAws_restJson1GetAdministratorAccountCommand = async (
   input: GetAdministratorAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/administrator";
   let body: any;
   body = "";
@@ -1343,7 +1353,9 @@ export const serializeAws_restJson1GetInvitationsCountCommand = async (
   input: GetInvitationsCountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/invitations/count";
   let body: any;
   body = "";
@@ -1363,7 +1375,9 @@ export const serializeAws_restJson1GetMasterAccountCommand = async (
   input: GetMasterAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/master";
   let body: any;
   body = "";

--- a/clients/client-sesv2/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1.ts
@@ -1033,7 +1033,9 @@ export const serializeAws_restJson1GetAccountCommand = async (
   input: GetAccountCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/v2/email/account";
   let body: any;
   body = "";
@@ -1280,7 +1282,9 @@ export const serializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = as
   input: GetDeliverabilityDashboardOptionsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/v2/email/deliverability-dashboard";
   let body: any;
   body = "";

--- a/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
@@ -733,6 +733,27 @@ const deserializeAws_restJson1AlternativeList = (output: any, context: __SerdeCo
     });
 };
 
+const deserializeAws_restJson1BadRequestException = (output: any, context: __SerdeContext): BadRequestException => {
+  return {
+    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+  } as any;
+};
+
+const deserializeAws_restJson1ConflictException = (output: any, context: __SerdeContext): ConflictException => {
+  return {
+    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+  } as any;
+};
+
+const deserializeAws_restJson1InternalFailureException = (
+  output: any,
+  context: __SerdeContext
+): InternalFailureException => {
+  return {
+    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+  } as any;
+};
+
 const deserializeAws_restJson1Item = (output: any, context: __SerdeContext): Item => {
   return {
     Confidence: output.Confidence !== undefined && output.Confidence !== null ? output.Confidence : undefined,
@@ -757,6 +778,15 @@ const deserializeAws_restJson1ItemList = (output: any, context: __SerdeContext):
       }
       return deserializeAws_restJson1Item(entry, context);
     });
+};
+
+const deserializeAws_restJson1LimitExceededException = (
+  output: any,
+  context: __SerdeContext
+): LimitExceededException => {
+  return {
+    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+  } as any;
 };
 
 const deserializeAws_restJson1MedicalAlternative = (output: any, context: __SerdeContext): MedicalAlternative => {
@@ -873,6 +903,49 @@ const deserializeAws_restJson1MedicalTranscriptEvent = (
   } as any;
 };
 
+const deserializeAws_restJson1MedicalTranscriptResultStream = (
+  output: any,
+  context: __SerdeContext
+): MedicalTranscriptResultStream => {
+  if (output.BadRequestException !== undefined && output.BadRequestException !== null) {
+    return {
+      BadRequestException: deserializeAws_restJson1BadRequestException(output.BadRequestException, context),
+    };
+  }
+  if (output.ConflictException !== undefined && output.ConflictException !== null) {
+    return {
+      ConflictException: deserializeAws_restJson1ConflictException(output.ConflictException, context),
+    };
+  }
+  if (output.InternalFailureException !== undefined && output.InternalFailureException !== null) {
+    return {
+      InternalFailureException: deserializeAws_restJson1InternalFailureException(
+        output.InternalFailureException,
+        context
+      ),
+    };
+  }
+  if (output.LimitExceededException !== undefined && output.LimitExceededException !== null) {
+    return {
+      LimitExceededException: deserializeAws_restJson1LimitExceededException(output.LimitExceededException, context),
+    };
+  }
+  if (output.ServiceUnavailableException !== undefined && output.ServiceUnavailableException !== null) {
+    return {
+      ServiceUnavailableException: deserializeAws_restJson1ServiceUnavailableException(
+        output.ServiceUnavailableException,
+        context
+      ),
+    };
+  }
+  if (output.TranscriptEvent !== undefined && output.TranscriptEvent !== null) {
+    return {
+      TranscriptEvent: deserializeAws_restJson1MedicalTranscriptEvent(output.TranscriptEvent, context),
+    };
+  }
+  return { $unknown: Object.entries(output)[0] };
+};
+
 const deserializeAws_restJson1Result = (output: any, context: __SerdeContext): Result => {
   return {
     Alternatives:
@@ -898,6 +971,15 @@ const deserializeAws_restJson1ResultList = (output: any, context: __SerdeContext
     });
 };
 
+const deserializeAws_restJson1ServiceUnavailableException = (
+  output: any,
+  context: __SerdeContext
+): ServiceUnavailableException => {
+  return {
+    Message: output.Message !== undefined && output.Message !== null ? output.Message : undefined,
+  } as any;
+};
+
 const deserializeAws_restJson1Transcript = (output: any, context: __SerdeContext): Transcript => {
   return {
     Results:
@@ -914,6 +996,49 @@ const deserializeAws_restJson1TranscriptEvent = (output: any, context: __SerdeCo
         ? deserializeAws_restJson1Transcript(output.Transcript, context)
         : undefined,
   } as any;
+};
+
+const deserializeAws_restJson1TranscriptResultStream = (
+  output: any,
+  context: __SerdeContext
+): TranscriptResultStream => {
+  if (output.BadRequestException !== undefined && output.BadRequestException !== null) {
+    return {
+      BadRequestException: deserializeAws_restJson1BadRequestException(output.BadRequestException, context),
+    };
+  }
+  if (output.ConflictException !== undefined && output.ConflictException !== null) {
+    return {
+      ConflictException: deserializeAws_restJson1ConflictException(output.ConflictException, context),
+    };
+  }
+  if (output.InternalFailureException !== undefined && output.InternalFailureException !== null) {
+    return {
+      InternalFailureException: deserializeAws_restJson1InternalFailureException(
+        output.InternalFailureException,
+        context
+      ),
+    };
+  }
+  if (output.LimitExceededException !== undefined && output.LimitExceededException !== null) {
+    return {
+      LimitExceededException: deserializeAws_restJson1LimitExceededException(output.LimitExceededException, context),
+    };
+  }
+  if (output.ServiceUnavailableException !== undefined && output.ServiceUnavailableException !== null) {
+    return {
+      ServiceUnavailableException: deserializeAws_restJson1ServiceUnavailableException(
+        output.ServiceUnavailableException,
+        context
+      ),
+    };
+  }
+  if (output.TranscriptEvent !== undefined && output.TranscriptEvent !== null) {
+    return {
+      TranscriptEvent: deserializeAws_restJson1TranscriptEvent(output.TranscriptEvent, context),
+    };
+  }
+  return { $unknown: Object.entries(output)[0] };
 };
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({

--- a/clients/client-xray/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1.ts
@@ -260,7 +260,9 @@ export const serializeAws_restJson1GetEncryptionConfigCommand = async (
   input: GetEncryptionConfigCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/EncryptionConfig";
   let body: any;
   body = "";

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -268,7 +268,9 @@ export const serializeAws_restJson1EmptyInputAndEmptyOutputCommand = async (
   input: EmptyInputAndEmptyOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/EmptyInputAndEmptyOutput";
   let body: any;
   body = "";
@@ -288,7 +290,9 @@ export const serializeAws_restJson1EndpointOperationCommand = async (
   input: EndpointOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/EndpointOperation";
   let body: any;
   body = "";
@@ -350,7 +354,9 @@ export const serializeAws_restJson1GreetingWithErrorsCommand = async (
   input: GreetingWithErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/GreetingWithErrors";
   let body: any;
   body = "";
@@ -501,7 +507,9 @@ export const serializeAws_restJson1HttpPrefixHeadersResponseCommand = async (
   input: HttpPrefixHeadersResponseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/HttpPrefixHeadersResponse";
   let body: any;
   body = "";
@@ -738,7 +746,9 @@ export const serializeAws_restJson1HttpResponseCodeCommand = async (
   input: HttpResponseCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/HttpResponseCode";
   let body: any;
   body = "";
@@ -782,7 +792,9 @@ export const serializeAws_restJson1IgnoreQueryParamsInResponseCommand = async (
   input: IgnoreQueryParamsInResponseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/IgnoreQueryParamsInResponse";
   let body: any;
   body = "";
@@ -1148,7 +1160,9 @@ export const serializeAws_restJson1NoInputAndNoOutputCommand = async (
   input: NoInputAndNoOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/NoInputAndNoOutput";
   let body: any;
   body = "";
@@ -1168,7 +1182,9 @@ export const serializeAws_restJson1NoInputAndOutputCommand = async (
   input: NoInputAndOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/json",
+  };
   let resolvedPath = "/NoInputAndOutputOutput";
   let body: any;
   body = "";

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -323,7 +323,9 @@ export const serializeAws_restXmlEmptyInputAndEmptyOutputCommand = async (
   input: EmptyInputAndEmptyOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/EmptyInputAndEmptyOutput";
   let body: any;
   body = "";
@@ -343,7 +345,9 @@ export const serializeAws_restXmlEndpointOperationCommand = async (
   input: EndpointOperationCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/EndpointOperation";
   let body: any;
   body = "";
@@ -503,7 +507,9 @@ export const serializeAws_restXmlFlattenedXmlMapWithXmlNamespaceCommand = async 
   input: FlattenedXmlMapWithXmlNamespaceCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/FlattenedXmlMapWithXmlNamespace";
   let body: any;
   body = "";
@@ -523,7 +529,9 @@ export const serializeAws_restXmlGreetingWithErrorsCommand = async (
   input: GreetingWithErrorsCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/GreetingWithErrors";
   let body: any;
   body = "";
@@ -549,6 +557,9 @@ export const serializeAws_restXmlHttpPayloadTraitsCommand = async (
   };
   let resolvedPath = "/HttpPayloadTraits";
   let body: any;
+  if (input.blob !== undefined) {
+    body = input.blob;
+  }
   let contents: any;
   if (input.blob !== undefined) {
     contents = input.blob;
@@ -576,6 +587,9 @@ export const serializeAws_restXmlHttpPayloadTraitsWithMediaTypeCommand = async (
   };
   let resolvedPath = "/HttpPayloadTraitsWithMediaType";
   let body: any;
+  if (input.blob !== undefined) {
+    body = input.blob;
+  }
   let contents: any;
   if (input.blob !== undefined) {
     contents = input.blob;
@@ -602,6 +616,9 @@ export const serializeAws_restXmlHttpPayloadWithMemberXmlNameCommand = async (
   };
   let resolvedPath = "/HttpPayloadWithMemberXmlName";
   let body: any;
+  if (input.nested !== undefined) {
+    body = serializeAws_restXmlPayloadWithXmlName(input.nested, context);
+  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = serializeAws_restXmlPayloadWithXmlName(input.nested, context);
@@ -629,6 +646,9 @@ export const serializeAws_restXmlHttpPayloadWithStructureCommand = async (
   };
   let resolvedPath = "/HttpPayloadWithStructure";
   let body: any;
+  if (input.nested !== undefined) {
+    body = serializeAws_restXmlNestedPayload(input.nested, context);
+  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = serializeAws_restXmlNestedPayload(input.nested, context);
@@ -656,6 +676,9 @@ export const serializeAws_restXmlHttpPayloadWithXmlNameCommand = async (
   };
   let resolvedPath = "/HttpPayloadWithXmlName";
   let body: any;
+  if (input.nested !== undefined) {
+    body = serializeAws_restXmlPayloadWithXmlName(input.nested, context);
+  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = serializeAws_restXmlPayloadWithXmlName(input.nested, context);
@@ -683,6 +706,9 @@ export const serializeAws_restXmlHttpPayloadWithXmlNamespaceCommand = async (
   };
   let resolvedPath = "/HttpPayloadWithXmlNamespace";
   let body: any;
+  if (input.nested !== undefined) {
+    body = serializeAws_restXmlPayloadWithXmlNamespace(input.nested, context);
+  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = serializeAws_restXmlPayloadWithXmlNamespace(input.nested, context);
@@ -711,6 +737,9 @@ export const serializeAws_restXmlHttpPayloadWithXmlNamespaceAndPrefixCommand = a
   };
   let resolvedPath = "/HttpPayloadWithXmlNamespaceAndPrefix";
   let body: any;
+  if (input.nested !== undefined) {
+    body = serializeAws_restXmlPayloadWithXmlNamespaceAndPrefix(input.nested, context);
+  }
   let contents: any;
   if (input.nested !== undefined) {
     contents = serializeAws_restXmlPayloadWithXmlNamespaceAndPrefix(input.nested, context);
@@ -980,7 +1009,9 @@ export const serializeAws_restXmlHttpResponseCodeCommand = async (
   input: HttpResponseCodeCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/HttpResponseCode";
   let body: any;
   body = "";
@@ -1000,7 +1031,9 @@ export const serializeAws_restXmlIgnoreQueryParamsInResponseCommand = async (
   input: IgnoreQueryParamsInResponseCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/IgnoreQueryParamsInResponse";
   let body: any;
   body = "";
@@ -1113,7 +1146,9 @@ export const serializeAws_restXmlNoInputAndNoOutputCommand = async (
   input: NoInputAndNoOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/NoInputAndNoOutput";
   let body: any;
   body = "";
@@ -1133,7 +1168,9 @@ export const serializeAws_restXmlNoInputAndOutputCommand = async (
   input: NoInputAndOutputCommandInput,
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
-  const headers: any = {};
+  const headers: any = {
+    "content-type": "application/xml",
+  };
   let resolvedPath = "/NoInputAndOutputOutput";
   let body: any;
   body = "";
@@ -1468,6 +1505,9 @@ export const serializeAws_restXmlXmlAttributesOnPayloadCommand = async (
   };
   let resolvedPath = "/XmlAttributesOnPayload";
   let body: any;
+  if (input.payload !== undefined) {
+    body = serializeAws_restXmlXmlAttributesInputOutput(input.payload, context);
+  }
   let contents: any;
   if (input.payload !== undefined) {
     contents = serializeAws_restXmlXmlAttributesInputOutput(input.payload, context);


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/305

### Description
Write content-type header for missing operations

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
