### PR TITLE
fix(client-s3,aws-models): change CompleteMultipartUpload to match doc

### DIFF
--- a/clients/client-s3/models/models_0.ts
+++ b/clients/client-s3/models/models_0.ts
@@ -399,18 +399,18 @@ export namespace CompletedPart {
 /**
  * <p>The container for the completed multipart upload details.</p>
  */
-export interface CompletedMultipartUpload {
+export interface CompleteMultipartUpload {
   /**
    * <p>Array of CompletedPart data types.</p>
    */
   Parts?: CompletedPart[];
 }
 
-export namespace CompletedMultipartUpload {
+export namespace CompleteMultipartUpload {
   /**
    * @internal
    */
-  export const filterSensitiveLog = (obj: CompletedMultipartUpload): any => ({
+  export const filterSensitiveLog = (obj: CompleteMultipartUpload): any => ({
     ...obj,
   });
 }
@@ -429,7 +429,7 @@ export interface CompleteMultipartUploadRequest {
   /**
    * <p>The container for the multipart upload request information.</p>
    */
-  MultipartUpload?: CompletedMultipartUpload;
+  MultipartUpload?: CompleteMultipartUpload;
 
   /**
    * <p>ID for the initiated multipart upload.</p>

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -261,7 +261,7 @@ import {
   CORSConfiguration,
   CORSRule,
   CommonPrefix,
-  CompletedMultipartUpload,
+  CompleteMultipartUpload,
   CompletedPart,
   Condition,
   CopyObjectResult,
@@ -503,11 +503,11 @@ export const serializeAws_restXmlCompleteMultipartUploadCommand = async (
   };
   let body: any;
   if (input.MultipartUpload !== undefined) {
-    body = serializeAws_restXmlCompletedMultipartUpload(input.MultipartUpload, context);
+    body = serializeAws_restXmlCompleteMultipartUpload(input.MultipartUpload, context);
   }
   let contents: any;
   if (input.MultipartUpload !== undefined) {
-    contents = serializeAws_restXmlCompletedMultipartUpload(input.MultipartUpload, context);
+    contents = serializeAws_restXmlCompleteMultipartUpload(input.MultipartUpload, context);
     body = '<?xml version="1.0" encoding="UTF-8"?>';
     contents.addAttribute("xmlns", "http://s3.amazonaws.com/doc/2006-03-01/");
     body += contents.toString();
@@ -10506,11 +10506,11 @@ const serializeAws_restXmlBucketLoggingStatus = (input: BucketLoggingStatus, con
   return bodyNode;
 };
 
-const serializeAws_restXmlCompletedMultipartUpload = (
-  input: CompletedMultipartUpload,
+const serializeAws_restXmlCompleteMultipartUpload = (
+  input: CompleteMultipartUpload,
   context: __SerdeContext
 ): any => {
-  const bodyNode = new __XmlNode("CompletedMultipartUpload");
+  const bodyNode = new __XmlNode("CompleteMultipartUpload");
   if (input.Parts !== undefined && input.Parts !== null) {
     const nodes = serializeAws_restXmlCompletedPartList(input.Parts, context);
     nodes.map((node: any) => {

--- a/codegen/sdk-codegen/aws-models/s3.2006-03-01.json
+++ b/codegen/sdk-codegen/aws-models/s3.2006-03-01.json
@@ -1246,7 +1246,7 @@
           }
         },
         "MultipartUpload": {
-          "target": "com.amazonaws.s3#CompletedMultipartUpload",
+          "target": "com.amazonaws.s3#CompleteMultipartUpload",
           "traits": {
             "smithy.api#documentation": "<p>The container for the multipart upload request information.</p>",
             "smithy.api#httpPayload": {},
@@ -1276,7 +1276,7 @@
         }
       }
     },
-    "com.amazonaws.s3#CompletedMultipartUpload": {
+    "com.amazonaws.s3#CompleteMultipartUpload": {
       "type": "structure",
       "members": {
         "Parts": {


### PR DESCRIPTION
See issue #1814 , I just did a search and replace so everything is consistent:

    $ find . -exec sed s/CompletedMultipartUpload/CompleteMultipartUpload/g {} \;

### Issue
#1814 

### Description
Correctness fix as most everything uses "CompleteMultipartUpload" instead of "CompletedMultipartUpload" which does not match the docs (longer discussion in #1814 )

### Testing
Ran a node script to do a multipart upload, and it worked. Full test suite was not run.

### Additional context
None

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
