### PR TITLE
chore: update java group name

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
         mavenLocal()
         mavenCentral()
     }
-    group = "software.amazon.smithy"
+    group = "software.amazon.smithy.typescript"
     version = "0.3.0"
 }
 

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -21,5 +21,5 @@ dependencies {
     api("software.amazon.smithy:smithy-aws-traits:[1.7.0, 1.8.0[")
     api("software.amazon.smithy:smithy-waiters:[1.7.0, 1.8.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.7.0, 1.8.0[")
-    api("software.amazon.smithy:smithy-typescript-codegen:0.3.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.3.0")
 }


### PR DESCRIPTION
This updates the java group name to `software.amazon.smithy.typescript` so that publishing can be isolated from base smithy.

related: https://github.com/awslabs/smithy-typescript/pull/341

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
