### PR TITLE
feat(clients): enable Endpoint Discovery

### DIFF
--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -364,6 +364,13 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
+
+  /**
+   * The provider which populates default for endpointDisvoveryEnabled configuration, if it's
+   * not passed during client creation.
+   * @internal
+   */
+  endpointDiscoveryEnabledProvider?: __Provider<boolean | undefined>;
 }
 
 type DynamoDBClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -19,7 +19,11 @@ import {
   DescribeContributorInsightsCommandInput,
   DescribeContributorInsightsCommandOutput,
 } from "./commands/DescribeContributorInsightsCommand";
-import { DescribeEndpointsCommandInput, DescribeEndpointsCommandOutput } from "./commands/DescribeEndpointsCommand";
+import {
+  DescribeEndpointsCommand,
+  DescribeEndpointsCommandInput,
+  DescribeEndpointsCommandOutput,
+} from "./commands/DescribeEndpointsCommand";
 import { DescribeExportCommandInput, DescribeExportCommandOutput } from "./commands/DescribeExportCommand";
 import {
   DescribeGlobalTableCommandInput,

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -370,7 +370,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 
   /**
-   * The provider which populates default for endpointDisvoveryEnabled configuration, if it's
+   * The provider which populates default for endpointDiscoveryEnabled configuration, if it's
    * not passed during client creation.
    * @internal
    */
@@ -448,7 +448,7 @@ export class DynamoDBClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    let _config_7 = resolveEndpointDiscoveryConfig(_config_6);
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, DescribeEndpointsCommand);
     super(_config_7);
     this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -110,6 +110,11 @@ import {
 } from "@aws-sdk/config-resolver";
 import { getContentLengthPlugin } from "@aws-sdk/middleware-content-length";
 import {
+  EndpointDiscoveryInputConfig,
+  EndpointDiscoveryResolvedConfig,
+  resolveEndpointDiscoveryConfig,
+} from "@aws-sdk/middleware-endpoint-discovery";
+import {
   HostHeaderInputConfig,
   HostHeaderResolvedConfig,
   getHostHeaderPlugin,
@@ -368,7 +373,8 @@ type DynamoDBClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptio
   RetryInputConfig &
   HostHeaderInputConfig &
   AwsAuthInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  EndpointDiscoveryInputConfig;
 /**
  * The configuration interface of DynamoDBClient class constructor that set the region, credentials and other options.
  */
@@ -381,7 +387,8 @@ type DynamoDBClientResolvedConfigType = __SmithyResolvedConfiguration<__HttpHand
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  EndpointDiscoveryResolvedConfig;
 /**
  * The resolved configuration interface of DynamoDBClient class. This is resolved and normalized from the {@link DynamoDBClientConfig | constructor configuration interface}.
  */
@@ -430,8 +437,9 @@ export class DynamoDBClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/hash-node": "3.15.0",
     "@aws-sdk/invalid-dependency": "3.15.0",
     "@aws-sdk/middleware-content-length": "3.15.0",
+    "@aws-sdk/middleware-endpoint-discovery": "3.0.0",
     "@aws-sdk/middleware-host-header": "3.15.0",
     "@aws-sdk/middleware-logger": "3.15.0",
     "@aws-sdk/middleware-retry": "3.15.0",

--- a/clients/client-dynamodb/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb/runtimeConfig.browser.ts
@@ -25,6 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
+  endpointDiscoveryEnabledProvider: () => Promise.resolve(undefined),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-dynamodb/runtimeConfig.ts
+++ b/clients/client-dynamodb/runtimeConfig.ts
@@ -4,6 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
+import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
@@ -28,6 +29,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
+  endpointDiscoveryEnabledProvider: loadNodeConfig(NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -166,6 +166,13 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
+
+  /**
+   * The provider which populates default for endpointDisvoveryEnabled configuration, if it's
+   * not passed during client creation.
+   * @internal
+   */
+  endpointDiscoveryEnabledProvider?: __Provider<boolean | undefined>;
 }
 
 type TimestreamQueryClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -172,7 +172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 
   /**
-   * The provider which populates default for endpointDisvoveryEnabled configuration, if it's
+   * The provider which populates default for endpointDiscoveryEnabled configuration, if it's
    * not passed during client creation.
    * @internal
    */
@@ -234,7 +234,7 @@ export class TimestreamQueryClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    let _config_7 = resolveEndpointDiscoveryConfig(_config_6);
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, DescribeEndpointsCommand);
     super(_config_7);
     this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -1,5 +1,9 @@
 import { CancelQueryCommandInput, CancelQueryCommandOutput } from "./commands/CancelQueryCommand";
