### PR TITLE
feat(codegen): add user agent for non AWS clients

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
@@ -1,0 +1,88 @@
+package software.amazon.smithy.aws.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
+
+public class AddUserAgentDependencyTest {
+    @Test
+    public void addsUserAgentForAwsService() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("NotSame.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                                  .withMember("service", Node.from("smithy.example#OriginalName"))
+                                  .withMember("package", Node.from("example"))
+                                  .withMember("packageVersion", Node.from("1.0.0"))
+                                  .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check that one of the many dependencies was added.
+        assertThat(manifest.getFileString("package.json").get(),
+                   containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
+
+        // Check that both the config files were updated.
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("ClientSharedValues.serviceId"));
+
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("ClientSharedValues.serviceId"));
+
+        // Check that the dependency interface was updated.
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("defaultUserAgentProvider?"));
+    }
+
+    @Test
+    public void addsUserAgentForNonAwsService() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("NonAwsService.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#ExampleService"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check that one of the many dependencies was added.
+        assertThat(manifest.getFileString("package.json").get(),
+                containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
+
+        // Check that both the config files were updated.
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+
+        // Check that the dependency interface was updated.
+        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("defaultUserAgentProvider?"));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/NonAwsService.smithy
+++ b/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/NonAwsService.smithy
@@ -1,0 +1,21 @@
+namespace smithy.example
+
+use aws.protocols#restJson1
+
+@restJson1
+service ExampleService {
+    version: "2019-10-15",
+    operations: [GetFoo]
+}
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
+structure GetFooInput {}
+structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}


### PR DESCRIPTION
### Description
I had disabled user agent plugin for non AWS clients earlier as it depended on serviceId which is not present for non AWS services. This enables it back. serviceId is [optional](https://github.com/aws/aws-sdk-js-v3/blob/10db5ac2aa34d11ecf039ab51071f55985d76cf0/packages/util-user-agent-node/src/index.ts#L10), so omitting it for non AWS services.

### Testing
Added unit tests.

Generated client for non AWS service in demo package and looked at headers sent to the service by this client and compared with AWS service's client.

Demo service client:
```
user-agent: aws-sdk-js/1.0.0-rc.1 os/darwin/19.6.0 lang/js md/nodejs/15.10.0
x-amz-user-agent: aws-sdk-js/1.0.0-rc.1
```
where 1.0.0-rc.1 is the version of generated client in its package.json.

AWS service client (used AccessAnalyzerClient):
```
user-agent: aws-sdk-js/3.16.0 os/darwin/19.6.0 lang/js md/nodejs/15.10.0 api/accessanalyzer/3.16.0
x-amz-user-agent: aws-sdk-js/3.16.0
```

I assume for browser client, the `user-agent` header would not be there but the `x-amz-user-agent` would be.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
