### PR TITLE
feat(credential-provider-node): throw cannot load credential error from credentail chain

### DIFF
--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
@@ -1,5 +1,5 @@
 import { GetCredentialsForIdentityCommand } from "@aws-sdk/client-cognito-identity";
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 import { fromCognitoIdentity } from "./fromCognitoIdentity";
 
@@ -76,7 +76,7 @@ describe("fromCognitoIdentity", () => {
         identityId,
         customRoleArn: "myArn",
       })()
-    ).rejects.toMatchObject(new ProviderError("Response from Amazon Cognito contained no credentials"));
+    ).rejects.toMatchObject(new CredentialsProviderError("Response from Amazon Cognito contained no credentials"));
   });
 
   it("should convert a GetCredentialsForIdentity response without an access key ID to a provider error", async () => {
@@ -93,7 +93,7 @@ describe("fromCognitoIdentity", () => {
         identityId,
         customRoleArn: "myArn",
       })()
-    ).rejects.toMatchObject(new ProviderError("Response from Amazon Cognito contained no access key ID"));
+    ).rejects.toMatchObject(new CredentialsProviderError("Response from Amazon Cognito contained no access key ID"));
   });
 
   it("should convert a GetCredentialsForIdentity response without a secret key to a provider error", async () => {
@@ -110,6 +110,6 @@ describe("fromCognitoIdentity", () => {
         identityId,
         customRoleArn: "myArn",
       })()
-    ).rejects.toMatchObject(new ProviderError("Response from Amazon Cognito contained no secret key"));
+    ).rejects.toMatchObject(new CredentialsProviderError("Response from Amazon Cognito contained no secret key"));
   });
 });

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -1,5 +1,5 @@
 import { GetCredentialsForIdentityCommand } from "@aws-sdk/client-cognito-identity";
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { Credentials, Provider } from "@aws-sdk/types";
 
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
@@ -56,13 +56,13 @@ export interface FromCognitoIdentityParameters extends CognitoProviderParameters
 }
 
 function throwOnMissingAccessKeyId(): never {
-  throw new ProviderError("Response from Amazon Cognito contained no access key ID");
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no access key ID");
 }
 
 function throwOnMissingCredentials(): never {
-  throw new ProviderError("Response from Amazon Cognito contained no credentials");
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no credentials");
 }
 
 function throwOnMissingSecretKey(): never {
-  throw new ProviderError("Response from Amazon Cognito contained no secret key");
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no secret key");
 }

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.spec.ts
@@ -1,5 +1,5 @@
 import { GetIdCommand } from "@aws-sdk/client-cognito-identity";
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 import { fromCognitoIdentityPool } from "./fromCognitoIdentityPool";
 
@@ -127,7 +127,7 @@ describe("fromCognitoIdentityPool", () => {
         client: mockClient,
         identityPoolId,
       })()
-    ).rejects.toMatchObject(new ProviderError("Response from Amazon Cognito contained no identity ID"));
+    ).rejects.toMatchObject(new CredentialsProviderError("Response from Amazon Cognito contained no identity ID"));
   });
 
   it("should allow injecting a custom cache", async () => {

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -1,5 +1,5 @@
 import { GetIdCommand } from "@aws-sdk/client-cognito-identity";
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
 import { CognitoIdentityCredentialProvider, fromCognitoIdentity } from "./fromCognitoIdentity";
@@ -99,5 +99,5 @@ export interface FromCognitoIdentityPoolParameters extends CognitoProviderParame
 }
 
 function throwOnMissingId(): never {
-  throw new ProviderError("Response from Amazon Cognito contained no identity ID");
+  throw new CredentialsProviderError("Response from Amazon Cognito contained no identity ID");
 }

--- a/packages/credential-provider-env/src/index.spec.ts
+++ b/packages/credential-provider-env/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 import { ENV_EXPIRATION, ENV_KEY, ENV_SECRET, ENV_SESSION, fromEnv } from "./";
 
@@ -49,7 +49,7 @@ describe("fromEnv", () => {
 
   it("should reject the promise if no environmental credentials can be found", async () => {
     await expect(fromEnv()()).rejects.toMatchObject(
-      new ProviderError("Unable to find environment variable credentials.")
+      new CredentialsProviderError("Unable to find environment variable credentials.")
     );
   });
 
@@ -59,7 +59,7 @@ describe("fromEnv", () => {
         throw new Error("The promise should have been rejected.");
       },
       (err) => {
-        expect((err as ProviderError).tryNextLink).toBe(true);
+        expect((err as CredentialsProviderError).tryNextLink).toBe(true);
       }
     );
   });

--- a/packages/credential-provider-env/src/index.ts
+++ b/packages/credential-provider-env/src/index.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider } from "@aws-sdk/types";
 
 export const ENV_KEY = "AWS_ACCESS_KEY_ID";
