### PR TITLE
chore(deps-dev): bump typescript to ~4.3.2

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -73,7 +73,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -85,7 +85,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -74,7 +74,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^14.11.2",
     "jest": "^26.4.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -38,7 +38,7 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-typescript": "^5.2.0",
     "ts-jest": "^26.4.1",
-    "typescript": "~4.2.4",
+    "typescript": "~4.3.2",
     "web-streams-polyfill": "^3.0.0"
   },
   "typesVersions": {

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -14,7 +14,7 @@ const putObjectTaggingMock = jest.fn().mockResolvedValue({
 });
 
 jest.mock("@aws-sdk/client-s3", () => ({
-  ...jest.requireActual("@aws-sdk/client-s3"),
+  ...(jest.requireActual("@aws-sdk/client-s3") as {}),
   S3: jest.fn().mockReturnValue({
     send: sendMock,
   }),

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ts-jest": "^26.4.1",
     "ts-loader": "^7.0.5",
     "typedoc-plugin-lerna-packages": "^0.3.1",
-    "typescript": "~4.2.4",
+    "typescript": "~4.3.2",
     "verdaccio": "^4.7.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/util-utf8-browser": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/util-utf8-node": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "tslib": "^2.0.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "dependencies": {
     "@aws-sdk/signature-v4": "3.15.0",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "private": true,
   "typesVersions": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "nock": "^13.0.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -33,7 +33,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -39,7 +39,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "typesVersions": {

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/util-utf8-node": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "browser": {
     "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-utf8-node": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/util-utf8-node": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@aws-sdk/abort-controller": "3.15.0",
     "@types/jest": "^26.0.4",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-hex-encoding": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "react-native": {
     "@aws-sdk/chunked-blob-reader": "@aws-sdk/chunked-blob-reader-native"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "dependencies": {
     "@aws-sdk/types": "3.15.0",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "dependencies": {
     "@aws-sdk/types": "3.15.0",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/node-config-provider": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/node-config-provider": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "dependencies": {
     "@aws-sdk/config-resolver": "3.16.0",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/smithy-client": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/middleware-stack": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "dependencies": {
     "@aws-sdk/middleware-signing": "3.16.0",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -32,7 +32,7 @@
     "jest": "^26.1.0",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.0.3",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "dependencies": {
     "@aws-sdk/property-provider": "3.15.0",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/types": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/middleware-stack": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "jest": {
     "coveragePathIgnorePatterns": [

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -30,7 +30,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/smithy-client": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-utf8-node": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "scripts": {
     "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/util-buffer-from": "3.13.1",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/types/index.d.ts",
   "description": "Types for the AWS SDK",
   "devDependencies": {
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "scripts": {
     "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "typesVersions": {

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -13,7 +13,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.3",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-dynamodb": "3.17.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -20,7 +20,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/protocol-http": "3.15.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "types": "./dist/types/index.d.ts",
   "typesVersions": {

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "scripts": {
     "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "scripts": {
     "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11469,10 +11469,15 @@ typedoc@^0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-typescript@^4.1.0-dev.20201026, typescript@~4.2.4:
+typescript@^4.1.0-dev.20201026:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+
+typescript@~4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
 ua-parser-js@0.7.22:
   version "0.7.22"


### PR DESCRIPTION
### Issue
N/A

### Description
bump typescript to [~4.3.2](https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/)

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
