### PR TITLE
docs(lib-storage): fix typo paralell -> parallel

### DIFF
--- a/lib/lib-storage/README.md
+++ b/lib/lib-storage/README.md
@@ -13,7 +13,7 @@ Upload allows for easy and efficient uploading of buffers, blobs, or streams, us
 
   const target = { Bucket, Key, Body };
   try {
-    const paralellUploads3 = new Upload({
+    const parallelUploads3 = new Upload({
       client: new S3({}) || new S3Client({}),
       tags: [...], // optional tags
       queueSize: 4, // optional concurrency configuration
@@ -22,11 +22,11 @@ Upload allows for easy and efficient uploading of buffers, blobs, or streams, us
       params: target,
     });
 
-    paralellUploads3.on("httpUploadProgress", (progress) => {
+    parallelUploads3.on("httpUploadProgress", (progress) => {
       console.log(progress);
     });
 
-    await paralellUploads3.done();
+    await parallelUploads3.done();
   } catch (e) {
     console.log(e);
   }

--- a/lib/lib-storage/example-code/upload-string.ts
+++ b/lib/lib-storage/example-code/upload-string.ts
@@ -9,14 +9,14 @@ const Body =
 
 (async () => {
   const target = { Bucket, Key, Body };
-  const paralellUploads3 = new Upload({
+  const parallelUploads3 = new Upload({
     client: new S3({}),
     params: target,
   });
 
-  paralellUploads3.on("httpUploadProgress", (progress) => {
+  parallelUploads3.on("httpUploadProgress", (progress) => {
     console.log(progress);
   });
 
-  await paralellUploads3.done();
+  await parallelUploads3.done();
 })();


### PR DESCRIPTION
### Description
Fix the typo in the readme and example code
"paralell -> parallel"

### Testing
Example code was tested locally



---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