@@ -25,6 +25,6 @@ export function fromEnv(): CredentialProvider {
       });
     }
 
-    return Promise.reject(new ProviderError("Unable to find environment variable credentials."));
+    return Promise.reject(new CredentialsProviderError("Unable to find environment variable credentials."));
   };
 }

--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider } from "@aws-sdk/types";
 import { RequestOptions } from "http";
 import { parse } from "url";
@@ -23,7 +23,7 @@ export const fromContainerMetadata = (init: RemoteProviderInit = {}): Credential
       const requestOptions = await getCmdsUri();
       const credsResponse = JSON.parse(await requestFromEcsImds(timeout, requestOptions));
       if (!isImdsCredentials(credsResponse)) {
-        throw new ProviderError("Invalid response received from instance metadata service.");
+        throw new CredentialsProviderError("Invalid response received from instance metadata service.");
       }
       return fromImdsCredentials(credsResponse);
     }, maxRetries);
@@ -65,11 +65,17 @@ const getCmdsUri = async (): Promise<RequestOptions> => {
   if (process.env[ENV_CMDS_FULL_URI]) {
     const parsed = parse(process.env[ENV_CMDS_FULL_URI]!);
     if (!parsed.hostname || !(parsed.hostname in GREENGRASS_HOSTS)) {
-      throw new ProviderError(`${parsed.hostname} is not a valid container metadata service hostname`, false);
+      throw new CredentialsProviderError(
+        `${parsed.hostname} is not a valid container metadata service hostname`,
+        false
+      );
     }
 
     if (!parsed.protocol || !(parsed.protocol in GREENGRASS_PROTOCOLS)) {
-      throw new ProviderError(`${parsed.protocol} is not a valid container metadata service protocol`, false);
+      throw new CredentialsProviderError(
+        `${parsed.protocol} is not a valid container metadata service protocol`,
+        false
+      );
     }
 
     return {
@@ -78,7 +84,7 @@ const getCmdsUri = async (): Promise<RequestOptions> => {
     };
   }
 
-  throw new ProviderError(
+  throw new CredentialsProviderError(
     "The container metadata credential provider cannot be used unless" +
       ` the ${ENV_CMDS_RELATIVE_URI} or ${ENV_CMDS_FULL_URI} environment` +
       " variable is set",

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.spec.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 import { fromInstanceMetadata } from "./fromInstanceMetadata";
 import { httpRequest } from "./remoteProvider/httpRequest";
@@ -124,7 +124,7 @@ describe("fromInstanceMetadata", () => {
     expect((retry as jest.Mock).mock.calls[1][1]).toBe(mockMaxRetries);
   });
 
-  it("throws ProviderError if credentials returned are incorrect", async () => {
+  it("throws CredentialsProviderError if credentials returned are incorrect", async () => {
     (httpRequest as jest.Mock)
       .mockResolvedValueOnce(mockToken)
       .mockResolvedValueOnce(mockProfile)
@@ -134,7 +134,7 @@ describe("fromInstanceMetadata", () => {
     (isImdsCredentials as unknown as jest.Mock).mockReturnValueOnce(false);
 
     await expect(fromInstanceMetadata()()).rejects.toEqual(
-      new ProviderError("Invalid response received from instance metadata service.")
+      new CredentialsProviderError("Invalid response received from instance metadata service.")
     );
     expect(retry).toHaveBeenCalledTimes(2);
     expect(httpRequest).toHaveBeenCalledTimes(3);

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { RequestOptions } from "http";
 
@@ -103,7 +103,7 @@ const getCredentialsFromProfile = async (profile: string, options: RequestOption
   );
 
   if (!isImdsCredentials(credsResponse)) {
-    throw new ProviderError("Invalid response received from instance metadata service.");
+    throw new CredentialsProviderError("Invalid response received from instance metadata service.");
   }
 
   return fromImdsCredentials(credsResponse);

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.spec.ts
@@ -88,7 +88,9 @@ describe("httpRequest", () => {
       .delay(timeout * 2)
       .reply(200, "expectedResponse");
 
-    await expect(httpRequest({ host, path, port, timeout })).rejects.toStrictEqual(new Error("TimeoutError"));
+    await expect(httpRequest({ host, path, port, timeout })).rejects.toStrictEqual(
+      new ProviderError("TimeoutError from instance metadata service")
+    );
 
     scope.done();
   });

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -14,7 +14,7 @@ export function httpRequest(options: RequestOptions): Promise<Buffer> {
     });
 
     req.on("timeout", () => {
-      reject(new Error("TimeoutError"));
+      reject(new ProviderError("TimeoutError from instance metadata service"));
     });
 
     req.on("response", (res: IncomingMessage) => {

--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -1,7 +1,7 @@
 import { fromEnv } from "@aws-sdk/credential-provider-env";
 import { fromContainerMetadata, fromInstanceMetadata } from "@aws-sdk/credential-provider-imds";
 import { AssumeRoleWithWebIdentityParams, fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import {
   loadSharedConfigFiles,
   ParsedIniData,
@@ -203,14 +203,14 @@ const resolveProfileData = async (
     } = data;
 
     if (!options.roleAssumer) {
-      throw new ProviderError(
+      throw new CredentialsProviderError(
         `Profile ${profileName} requires a role to be assumed, but no` + ` role assumption callback was provided.`,
         false
       );
     }
 
     if (source_profile && source_profile in visitedProfiles) {
-      throw new ProviderError(
+      throw new CredentialsProviderError(
         `Detected a cycle attempting to resolve credentials for profile` +
           ` ${getMasterProfileName(options)}. Profiles visited: ` +
           Object.keys(visitedProfiles).join(", "),
@@ -228,7 +228,7 @@ const resolveProfileData = async (
     const params: AssumeRoleParams = { RoleArn, RoleSessionName, ExternalId };
     if (mfa_serial) {
       if (!options.mfaCodeProvider) {
-        throw new ProviderError(
+        throw new CredentialsProviderError(
           `Profile ${profileName} requires multi-factor authentication,` + ` but no MFA code callback was provided.`,
           false
         );
@@ -257,7 +257,9 @@ const resolveProfileData = async (
   // terminal resolution error if a profile has been specified by the user
   // (whether via a parameter, an environment variable, or another profile's
   // `source_profile` key).
-  throw new ProviderError(`Profile ${profileName} could not be found or parsed in shared` + ` credentials file.`);
+  throw new CredentialsProviderError(
+    `Profile ${profileName} could not be found or parsed in shared` + ` credentials file.`
+  );
 };
 
 /**
@@ -276,7 +278,7 @@ const resolveCredentialSource = (credentialSource: string, profileName: string):
   if (credentialSource in sourceProvidersMap) {
     return sourceProvidersMap[credentialSource]();
   } else {
-    throw new ProviderError(
+    throw new CredentialsProviderError(
       `Unsupported credential source in profile ${profileName}. Got ${credentialSource}, ` +
         `expected EcsContainer or Ec2InstanceMetadata or Environment.`
     );

--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -243,7 +243,7 @@ describe("defaultProvider", () => {
 
     process.env[ENV_IMDS_DISABLED] = "1";
 
-    expect.assertions(2);
+    expect.assertions(1);
     try {
       await defaultProvider()();
     } catch (e) {

--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { fromEnv } from "@aws-sdk/credential-provider-env";
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
 
 import { defaultProvider, ENV_IMDS_DISABLED } from "./";
@@ -129,7 +129,7 @@ describe("defaultProvider", () => {
       secretAccessKey: "bar",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
     (fromSSO() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
@@ -148,10 +148,10 @@ describe("defaultProvider", () => {
       secretAccessKey: "bar",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
     (fromTokenFile() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
@@ -170,9 +170,9 @@ describe("defaultProvider", () => {
       secretAccessKey: "bar",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
     (fromIni() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
@@ -191,9 +191,9 @@ describe("defaultProvider", () => {
       secretAccessKey: "bar",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
     (fromProcess() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
@@ -211,11 +211,11 @@ describe("defaultProvider", () => {
       accessKeyId: "foo",
       secretAccessKey: "bar",
     };
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nope!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.resolve(creds));
 
     expect(await defaultProvider()()).toEqual(creds);
@@ -234,11 +234,11 @@ describe("defaultProvider", () => {
       secretAccessKey: "bar",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nope!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.resolve(creds));
 
     process.env[ENV_IMDS_DISABLED] = "1";
@@ -247,7 +247,10 @@ describe("defaultProvider", () => {
     try {
       await defaultProvider()();
     } catch (e) {
-      expect(e).toMatchObject({ message: "Could not load credentials from any providers", name: "CredentialsError" });
+      expect(e).toMatchObject({
+        message: "Could not load credentials from any providers",
+        name: "CredentialsProviderError",
+      });
     }
   });
 
@@ -257,11 +260,11 @@ describe("defaultProvider", () => {
       secretAccessKey: "bar",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nope!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new Error("PANIC")));
     (fromContainerMetadata() as any).mockImplementation(() => Promise.resolve(creds));
 
@@ -278,19 +281,22 @@ describe("defaultProvider", () => {
   });
 
   it("should throw no credentials error if none of the credential providers can load", async () => {
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
-    (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-    (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("BOOM")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nope!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nor here!")));
+    (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+    (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("BOOM")));
     process.env[ENV_CMDS_RELATIVE_URI] = "/credentials";
     expect.assertions(1);
     try {
       await defaultProvider()();
     } catch (e) {
-      expect(e).toMatchObject({ message: "Could not load credentials from any providers", name: "CredentialsError" });
+      expect(e).toMatchObject({
+        message: "Could not load credentials from any providers",
+        name: "CredentialsProviderError",
+      });
     }
   });
 
@@ -300,11 +306,11 @@ describe("defaultProvider", () => {
       secretAccessKey: "bar",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Nope!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nope!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() => Promise.resolve(creds));
 
     await expect(defaultProvider()()).resolves;
@@ -322,7 +328,7 @@ describe("defaultProvider", () => {
       configFilepath: "/home/user/.secrets/credentials.ini",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
     (fromSSO() as any).mockImplementation(() =>
       Promise.resolve({
         accessKeyId: "foo",
@@ -344,8 +350,8 @@ describe("defaultProvider", () => {
       webIdentityTokenFile: "/home/user/.secrets/tokenFile",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
     (fromTokenFile() as any).mockImplementation(() =>
       Promise.resolve({
         accessKeyId: "foo",
@@ -374,7 +380,7 @@ describe("defaultProvider", () => {
       configFilepath: "/home/user/.secrets/credentials.ini",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
     (fromIni() as any).mockImplementation(() =>
       Promise.resolve({
         accessKeyId: "foo",
@@ -396,8 +402,8 @@ describe("defaultProvider", () => {
       configFilepath: "/home/user/.secrets/credentials.ini",
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
     (fromProcess() as any).mockImplementation(() =>
       Promise.resolve({
         accessKeyId: "foo",
@@ -419,9 +425,9 @@ describe("defaultProvider", () => {
       maxRetries: 3,
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
-    (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("Nor here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
+    (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nor here!")));
     (fromInstanceMetadata() as any).mockImplementation(() =>
       Promise.resolve({
         accessKeyId: "foo",
@@ -443,8 +449,8 @@ describe("defaultProvider", () => {
       maxRetries: 3,
     };
 
-    (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("Keep moving!")));
-    (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+    (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Keep moving!")));
+    (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("Nothing here!")));
     (fromContainerMetadata() as any).mockImplementation(() =>
       Promise.resolve({
         accessKeyId: "foo",
@@ -524,12 +530,12 @@ describe("defaultProvider", () => {
         secretAccessKey: "bar",
       };
 
-      (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
       (fromSSO() as any).mockImplementation(() => Promise.resolve(Promise.resolve(creds)));
-      (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
 
       expect(await defaultProvider({ profile: "foo" })()).toEqual(creds);
       expect((fromEnv() as any).mock.calls.length).toBe(0);
@@ -546,13 +552,13 @@ describe("defaultProvider", () => {
         secretAccessKey: "bar",
       };
 
-      (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
       (fromSSO() as any).mockImplementation(() => Promise.resolve(creds));
-      (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromProcess() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromTokenFile() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromProcess() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
 
       process.env[ENV_PROFILE] = "foo";
       expect(await defaultProvider()()).toEqual(creds);
@@ -571,11 +577,11 @@ describe("defaultProvider", () => {
         secretAccessKey: "bar",
       };
 
-      (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
       (fromIni() as any).mockImplementation(() => Promise.resolve(Promise.resolve(creds)));
-      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
 
       expect(await defaultProvider({ profile: "foo" })()).toEqual(creds);
       expect((fromEnv() as any).mock.calls.length).toBe(0);
@@ -592,12 +598,12 @@ describe("defaultProvider", () => {
         secretAccessKey: "bar",
       };
 
-      (fromEnv() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromSSO() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromEnv() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromSSO() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromIni() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
       (fromProcess() as any).mockImplementation(() => Promise.resolve(creds));
-      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
-      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new ProviderError("PANIC")));
+      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
+      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new CredentialsProviderError("PANIC")));
 
       process.env[ENV_PROFILE] = "foo";
       expect(await defaultProvider()()).toEqual(creds);

--- a/packages/credential-provider-node/src/index.ts
+++ b/packages/credential-provider-node/src/index.ts
@@ -10,7 +10,7 @@ import { ENV_PROFILE, fromIni, FromIniInit } from "@aws-sdk/credential-provider-
 import { fromProcess, FromProcessInit } from "@aws-sdk/credential-provider-process";
 import { fromSSO, FromSSOInit } from "@aws-sdk/credential-provider-sso";
 import { fromTokenFile, FromTokenFileInit } from "@aws-sdk/credential-provider-web-identity";
-import { chain, memoize, ProviderError } from "@aws-sdk/property-provider";
+import { chain, CredentialsProviderError, memoize } from "@aws-sdk/property-provider";
 import { loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider } from "@aws-sdk/types";
 
@@ -62,7 +62,7 @@ export const defaultProvider = (
     fromTokenFile(options),
     remoteProvider(options),
     async () => {
-      throw new ProviderError("Could not load credentials from any providers", false);
+      throw new CredentialsProviderError("Could not load credentials from any providers", false);
     },
   ];
   if (!options.profile) providers.unshift(fromEnv());
@@ -81,7 +81,7 @@ const remoteProvider = (init: RemoteProviderInit): CredentialProvider => {
   }
 
   if (process.env[ENV_IMDS_DISABLED]) {
-    return () => Promise.reject(new ProviderError("EC2 Instance Metadata Service access disabled"));
+    return () => Promise.reject(new CredentialsProviderError("EC2 Instance Metadata Service access disabled"));
   }
 
   return fromInstanceMetadata(init);

--- a/packages/credential-provider-node/src/index.ts
+++ b/packages/credential-provider-node/src/index.ts
@@ -61,6 +61,9 @@ export const defaultProvider = (
     fromProcess(options),
     fromTokenFile(options),
     remoteProvider(options),
+    async () => {
+      throw new ProviderError("Could not load credentials from any providers", false);
+    },
   ];
   if (!options.profile) providers.unshift(fromEnv());
   const providerChain = chain(...providers);

--- a/packages/credential-provider-process/src/index.ts
+++ b/packages/credential-provider-process/src/index.ts
@@ -1,5 +1,5 @@
 import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/credential-provider-ini";
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { ParsedIniData } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { exec } from "child_process";
@@ -72,17 +72,17 @@ const resolveProcessCredentials = async (profileName: string, profiles: ParsedIn
           };
         })
         .catch((error: Error) => {
-          throw new ProviderError(error.message);
+          throw new CredentialsProviderError(error.message);
         });
     } else {
-      throw new ProviderError(`Profile ${profileName} did not contain credential_process.`);
+      throw new CredentialsProviderError(`Profile ${profileName} did not contain credential_process.`);
     }
   } else {
     // If the profile cannot be parsed or does not contain the default or
     // specified profile throw an error. This should be considered a terminal
     // resolution error if a profile has been specified by the user (whether via
     // a parameter, anenvironment variable, or another profile's `source_profile` key).
-    throw new ProviderError(`Profile ${profileName} could not be found in shared credentials file.`);
+    throw new CredentialsProviderError(`Profile ${profileName} could not be found in shared credentials file.`);
   }
 };
 

--- a/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.spec.ts
@@ -9,7 +9,7 @@ const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
 const ENV_ROLE_ARN = "AWS_ROLE_ARN";
 const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
 
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 jest.mock("fs");
 
@@ -123,7 +123,7 @@ describe(fromTokenFile.name, () => {
         await fromTokenFile()();
         fail(`Expected error to be thrown`);
       } catch (error) {
-        expect(error).toBeInstanceOf(ProviderError);
+        expect(error).toBeInstanceOf(CredentialsProviderError);
         expect(error.tryNextLink).toBe(true);
       }
     });
@@ -134,7 +134,7 @@ describe(fromTokenFile.name, () => {
         await fromTokenFile()();
         fail(`Expected error to be thrown`);
       } catch (error) {
-        expect(error).toBeInstanceOf(ProviderError);
+        expect(error).toBeInstanceOf(CredentialsProviderError);
         expect(error.tryNextLink).toBe(true);
       }
     });

--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { readFileSync } from "fs";
 
@@ -30,7 +30,7 @@ const resolveTokenFile = (init?: FromTokenFileInit): Promise<Credentials> => {
   const roleSessionName = init?.roleSessionName ?? process.env[ENV_ROLE_SESSION_NAME];
 
   if (!webIdentityTokenFile || !roleArn) {
-    throw new ProviderError("Web identity configuration not specified");
+    throw new CredentialsProviderError("Web identity configuration not specified");
   }
 
   return fromWebToken({

--- a/packages/credential-provider-web-identity/src/fromWebToken.spec.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.spec.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 import { fromWebToken } from "./fromWebToken";
 
@@ -29,7 +29,7 @@ describe("fromWebToken", () => {
       fail(`Expected error to be thrown`);
     } catch (error) {
       expect(error).toEqual(
-        new ProviderError(
+        new CredentialsProviderError(
           `Role Arn '${mockRoleArn}' needs to be assumed with web identity, but no role assumption callback was provided.`,
           false
         )

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 
 export interface AssumeRoleWithWebIdentityParams {
@@ -142,7 +142,7 @@ export const fromWebToken =
     } = init;
 
     if (!roleAssumerWithWebIdentity) {
-      throw new ProviderError(
+      throw new CredentialsProviderError(
         `Role Arn '${roleArn}' needs to be assumed with web identity,` +
           ` but no role assumption callback was provided.`,
         false

--- a/packages/node-config-provider/src/fromEnv.spec.ts
+++ b/packages/node-config-provider/src/fromEnv.spec.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 
 import { fromEnv, GetterFromEnv } from "./fromEnv";
 
@@ -9,8 +9,8 @@ describe("fromEnv", () => {
     const envVarValue = process.env[envVarName];
     const mockEnvVarValue = "mockEnvVarValue";
 
-    const getProviderError = (getter: GetterFromEnv<string>) =>
-      new ProviderError(`Cannot load config from environment variables with getter: ${getter}`);
+    const getCredentialsProviderError = (getter: GetterFromEnv<string>) =>
+      new CredentialsProviderError(`Cannot load config from environment variables with getter: ${getter}`);
 
     beforeEach(() => {
       delete process.env[envVarName];
@@ -35,7 +35,7 @@ describe("fromEnv", () => {
 
     it(`throws when '${envVarName}' env var is not set`, () => {
       expect.assertions(1);
-      return expect(fromEnv(envVarGetter)()).rejects.toMatchObject(getProviderError(envVarGetter));
+      return expect(fromEnv(envVarGetter)()).rejects.toMatchObject(getCredentialsProviderError(envVarGetter));
     });
 
     it("throws when the getter function throws", () => {

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { Provider } from "@aws-sdk/types";
 
 export type GetterFromEnv<T> = (env: NodeJS.ProcessEnv) => T | undefined;
@@ -17,7 +17,7 @@ export const fromEnv =
       }
       return config as T;
     } catch (e) {
-      throw new ProviderError(
+      throw new CredentialsProviderError(
         e.message || `Cannot load config from environment variables with getter: ${envVarSelector}`
       );
     }

--- a/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { loadSharedConfigFiles, ParsedIniData, Profile } from "@aws-sdk/shared-ini-file-loader";
 
 import { ENV_PROFILE, fromSharedConfigFiles, GetterFromConfig, SharedConfigInit } from "./fromSharedConfigFiles";
@@ -20,8 +20,10 @@ describe("fromSharedConfigFiles", () => {
     process.env[ENV_PROFILE] = envProfile;
   });
 
-  const getProviderError = (profile: string, getter: GetterFromConfig<string>) =>
-    new ProviderError(`Cannot load config for profile ${profile} in SDK configuration files with getter: ${getter}`);
+  const getCredentialsProviderError = (profile: string, getter: GetterFromConfig<string>) =>
+    new CredentialsProviderError(
+      `Cannot load config for profile ${profile} in SDK configuration files with getter: ${getter}`
+    );
 
   describe("loadedConfig", () => {
     const mockConfigAnswer = "mockConfigAnswer";
@@ -134,7 +136,7 @@ describe("fromSharedConfigFiles", () => {
             credentialsFile: iniDataInCredentials,
           });
           return expect(fromSharedConfigFiles(configGetter, { profile, preferredFile })()).rejects.toMatchObject(
-            getProviderError(profile ?? "default", configGetter)
+            getCredentialsProviderError(profile ?? "default", configGetter)
           );
         });
       });
@@ -163,7 +165,7 @@ describe("fromSharedConfigFiles", () => {
           });
           return expect(
             fromSharedConfigFiles(configGetter, { loadedConfig, profile, preferredFile })()
-          ).rejects.toMatchObject(getProviderError(profile ?? "default", configGetter));
+          ).rejects.toMatchObject(getCredentialsProviderError(profile ?? "default", configGetter));
         });
       });
     });
@@ -177,7 +179,7 @@ describe("fromSharedConfigFiles", () => {
         configFile: {},
         credentialsFile: {},
       });
-      return expect(fromSharedConfigFiles(failGetter)()).rejects.toMatchObject(new ProviderError(message));
+      return expect(fromSharedConfigFiles(failGetter)()).rejects.toMatchObject(new CredentialsProviderError(message));
     });
   });
 

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -1,4 +1,4 @@
-import { ProviderError } from "@aws-sdk/property-provider";
+import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import {
   loadSharedConfigFiles,
   Profile,
@@ -61,7 +61,7 @@ export const fromSharedConfigFiles =
       }
       return configValue;
     } catch (e) {
-      throw new ProviderError(
+      throw new CredentialsProviderError(
         e.message ||
           `Cannot load config for profile ${profile} in SDK configuration files with getter: ${configSelector}`
       );

--- a/packages/property-provider/src/ProviderError.spec.ts
+++ b/packages/property-provider/src/ProviderError.spec.ts
@@ -1,16 +1,16 @@
-import { ProviderError } from "./ProviderError";
+import { CredentialsProviderError } from "./ProviderError";
 
 describe("ProviderError", () => {
   it("should be named as CredentialsError", () => {
-    expect(new ProviderError("PANIC").name).toBe("CredentialsError");
+    expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
   });
 
   it("should direct the chain to proceed to the next link by default", () => {
-    expect(new ProviderError("PANIC").tryNextLink).toBe(true);
+    expect(new CredentialsProviderError("PANIC").tryNextLink).toBe(true);
   });
 
   it("should allow errors to halt the chain", () => {
-    expect(new ProviderError("PANIC", false).tryNextLink).toBe(false);
+    expect(new CredentialsProviderError("PANIC", false).tryNextLink).toBe(false);
   });
 
   describe("from()", () => {
@@ -18,7 +18,7 @@ describe("ProviderError", () => {
       const error = new Error("PANIC");
       // @ts-expect-error Property 'someValue' does not exist on type 'Error'.
       error.someValue = "foo";
-      const providerError = ProviderError.from(error);
+      const providerError = CredentialsProviderError.from(error);
       // @ts-expect-error Property 'someValue' does not exist on type 'ProviderError'.
       expect(providerError.someValue).toBe("foo");
       expect(providerError.tryNextLink).toBe(true);

--- a/packages/property-provider/src/ProviderError.spec.ts
+++ b/packages/property-provider/src/ProviderError.spec.ts
@@ -1,7 +1,7 @@
 import { CredentialsProviderError } from "./ProviderError";
 
 describe("ProviderError", () => {
-  it("should be named as CredentialsError", () => {
+  it("should be named as CredentialsProviderError", () => {
     expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
   });
 

--- a/packages/property-provider/src/ProviderError.spec.ts
+++ b/packages/property-provider/src/ProviderError.spec.ts
@@ -1,6 +1,10 @@
 import { ProviderError } from "./ProviderError";
 
 describe("ProviderError", () => {
+  it("should be named as CredentialsError", () => {
+    expect(new ProviderError("PANIC").name).toBe("CredentialsError");
+  });
+
   it("should direct the chain to proceed to the next link by default", () => {
     expect(new ProviderError("PANIC").tryNextLink).toBe(true);
   });

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -6,9 +6,10 @@
  * to the next provider if the value of the `tryNextLink` property on the error
  * is truthy. This allows individual providers to halt the chain and also
  * ensures the chain will stop if an entirely unexpected error is encountered.
+ *
+ * @deprecated
  */
 export class ProviderError extends Error {
-  readonly name = "CredentialsError";
   constructor(message: string, public readonly tryNextLink: boolean = true) {
     super(message);
   }
@@ -20,5 +21,29 @@ export class ProviderError extends Error {
       writable: false,
     });
     return error as ProviderError;
+  }
+}
+
+/**
+ * An error representing a failure of an individual credential provider.
+ *
+ * This error class has special meaning to the {@link chain} method. If a
+ * provider in the chain is rejected with an error, the chain will only proceed
+ * to the next provider if the value of the `tryNextLink` property on the error
+ * is truthy. This allows individual providers to halt the chain and also
+ * ensures the chain will stop if an entirely unexpected error is encountered.
+ */ export class CredentialsProviderError extends Error {
+  readonly name = "CredentialsProviderError";
+  constructor(message: string, public readonly tryNextLink: boolean = true) {
+    super(message);
+  }
+  static from(error: Error, tryNextLink = true): CredentialsProviderError {
+    Object.defineProperty(error, "tryNextLink", {
+      value: tryNextLink,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
+    return error as CredentialsProviderError;
   }
 }

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -8,6 +8,7 @@
  * ensures the chain will stop if an entirely unexpected error is encountered.
  */
 export class ProviderError extends Error {
+  readonly name = "CredentialsError";
   constructor(message: string, public readonly tryNextLink: boolean = true) {
     super(message);
   }

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -32,7 +32,8 @@ export class ProviderError extends Error {
  * to the next provider if the value of the `tryNextLink` property on the error
  * is truthy. This allows individual providers to halt the chain and also
  * ensures the chain will stop if an entirely unexpected error is encountered.
- */ export class CredentialsProviderError extends Error {
+ */
+export class CredentialsProviderError extends Error {
   readonly name = "CredentialsProviderError";
   constructor(message: string, public readonly tryNextLink: boolean = true) {
     super(message);


### PR DESCRIPTION
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2137

### Description
Previously when credential resolve chain fails to resolve the credentials, it throws the error message from the last credential provider. As a result, the error message from the credential provider chain is not helpful, when no credentials can be resolved. For example, users see `Error: TimeoutError` when no credentials can be resolved. This is because the last provider in the credential chain is the Instance Metadata Service, and it will timeout when running on local machine. Instead, we should indicate credential error in the message. 

With this change, if none of the provider can resolve to a valid credential, the Node.js credential provider chain will throw `CredentialsError: Could not load credentials from any providers` just like v2. 

The chain would also throw directly from any credential provider if the thrown error's `tryNextLink` flag is set to false. In this case users will know this is a credential error from the error name `CredentialsError: XXX is wrong`. 

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