-import { DescribeEndpointsCommandInput, DescribeEndpointsCommandOutput } from "./commands/DescribeEndpointsCommand";
+import {
+  DescribeEndpointsCommand,
+  DescribeEndpointsCommandInput,
+  DescribeEndpointsCommandOutput,
+} from "./commands/DescribeEndpointsCommand";
 import { QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
 import { ClientDefaultValues as __ClientDefaultValues } from "./runtimeConfig";
 import {

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -12,6 +12,11 @@ import {
 } from "@aws-sdk/config-resolver";
 import { getContentLengthPlugin } from "@aws-sdk/middleware-content-length";
 import {
+  EndpointDiscoveryInputConfig,
+  EndpointDiscoveryResolvedConfig,
+  resolveEndpointDiscoveryConfig,
+} from "@aws-sdk/middleware-endpoint-discovery";
+import {
   HostHeaderInputConfig,
   HostHeaderResolvedConfig,
   getHostHeaderPlugin,
@@ -170,7 +175,8 @@ type TimestreamQueryClientConfigType = Partial<__SmithyConfiguration<__HttpHandl
   RetryInputConfig &
   HostHeaderInputConfig &
   AwsAuthInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  EndpointDiscoveryInputConfig;
 /**
  * The configuration interface of TimestreamQueryClient class constructor that set the region, credentials and other options.
  */
@@ -183,7 +189,8 @@ type TimestreamQueryClientResolvedConfigType = __SmithyResolvedConfiguration<__H
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  EndpointDiscoveryResolvedConfig;
 /**
  * The resolved configuration interface of TimestreamQueryClient class. This is resolved and normalized from the {@link TimestreamQueryClientConfig | constructor configuration interface}.
  */
@@ -216,8 +223,9 @@ export class TimestreamQueryClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/clients/client-timestream-query/commands/CancelQueryCommand.ts
+++ b/clients/client-timestream-query/commands/CancelQueryCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0CancelQueryCommand,
   serializeAws_json1_0CancelQueryCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -64,6 +65,7 @@ export class CancelQueryCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CancelQueryCommandInput, CancelQueryCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-query/commands/QueryCommand.ts
+++ b/clients/client-timestream-query/commands/QueryCommand.ts
@@ -1,6 +1,7 @@
 import { ServiceInputTypes, ServiceOutputTypes, TimestreamQueryClientResolvedConfig } from "../TimestreamQueryClient";
 import { QueryRequest, QueryResponse } from "../models/models_0";
 import { deserializeAws_json1_0QueryCommand, serializeAws_json1_0QueryCommand } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -55,6 +56,7 @@ export class QueryCommand extends $Command<QueryCommandInput, QueryCommandOutput
     options?: __HttpHandlerOptions
   ): Handler<QueryCommandInput, QueryCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/hash-node": "3.15.0",
     "@aws-sdk/invalid-dependency": "3.15.0",
     "@aws-sdk/middleware-content-length": "3.15.0",
+    "@aws-sdk/middleware-endpoint-discovery": "3.0.0",
     "@aws-sdk/middleware-host-header": "3.15.0",
     "@aws-sdk/middleware-logger": "3.15.0",
     "@aws-sdk/middleware-retry": "3.15.0",

--- a/clients/client-timestream-query/runtimeConfig.browser.ts
+++ b/clients/client-timestream-query/runtimeConfig.browser.ts
@@ -25,6 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
+  endpointDiscoveryEnabledProvider: () => Promise.resolve(undefined),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-timestream-query/runtimeConfig.ts
+++ b/clients/client-timestream-query/runtimeConfig.ts
@@ -4,6 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
+import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
@@ -28,6 +29,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
+  endpointDiscoveryEnabledProvider: loadNodeConfig(NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -217,7 +217,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   defaultUserAgentProvider?: Provider<__UserAgent>;
 
   /**
-   * The provider which populates default for endpointDisvoveryEnabled configuration, if it's
+   * The provider which populates default for endpointDiscoveryEnabled configuration, if it's
    * not passed during client creation.
    * @internal
    */
@@ -277,7 +277,7 @@ export class TimestreamWriteClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    let _config_7 = resolveEndpointDiscoveryConfig(_config_6);
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, DescribeEndpointsCommand);
     super(_config_7);
     this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -3,7 +3,11 @@ import { CreateTableCommandInput, CreateTableCommandOutput } from "./commands/Cr
 import { DeleteDatabaseCommandInput, DeleteDatabaseCommandOutput } from "./commands/DeleteDatabaseCommand";
 import { DeleteTableCommandInput, DeleteTableCommandOutput } from "./commands/DeleteTableCommand";
 import { DescribeDatabaseCommandInput, DescribeDatabaseCommandOutput } from "./commands/DescribeDatabaseCommand";
-import { DescribeEndpointsCommandInput, DescribeEndpointsCommandOutput } from "./commands/DescribeEndpointsCommand";
+import {
+  DescribeEndpointsCommand,
+  DescribeEndpointsCommandInput,
+  DescribeEndpointsCommandOutput,
+} from "./commands/DescribeEndpointsCommand";
 import { DescribeTableCommandInput, DescribeTableCommandOutput } from "./commands/DescribeTableCommand";
 import { ListDatabasesCommandInput, ListDatabasesCommandOutput } from "./commands/ListDatabasesCommand";
 import { ListTablesCommandInput, ListTablesCommandOutput } from "./commands/ListTablesCommand";

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -27,6 +27,11 @@ import {
 } from "@aws-sdk/config-resolver";
 import { getContentLengthPlugin } from "@aws-sdk/middleware-content-length";
 import {
+  EndpointDiscoveryInputConfig,
+  EndpointDiscoveryResolvedConfig,
+  resolveEndpointDiscoveryConfig,
+} from "@aws-sdk/middleware-endpoint-discovery";
+import {
   HostHeaderInputConfig,
   HostHeaderResolvedConfig,
   getHostHeaderPlugin,
@@ -215,7 +220,8 @@ type TimestreamWriteClientConfigType = Partial<__SmithyConfiguration<__HttpHandl
   RetryInputConfig &
   HostHeaderInputConfig &
   AwsAuthInputConfig &
-  UserAgentInputConfig;
+  UserAgentInputConfig &
+  EndpointDiscoveryInputConfig;
 /**
  * The configuration interface of TimestreamWriteClient class constructor that set the region, credentials and other options.
  */
@@ -228,7 +234,8 @@ type TimestreamWriteClientResolvedConfigType = __SmithyResolvedConfiguration<__H
   RetryResolvedConfig &
   HostHeaderResolvedConfig &
   AwsAuthResolvedConfig &
-  UserAgentResolvedConfig;
+  UserAgentResolvedConfig &
+  EndpointDiscoveryResolvedConfig;
 /**
  * The resolved configuration interface of TimestreamWriteClient class. This is resolved and normalized from the {@link TimestreamWriteClientConfig | constructor configuration interface}.
  */
@@ -259,8 +266,9 @@ export class TimestreamWriteClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -211,6 +211,13 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * @internal
    */
   defaultUserAgentProvider?: Provider<__UserAgent>;
+
+  /**
+   * The provider which populates default for endpointDisvoveryEnabled configuration, if it's
+   * not passed during client creation.
+   * @internal
+   */
+  endpointDiscoveryEnabledProvider?: __Provider<boolean | undefined>;
 }
 
 type TimestreamWriteClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-timestream-write/commands/CreateDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/CreateDatabaseCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0CreateDatabaseCommand,
   serializeAws_json1_0CreateDatabaseCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -63,6 +64,7 @@ export class CreateDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateDatabaseCommandInput, CreateDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/CreateTableCommand.ts
+++ b/clients/client-timestream-write/commands/CreateTableCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0CreateTableCommand,
   serializeAws_json1_0CreateTableCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -67,6 +68,7 @@ export class CreateTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateTableCommandInput, CreateTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DeleteDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/DeleteDatabaseCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0DeleteDatabaseCommand,
   serializeAws_json1_0DeleteDatabaseCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -68,6 +69,7 @@ export class DeleteDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteDatabaseCommandInput, DeleteDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DeleteTableCommand.ts
+++ b/clients/client-timestream-write/commands/DeleteTableCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0DeleteTableCommand,
   serializeAws_json1_0DeleteTableCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -65,6 +66,7 @@ export class DeleteTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteTableCommandInput, DeleteTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DescribeDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/DescribeDatabaseCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0DescribeDatabaseCommand,
   serializeAws_json1_0DescribeDatabaseCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -62,6 +63,7 @@ export class DescribeDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeDatabaseCommandInput, DescribeDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DescribeTableCommand.ts
+++ b/clients/client-timestream-write/commands/DescribeTableCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0DescribeTableCommand,
   serializeAws_json1_0DescribeTableCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -63,6 +64,7 @@ export class DescribeTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeTableCommandInput, DescribeTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/ListDatabasesCommand.ts
+++ b/clients/client-timestream-write/commands/ListDatabasesCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0ListDatabasesCommand,
   serializeAws_json1_0ListDatabasesCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -62,6 +63,7 @@ export class ListDatabasesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListDatabasesCommandInput, ListDatabasesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/ListTablesCommand.ts
+++ b/clients/client-timestream-write/commands/ListTablesCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0ListTablesCommand,
   serializeAws_json1_0ListTablesCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -61,6 +62,7 @@ export class ListTablesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListTablesCommandInput, ListTablesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/ListTagsForResourceCommand.ts
+++ b/clients/client-timestream-write/commands/ListTagsForResourceCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0ListTagsForResourceCommand,
   serializeAws_json1_0ListTagsForResourceCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -62,6 +63,7 @@ export class ListTagsForResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListTagsForResourceCommandInput, ListTagsForResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/TagResourceCommand.ts
+++ b/clients/client-timestream-write/commands/TagResourceCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0TagResourceCommand,
   serializeAws_json1_0TagResourceCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -64,6 +65,7 @@ export class TagResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<TagResourceCommandInput, TagResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/UntagResourceCommand.ts
+++ b/clients/client-timestream-write/commands/UntagResourceCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0UntagResourceCommand,
   serializeAws_json1_0UntagResourceCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -62,6 +63,7 @@ export class UntagResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UntagResourceCommandInput, UntagResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/UpdateDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/UpdateDatabaseCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0UpdateDatabaseCommand,
   serializeAws_json1_0UpdateDatabaseCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -64,6 +65,7 @@ export class UpdateDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateDatabaseCommandInput, UpdateDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/UpdateTableCommand.ts
+++ b/clients/client-timestream-write/commands/UpdateTableCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0UpdateTableCommand,
   serializeAws_json1_0UpdateTableCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -66,6 +67,7 @@ export class UpdateTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateTableCommandInput, UpdateTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/WriteRecordsCommand.ts
+++ b/clients/client-timestream-write/commands/WriteRecordsCommand.ts
@@ -4,6 +4,7 @@ import {
   deserializeAws_json1_0WriteRecordsCommand,
   serializeAws_json1_0WriteRecordsCommand,
 } from "../protocols/Aws_json1_0";
+import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -73,6 +74,7 @@ export class WriteRecordsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<WriteRecordsCommandInput, WriteRecordsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/hash-node": "3.15.0",
     "@aws-sdk/invalid-dependency": "3.15.0",
     "@aws-sdk/middleware-content-length": "3.15.0",
+    "@aws-sdk/middleware-endpoint-discovery": "3.0.0",
     "@aws-sdk/middleware-host-header": "3.15.0",
     "@aws-sdk/middleware-logger": "3.15.0",
     "@aws-sdk/middleware-retry": "3.15.0",

--- a/clients/client-timestream-write/runtimeConfig.browser.ts
+++ b/clients/client-timestream-write/runtimeConfig.browser.ts
@@ -25,6 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
+  endpointDiscoveryEnabledProvider: () => Promise.resolve(undefined),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-timestream-write/runtimeConfig.ts
+++ b/clients/client-timestream-write/runtimeConfig.ts
@@ -4,6 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
+import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
 import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
@@ -28,6 +29,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
+  endpointDiscoveryEnabledProvider: loadNodeConfig(NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -55,8 +55,8 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
             // Add import for endpoint discovery command here, as getClientPlugins doesn't have access to writer.
             addEndpointDiscoveryCommandImport(model, symbolProvider, service, writer);
             writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-            writer.writeDocs("The provider which populates default for endpointDisvoveryEnabled configuration, if it's\n"
-                + "not passed during client creation.\n@internal")
+            writer.writeDocs("The provider which populates default for endpointDiscoveryEnabled configuration,"
+                + " if it's\nnot passed during client creation.\n@internal")
                 .write("endpointDiscoveryEnabledProvider?: __Provider<boolean | undefined>;\n");
         }
     }
@@ -67,6 +67,8 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
+                        // ToDo: The Endpoint Discovery Command Name needs to be read from ClientEndpointDiscoveryTrait.
+                        .additionalResolveFunctionParameters("DescribeEndpointsCommand")
                         .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
                         .build()
         );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-
 import software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientDiscoveredEndpointTrait;
 import software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryTrait;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -34,7 +33,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
