### PR TITLE
fix(endpoint-cache): reduce bundle size

### DIFF
--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -1,9 +1,9 @@
-import { LRUCache } from "mnemonist";
+import LRUCache from "mnemonist/lru-cache";
 
 import { Endpoint } from "./Endpoint";
 import { EndpointCache } from "./EndpointCache";
 
-jest.mock("mnemonist");
+jest.mock("mnemonist/lru-cache");
 
 describe(EndpointCache.name, () => {
   let endpointCache;

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -1,4 +1,4 @@
-import { LRUCache } from "mnemonist";
+import LRUCache from "mnemonist/lru-cache";
 
 import { Endpoint } from "./Endpoint";
 


### PR DESCRIPTION
### Description
`mnemonist` is a pretty big (well, for web-bundles anyway) commonjs package, which is currently included IN FULL from the endpoint-cache package. This is less than ideal when using the sdk on the frontend side, since it adds about 270kb to the bundle (before minification).

Since only the LRU-Cache is needed, changing the import to directly target the lru-cache module helps bundlers tree shake correctly, reducing the included code to about 15kb.

### Testing
I ran compilation on the `endpoint-cache` package and executed the commonjs build via `node dist/cjs/EndpointCache.js` just to check if the import would throw. I tested the es build integrated in my webpack project to check the reduced bundle size.
Also ran `yarn test:all`

### Additional context
Before:
![image](https://user-images.githubusercontent.com/10298987/118411730-5e659f80-b696-11eb-9c06-9f57e2e0e522.png)
After:
![image](https://user-images.githubusercontent.com/10298987/118411767-83f2a900-b696-11eb-84f7-80894c8283d2.png)


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
