### PR TITLE
feat(middleware-bucket-endpoint): arn supports fips & handles global regions

### DIFF
--- a/packages/middleware-bucket-endpoint/src/bucketHostname.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.ts
@@ -9,6 +9,7 @@ import {
   isDnsCompatibleBucketName,
   validateAccountId,
   validateArnEndpointOptions,
+  validateClientRegion,
   validateDNSHostLabel,
   validateNoDualstack,
   validateNoFIPS,
@@ -66,7 +67,7 @@ const getEndpointFromArn = (options: ArnHostnameParams & { isCustomEndpoint: boo
   validateService(service);
   validatePartition(partition, { clientPartition });
   validateAccountId(accountId);
-  validateRegion(region, { useArnRegion, clientRegion, clientSigningRegion });
+  validateClientRegion(clientRegion);
   const { accesspointName, outpostId } = getArnResources(resource);
   const DNSHostLabel = `${accesspointName}-${accountId}`;
   validateDNSHostLabel(DNSHostLabel, { tlsCompatible });
@@ -74,6 +75,7 @@ const getEndpointFromArn = (options: ArnHostnameParams & { isCustomEndpoint: boo
   const endpointRegion = useArnRegion ? region : clientRegion;
   const signingRegion = useArnRegion ? region : clientSigningRegion;
   if (service === "s3-object-lambda") {
+    validateRegion(region, { useArnRegion, clientRegion, clientSigningRegion, allowFipsRegion: true });
     validateNoDualstack(dualstackEndpoint);
     return {
       bucketEndpoint: true,
@@ -83,6 +85,7 @@ const getEndpointFromArn = (options: ArnHostnameParams & { isCustomEndpoint: boo
     };
   } else if (outpostId) {
     // if this is an Outpost ARN
+    validateRegion(region, { useArnRegion, clientRegion, clientSigningRegion });
     validateOutpostService(service);
     validateDNSHostLabel(outpostId, { tlsCompatible });
     validateNoDualstack(dualstackEndpoint);
@@ -96,6 +99,7 @@ const getEndpointFromArn = (options: ArnHostnameParams & { isCustomEndpoint: boo
     };
   }
   // construct endpoint from Accesspoint ARN
+  validateRegion(region, { useArnRegion, clientRegion, clientSigningRegion, allowFipsRegion: true });
   validateS3Service(service);
   const hostnamePrefix = `${DNSHostLabel}`;
   return {

--- a/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
@@ -124,12 +124,16 @@ export const validateRegion = (
   region: string,
   options: {
     useArnRegion?: boolean;
+    allowFipsRegion?: boolean;
     clientRegion: string;
     clientSigningRegion: string;
   }
 ) => {
   if (region === "") {
     throw new Error("ARN region is empty");
+  }
+  if (!options.allowFipsRegion && isFipsRegion(region)) {
+    throw new Error("Endpoint does not support FIPS region");
   }
   if (
     !options.useArnRegion &&
@@ -138,8 +142,15 @@ export const validateRegion = (
   ) {
     throw new Error(`Region in ARN is incompatible, got ${region} but expected ${options.clientRegion}`);
   }
-  if (options.useArnRegion && isFipsRegion(region)) {
-    throw new Error("Endpoint does not support FIPS region");
+};
+
+/**
+ *
+ * @param region
+ */
+export const validateClientRegion = (region: string) => {
+  if (["s3-external-1", "aws-global"].includes(getPseudoRegion(region))) {
+    throw new Error(`Client region ${region} is not regional`);
   }
 };
 

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/plugin.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/plugin.spec.ts
@@ -187,7 +187,7 @@ describe("getProcessArnablesMiddleware", () => {
           },
         });
       } catch (e) {
-        expect(e.message).toContain("FIPS region is not supported with Outpost, got fips-us-gov-east-1");
+        expect(e.message).toContain("FIPS region is not supported");
       }
     });
 
@@ -210,7 +210,7 @@ describe("getProcessArnablesMiddleware", () => {
           },
         });
       } catch (e) {
-        expect(e.message).toContain("does not support FIPS region");
+        expect(e.message).toContain("FIPS region is not supported");
       }
     });
 
@@ -432,7 +432,7 @@ describe("getProcessArnablesMiddleware", () => {
           },
         });
       } catch (e) {
-        expect(e.message).toContain("FIPS region is not supported with Outpost, got fips-us-gov-east-1");
+        expect(e.message).toContain("FIPS region is not supported");
       }
     });
 
@@ -455,7 +455,7 @@ describe("getProcessArnablesMiddleware", () => {
           },
         });
       } catch (e) {
-        expect(e.message).toContain("does not support FIPS region");
+        expect(e.message).toContain("FIPS region is not supported");
       }
     });
 


### PR DESCRIPTION
3 formats of ARN s3 accepts is touched in this change: Outposts ARN, AccessPoint ARN,
and ObjectLambda ARN. Here are the changes:
* All of the 3 ARN formats no longer accept s3 global region: s3-global("s3.amazonaws.com"),
s3-external-1("s3-external-1.amazonaws.com").
* Outposts ARN no longer support FIPS region, e.g. fips-us-gov-east-1
* AccessPoint ARN accepts FIPS regions with a special endpoint format, e.g. `{accesspoint-name}-{account-id}.s3-accesspoint[-fips][.dualstack].{region}.{partition}`
* ObjectLambda ARN accepts FIPS regions with a special endpoint format, e.g. `{accesspointName}-{accountId}.s3-object-lambda[-fips].{region}.{dnsSuffix}`

#JS-2608

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