-import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -44,7 +42,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
-    
+
     @Override
     public void addConfigInterfaceFields(
         TypeScriptSettings settings,
@@ -87,7 +85,6 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                         .additionalPluginFunctionParameters(new String[]{"clientStack", "options"})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointOptional(s, o))
                         .build()
-                
         );
     }
 
@@ -142,7 +139,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
     }
 
     private static boolean hasClientEndpointDiscovery(ServiceShape service) {
-        if(service.hasTrait(ClientEndpointDiscoveryTrait.class)) {
+        if (service.hasTrait(ClientEndpointDiscoveryTrait.class)) {
             return true;
         }
         return false;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -48,7 +48,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
         TypeScriptWriter writer
     ) {
         ServiceShape service = settings.getService(model);
-        if (hasClientEndpointDiscovery(model, service)) {
+        if (hasClientEndpointDiscovery(service)) {
             writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
             writer.writeDocs("The provider which populates default for endpointDisvoveryEnabled configuration, if it's\n"
                 + "not passed during client creation.\n@internal")
@@ -62,7 +62,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
-                        .servicePredicate(AddEndpointDiscoveryPlugin::hasClientEndpointDiscovery)
+                        .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
                         .build()
         );
     }
@@ -75,7 +75,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
         LanguageTarget target
     ) {
         ServiceShape service = settings.getService(model);
-        if (!hasClientEndpointDiscovery(model, service)) {
+        if (!hasClientEndpointDiscovery(service)) {
             return Collections.emptyMap();
         }
         switch (target) {
@@ -101,10 +101,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
         }
     }
 
-    private static boolean hasClientEndpointDiscovery(
-            Model model,
-            ServiceShape service
-    ) {
+    private static boolean hasClientEndpointDiscovery(ServiceShape service) {
         if(service.getTrait(ClientEndpointDiscoveryTrait.class).isPresent()) {
             return true;
         }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -78,13 +78,13 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryRequired", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .additionalResolveFunctionParameters(new String[]{"clientStack", "options"})
+                        .additionalPluginFunctionParameters(new String[]{"clientStack", "options"})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointRequired(s, o))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryOptional", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .additionalResolveFunctionParameters(new String[]{"clientStack", "options"})
+                        .additionalPluginFunctionParameters(new String[]{"clientStack", "options"})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointOptional(s, o))
                         .build()
                 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.List;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds runtime plugins which handle endpoint discovery logic.
+ */
+@SmithyInternalApi
+public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+                RuntimeClientPlugin.builder()
+                        .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
+                                "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
+                        .servicePredicate(AddEndpointDiscoveryPlugin::hasClientEndpointDiscovery)
+                        .build()
+        );
+    }
+
+    private static boolean hasClientEndpointDiscovery(
+            Model model,
+            ServiceShape service
+    ) {
+        return true;
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.List;
 
+import software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryTrait;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
@@ -45,6 +46,9 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
             Model model,
             ServiceShape service
     ) {
-        return true;
+        if(service.getTrait(ClientEndpointDiscoveryTrait.class).isPresent()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -67,7 +67,8 @@ public enum AwsDependency implements SymbolDependencyContainer {
     MIDDLEWARE_LOGGER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-logger", "3.15.0"),
     MIDDLEWARE_USER_AGENT("dependencies", "@aws-sdk/middleware-user-agent", "3.15.0"),
     AWS_SDK_UTIL_USER_AGENT_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/util-user-agent-browser", "3.15.0"),
-    AWS_SDK_UTIL_USER_AGENT_NODE(NORMAL_DEPENDENCY, "@aws-sdk/util-user-agent-node", "3.15.0");
+    AWS_SDK_UTIL_USER_AGENT_NODE(NORMAL_DEPENDENCY, "@aws-sdk/util-user-agent-node", "3.15.0"),
+    MIDDLEWARE_ENDPOINT_DISCOVERY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-endpoint-discovery", "3.0.0");
 
     public final String packageName;
     public final String version;

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -18,3 +18,4 @@ software.amazon.smithy.aws.typescript.codegen.AddOmitRetryHeadersDependency
 software.amazon.smithy.aws.typescript.codegen.StripNewEnumNames
 software.amazon.smithy.aws.typescript.codegen.AddCrossRegionCopyingPlugin
 software.amazon.smithy.aws.typescript.codegen.AddDocumentClientPlugin
+software.amazon.smithy.aws.typescript.codegen.AddEndpointDiscoveryPlugin


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2211

### Description
Enables Endpoint Discovery on clients which have clientEndpointDiscovery smithy trait set.

### Testing
Tested with the following code:

```js
import { TimestreamQuery } from "../aws-sdk-js-v3/clients/client-timestream-query/dist/cjs/index.js";

const region = "us-west-2";
const client = new TimestreamQuery({ region, logger: console });

const DatabaseName = `Database1619998684282`;
const TableName = `Table1619998684282`;
const QueryString = `SELECT * FROM ${DatabaseName}.${TableName} ORDER BY time`;

await Promise.all([
  client.query({ QueryString }),
  client.query({ QueryString: `${QueryString} LIMIT 2` }),
  client.query({ QueryString: `${QueryString} LIMIT 5` }),
]);
```

Verified that discovery endpoint operation (i.e. DescribeEndpoints) is called only once although there are three parallel query calls.

```console
{
  clientName: 'TimestreamQueryClient',
  commandName: 'DescribeEndpointsCommand',
  input: { Operation: 'Query', Identifiers: undefined },
  output: { Endpoints: [ [Object] ] },
  metadata: {
    httpStatusCode: 200,
    requestId: '32384c2d-e075-492e-8d9a-02d4cd21fe69',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
{
  clientName: 'TimestreamQueryClient',
  commandName: 'QueryCommand',
  input: { QueryString: '***SensitiveInformation***' },
  output: {
    ColumnInfo: [ [Object], [Object], [Object], [Object], [Object], [Object] ],
    NextToken: undefined,
    QueryId: 'AEDACAM4AC55UWHUXUYJ4JBU7VT76KSI5RM47JCDJYSIAN5VXANLIJG3QK24XEY',
    QueryStatus: {
      CumulativeBytesMetered: 10000000,
      CumulativeBytesScanned: 1048,
      ProgressPercentage: 100
    },
    Rows: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ]
  },
  metadata: {
    httpStatusCode: 200,
    requestId: 'K6W27XSYKRL7HD36HOW5WTWTUE',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
{
  clientName: 'TimestreamQueryClient',
  commandName: 'QueryCommand',
  input: { QueryString: '***SensitiveInformation***' },
  output: {
    ColumnInfo: [ [Object], [Object], [Object], [Object], [Object], [Object] ],
    NextToken: undefined,
    QueryId: 'AEDACAM4AC5YR3ZREISR2NVE723ZZENOCEU4HKFCT4REEANXSZ5ITP7RCD47PGI',
    QueryStatus: {
      CumulativeBytesMetered: 10000000,
      CumulativeBytesScanned: 1048,
      ProgressPercentage: 100
    },
    Rows: [ [Object], [Object] ]
  },
  metadata: {
    httpStatusCode: 200,
    requestId: 'AJSTGRM3WS4UTI7CDAQYPQF5WE',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
{
  clientName: 'TimestreamQueryClient',
  commandName: 'QueryCommand',
  input: { QueryString: '***SensitiveInformation***' },
  output: {
    ColumnInfo: [ [Object], [Object], [Object], [Object], [Object], [Object] ],
    NextToken: undefined,
    QueryId: 'AEDACAM4AC5RFCPYGQPYPGWSOSAR7A54WJ2FBWOEZ2EQIAHOOXGYGUXX6EJS6NA',
    QueryStatus: {
      CumulativeBytesMetered: 10000000,
      CumulativeBytesScanned: 1048,
      ProgressPercentage: 100
    },
    Rows: [ [Object], [Object], [Object], [Object], [Object] ]
  },
  metadata: {
    httpStatusCode: 200,
    requestId: '73SI4DZ4R2KESFKBFJL6KKEE4Y',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
