### PR TITLE
chore(middleware-retry): move non-config interfaces to types.ts

### DIFF
--- a/packages/middleware-retry/src/defaultRetryQuota.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.ts
@@ -1,7 +1,7 @@
 import { SdkError } from "@aws-sdk/smithy-client";
 
 import { NO_RETRY_INCREMENT, RETRY_COST, TIMEOUT_RETRY_COST } from "./constants";
-import { RetryQuota } from "./defaultStrategy";
+import { RetryQuota } from "./types";
 
 export const getDefaultRetryQuota = (initialRetryTokens: number): RetryQuota => {
   const MAX_CAPACITY = initialRetryTokens;

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -4,9 +4,10 @@ import { v4 } from "uuid";
 
 import { DEFAULT_RETRY_DELAY_BASE, INITIAL_RETRY_TOKENS, THROTTLING_RETRY_DELAY_BASE } from "./constants";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
-import { DEFAULT_MAX_ATTEMPTS, RetryQuota, StandardRetryStrategy } from "./defaultStrategy";
+import { DEFAULT_MAX_ATTEMPTS, StandardRetryStrategy } from "./defaultStrategy";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
+import { RetryQuota } from "./types";
 
 jest.mock("@aws-sdk/service-error-classification");
 jest.mock("./delayDecider");

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -14,6 +14,7 @@ import {
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
+import { DelayDecider, RetryDecider, RetryQuota } from "./types";
 
 /**
  * The default value for how many HTTP requests an SDK should make for a
@@ -25,47 +26,6 @@ export const DEFAULT_MAX_ATTEMPTS = 3;
  * The default retry algorithm to use.
  */
 export const DEFAULT_RETRY_MODE = "standard";
-
-/**
- * Determines whether an error is retryable based on the number of retries
- * already attempted, the HTTP status code, and the error received (if any).
- *
- * @param error         The error encountered.
- */
-export interface RetryDecider {
-  (error: SdkError): boolean;
-}
-
-/**
- * Determines the number of milliseconds to wait before retrying an action.
- *
- * @param delayBase The base delay (in milliseconds).
- * @param attempts  The number of times the action has already been tried.
- */
-export interface DelayDecider {
-  (delayBase: number, attempts: number): number;
-}
-
-/**
- * Interface that specifies the retry quota behavior.
- */
-export interface RetryQuota {
-  /**
-   * returns true if retry tokens are available from the retry quota bucket.
-   */
-  hasRetryTokens: (error: SdkError) => boolean;
-
-  /**
-   * returns token amount from the retry quota bucket.
-   * throws error is retry tokens are not available.
-   */
-  retrieveRetryTokens: (error: SdkError) => number;
-
-  /**
-   * releases tokens back to the retry quota.
-   */
-  releaseRetryTokens: (releaseCapacityAmount?: number) => void;
-}
 
 /**
  * Strategy options to be passed to StandardRetryStrategy

--- a/packages/middleware-retry/src/index.ts
+++ b/packages/middleware-retry/src/index.ts
@@ -4,3 +4,4 @@ export * from "./defaultStrategy";
 export * from "./configurations";
 export * from "./delayDecider";
 export * from "./retryDecider";
+export * from "./types";

--- a/packages/middleware-retry/src/types.ts
+++ b/packages/middleware-retry/src/types.ts
@@ -1,0 +1,42 @@
+import { SdkError } from "@aws-sdk/smithy-client";
+
+/**
+ * Determines whether an error is retryable based on the number of retries
+ * already attempted, the HTTP status code, and the error received (if any).
+ *
+ * @param error         The error encountered.
+ */
+export interface RetryDecider {
+  (error: SdkError): boolean;
+}
+
+/**
+ * Determines the number of milliseconds to wait before retrying an action.
+ *
+ * @param delayBase The base delay (in milliseconds).
+ * @param attempts  The number of times the action has already been tried.
+ */
+export interface DelayDecider {
+  (delayBase: number, attempts: number): number;
+}
+
+/**
+ * Interface that specifies the retry quota behavior.
+ */
+export interface RetryQuota {
+  /**
+   * returns true if retry tokens are available from the retry quota bucket.
+   */
+  hasRetryTokens: (error: SdkError) => boolean;
+
+  /**
+   * returns token amount from the retry quota bucket.
+   * throws error is retry tokens are not available.
+   */
+  retrieveRetryTokens: (error: SdkError) => number;
+
+  /**
+   * releases tokens back to the retry quota.
+   */
+  releaseRetryTokens: (releaseCapacityAmount?: number) => void;
+}


### PR DESCRIPTION
### Issue
Refs: internal JS-2633

### Description
move non-config interfaces to types.ts in middleware-retry.

This is similar to `types.ts` file in:
* lib-storage https://github.com/aws/aws-sdk-js-v3/blob/main/lib/lib-storage/src/types.ts
* middleware-stack https://github.com/aws/aws-sdk-js-v3/blob/main/packages/middleware-stack/src/types.ts

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
