### PR TITLE
feat(clients): add retryModeProvider in runtimeConfig

### DIFF
--- a/clients/client-accessanalyzer/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/AccessAnalyzerClient.ts
@@ -245,6 +245,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-accessanalyzer/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/AccessAnalyzerClient.ts
@@ -248,7 +248,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-accessanalyzer/runtimeConfig.browser.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-accessanalyzer/runtimeConfig.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-acm-pca/ACMPCAClient.ts
+++ b/clients/client-acm-pca/ACMPCAClient.ts
@@ -245,6 +245,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-acm-pca/ACMPCAClient.ts
+++ b/clients/client-acm-pca/ACMPCAClient.ts
@@ -248,7 +248,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-acm-pca/runtimeConfig.browser.ts
+++ b/clients/client-acm-pca/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-acm-pca/runtimeConfig.ts
+++ b/clients/client-acm-pca/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-acm/ACMClient.ts
+++ b/clients/client-acm/ACMClient.ts
@@ -206,6 +206,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-acm/ACMClient.ts
+++ b/clients/client-acm/ACMClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-acm/runtimeConfig.browser.ts
+++ b/clients/client-acm/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-acm/runtimeConfig.ts
+++ b/clients/client-acm/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-alexa-for-business/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/AlexaForBusinessClient.ts
@@ -536,7 +536,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-alexa-for-business/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/AlexaForBusinessClient.ts
@@ -533,6 +533,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-alexa-for-business/runtimeConfig.browser.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-alexa-for-business/runtimeConfig.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-amp/AmpClient.ts
+++ b/clients/client-amp/AmpClient.ts
@@ -158,7 +158,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-amp/AmpClient.ts
+++ b/clients/client-amp/AmpClient.ts
@@ -155,6 +155,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-amp/runtimeConfig.browser.ts
+++ b/clients/client-amp/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-amp/runtimeConfig.ts
+++ b/clients/client-amp/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-amplify/AmplifyClient.ts
+++ b/clients/client-amplify/AmplifyClient.ts
@@ -278,6 +278,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-amplify/AmplifyClient.ts
+++ b/clients/client-amplify/AmplifyClient.ts
@@ -281,7 +281,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-amplify/runtimeConfig.browser.ts
+++ b/clients/client-amplify/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-amplify/runtimeConfig.ts
+++ b/clients/client-amplify/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-amplifybackend/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/AmplifyBackendClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-amplifybackend/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/AmplifyBackendClient.ts
@@ -224,6 +224,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-amplifybackend/runtimeConfig.browser.ts
+++ b/clients/client-amplifybackend/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-amplifybackend/runtimeConfig.ts
+++ b/clients/client-amplifybackend/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-api-gateway/APIGatewayClient.ts
+++ b/clients/client-api-gateway/APIGatewayClient.ts
@@ -609,7 +609,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-api-gateway/APIGatewayClient.ts
+++ b/clients/client-api-gateway/APIGatewayClient.ts
@@ -606,6 +606,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-api-gateway/runtimeConfig.browser.ts
+++ b/clients/client-api-gateway/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-api-gateway/runtimeConfig.ts
+++ b/clients/client-api-gateway/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
@@ -143,6 +143,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
@@ -146,7 +146,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-apigatewayv2/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/ApiGatewayV2Client.ts
@@ -392,6 +392,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-apigatewayv2/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/ApiGatewayV2Client.ts
@@ -395,7 +395,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-apigatewayv2/runtimeConfig.browser.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-apigatewayv2/runtimeConfig.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-app-mesh/AppMeshClient.ts
+++ b/clients/client-app-mesh/AppMeshClient.ts
@@ -305,7 +305,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-app-mesh/AppMeshClient.ts
+++ b/clients/client-app-mesh/AppMeshClient.ts
@@ -302,6 +302,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-app-mesh/runtimeConfig.browser.ts
+++ b/clients/client-app-mesh/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-app-mesh/runtimeConfig.ts
+++ b/clients/client-app-mesh/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appconfig/AppConfigClient.ts
+++ b/clients/client-appconfig/AppConfigClient.ts
@@ -284,6 +284,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-appconfig/AppConfigClient.ts
+++ b/clients/client-appconfig/AppConfigClient.ts
@@ -287,7 +287,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-appconfig/runtimeConfig.browser.ts
+++ b/clients/client-appconfig/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appconfig/runtimeConfig.ts
+++ b/clients/client-appconfig/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appflow/AppflowClient.ts
+++ b/clients/client-appflow/AppflowClient.ts
@@ -218,7 +218,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-appflow/AppflowClient.ts
+++ b/clients/client-appflow/AppflowClient.ts
@@ -215,6 +215,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-appflow/runtimeConfig.browser.ts
+++ b/clients/client-appflow/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appflow/runtimeConfig.ts
+++ b/clients/client-appflow/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appintegrations/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/AppIntegrationsClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-appintegrations/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/AppIntegrationsClient.ts
@@ -191,6 +191,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-appintegrations/runtimeConfig.browser.ts
+++ b/clients/client-appintegrations/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appintegrations/runtimeConfig.ts
+++ b/clients/client-appintegrations/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
@@ -191,6 +191,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-application-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-application-auto-scaling/runtimeConfig.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
@@ -257,6 +257,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-application-discovery-service/runtimeConfig.browser.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-application-discovery-service/runtimeConfig.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-application-insights/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/ApplicationInsightsClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-application-insights/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/ApplicationInsightsClient.ts
@@ -242,6 +242,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-application-insights/runtimeConfig.browser.ts
+++ b/clients/client-application-insights/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-application-insights/runtimeConfig.ts
+++ b/clients/client-application-insights/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appstream/AppStreamClient.ts
+++ b/clients/client-appstream/AppStreamClient.ts
@@ -338,7 +338,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-appstream/AppStreamClient.ts
+++ b/clients/client-appstream/AppStreamClient.ts
@@ -335,6 +335,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-appstream/runtimeConfig.browser.ts
+++ b/clients/client-appstream/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appstream/runtimeConfig.ts
+++ b/clients/client-appstream/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appsync/AppSyncClient.ts
+++ b/clients/client-appsync/AppSyncClient.ts
@@ -278,7 +278,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-appsync/AppSyncClient.ts
+++ b/clients/client-appsync/AppSyncClient.ts
@@ -275,6 +275,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-appsync/runtimeConfig.browser.ts
+++ b/clients/client-appsync/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-appsync/runtimeConfig.ts
+++ b/clients/client-appsync/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-athena/AthenaClient.ts
+++ b/clients/client-athena/AthenaClient.ts
@@ -266,6 +266,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-athena/AthenaClient.ts
+++ b/clients/client-athena/AthenaClient.ts
@@ -269,7 +269,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-athena/runtimeConfig.browser.ts
+++ b/clients/client-athena/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-athena/runtimeConfig.ts
+++ b/clients/client-athena/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-auditmanager/AuditManagerClient.ts
+++ b/clients/client-auditmanager/AuditManagerClient.ts
@@ -380,6 +380,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-auditmanager/AuditManagerClient.ts
+++ b/clients/client-auditmanager/AuditManagerClient.ts
@@ -383,7 +383,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-auditmanager/runtimeConfig.browser.ts
+++ b/clients/client-auditmanager/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-auditmanager/runtimeConfig.ts
+++ b/clients/client-auditmanager/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
@@ -164,6 +164,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-auto-scaling-plans/runtimeConfig.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-auto-scaling/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/AutoScalingClient.ts
@@ -440,6 +440,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-auto-scaling/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/AutoScalingClient.ts
@@ -443,7 +443,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-auto-scaling/runtimeConfig.ts
+++ b/clients/client-auto-scaling/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-backup/BackupClient.ts
+++ b/clients/client-backup/BackupClient.ts
@@ -377,6 +377,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-backup/BackupClient.ts
+++ b/clients/client-backup/BackupClient.ts
@@ -380,7 +380,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-backup/runtimeConfig.browser.ts
+++ b/clients/client-backup/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-backup/runtimeConfig.ts
+++ b/clients/client-backup/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-batch/BatchClient.ts
+++ b/clients/client-batch/BatchClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-batch/BatchClient.ts
+++ b/clients/client-batch/BatchClient.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-batch/runtimeConfig.browser.ts
+++ b/clients/client-batch/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-batch/runtimeConfig.ts
+++ b/clients/client-batch/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-braket/BraketClient.ts
+++ b/clients/client-braket/BraketClient.ts
@@ -167,6 +167,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-braket/BraketClient.ts
+++ b/clients/client-braket/BraketClient.ts
@@ -170,7 +170,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-braket/runtimeConfig.browser.ts
+++ b/clients/client-braket/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-braket/runtimeConfig.ts
+++ b/clients/client-braket/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-budgets/BudgetsClient.ts
+++ b/clients/client-budgets/BudgetsClient.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-budgets/BudgetsClient.ts
+++ b/clients/client-budgets/BudgetsClient.ts
@@ -227,6 +227,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-budgets/runtimeConfig.browser.ts
+++ b/clients/client-budgets/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-budgets/runtimeConfig.ts
+++ b/clients/client-budgets/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-chime/ChimeClient.ts
+++ b/clients/client-chime/ChimeClient.ts
@@ -1010,7 +1010,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-chime/ChimeClient.ts
+++ b/clients/client-chime/ChimeClient.ts
@@ -1007,6 +1007,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-chime/runtimeConfig.browser.ts
+++ b/clients/client-chime/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-chime/runtimeConfig.ts
+++ b/clients/client-chime/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloud9/Cloud9Client.ts
+++ b/clients/client-cloud9/Cloud9Client.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloud9/Cloud9Client.ts
+++ b/clients/client-cloud9/Cloud9Client.ts
@@ -200,6 +200,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloud9/runtimeConfig.browser.ts
+++ b/clients/client-cloud9/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloud9/runtimeConfig.ts
+++ b/clients/client-cloud9/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-clouddirectory/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/CloudDirectoryClient.ts
@@ -416,7 +416,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-clouddirectory/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/CloudDirectoryClient.ts
@@ -413,6 +413,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-clouddirectory/runtimeConfig.browser.ts
+++ b/clients/client-clouddirectory/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-clouddirectory/runtimeConfig.ts
+++ b/clients/client-clouddirectory/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudformation/CloudFormationClient.ts
+++ b/clients/client-cloudformation/CloudFormationClient.ts
@@ -371,6 +371,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudformation/CloudFormationClient.ts
+++ b/clients/client-cloudformation/CloudFormationClient.ts
@@ -374,7 +374,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudformation/runtimeConfig.browser.ts
+++ b/clients/client-cloudformation/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudformation/runtimeConfig.ts
+++ b/clients/client-cloudformation/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudfront/CloudFrontClient.ts
+++ b/clients/client-cloudfront/CloudFrontClient.ts
@@ -533,7 +533,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudfront/CloudFrontClient.ts
+++ b/clients/client-cloudfront/CloudFrontClient.ts
@@ -530,6 +530,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudfront/runtimeConfig.browser.ts
+++ b/clients/client-cloudfront/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudfront/runtimeConfig.ts
+++ b/clients/client-cloudfront/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
@@ -185,6 +185,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
@@ -188,7 +188,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudhsm-v2/runtimeConfig.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudhsm/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/CloudHSMClient.ts
@@ -206,7 +206,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudhsm/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/CloudHSMClient.ts
@@ -203,6 +203,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudhsm/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudhsm/runtimeConfig.ts
+++ b/clients/client-cloudhsm/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
@@ -140,6 +140,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
@@ -143,7 +143,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudsearch-domain/runtimeConfig.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudsearch/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/CloudSearchClient.ts
@@ -254,6 +254,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudsearch/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/CloudSearchClient.ts
@@ -257,7 +257,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudsearch/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudsearch/runtimeConfig.ts
+++ b/clients/client-cloudsearch/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudtrail/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/CloudTrailClient.ts
@@ -197,6 +197,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudtrail/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/CloudTrailClient.ts
@@ -200,7 +200,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudtrail/runtimeConfig.browser.ts
+++ b/clients/client-cloudtrail/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudtrail/runtimeConfig.ts
+++ b/clients/client-cloudtrail/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
@@ -341,7 +341,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
@@ -338,6 +338,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudwatch-events/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudwatch-events/runtimeConfig.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
@@ -302,7 +302,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
@@ -299,6 +299,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudwatch-logs/runtimeConfig.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudwatch/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/CloudWatchClient.ts
@@ -278,6 +278,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cloudwatch/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/CloudWatchClient.ts
@@ -281,7 +281,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cloudwatch/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cloudwatch/runtimeConfig.ts
+++ b/clients/client-cloudwatch/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codeartifact/CodeartifactClient.ts
+++ b/clients/client-codeartifact/CodeartifactClient.ts
@@ -305,6 +305,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codeartifact/CodeartifactClient.ts
+++ b/clients/client-codeartifact/CodeartifactClient.ts
@@ -308,7 +308,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codeartifact/runtimeConfig.browser.ts
+++ b/clients/client-codeartifact/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codeartifact/runtimeConfig.ts
+++ b/clients/client-codeartifact/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codebuild/CodeBuildClient.ts
+++ b/clients/client-codebuild/CodeBuildClient.ts
@@ -314,7 +314,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codebuild/CodeBuildClient.ts
+++ b/clients/client-codebuild/CodeBuildClient.ts
@@ -311,6 +311,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codebuild/runtimeConfig.browser.ts
+++ b/clients/client-codebuild/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codebuild/runtimeConfig.ts
+++ b/clients/client-codebuild/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codecommit/CodeCommitClient.ts
+++ b/clients/client-codecommit/CodeCommitClient.ts
@@ -515,7 +515,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codecommit/CodeCommitClient.ts
+++ b/clients/client-codecommit/CodeCommitClient.ts
@@ -512,6 +512,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codecommit/runtimeConfig.browser.ts
+++ b/clients/client-codecommit/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codecommit/runtimeConfig.ts
+++ b/clients/client-codecommit/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codedeploy/CodeDeployClient.ts
+++ b/clients/client-codedeploy/CodeDeployClient.ts
@@ -380,6 +380,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codedeploy/CodeDeployClient.ts
+++ b/clients/client-codedeploy/CodeDeployClient.ts
@@ -383,7 +383,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codedeploy/runtimeConfig.browser.ts
+++ b/clients/client-codedeploy/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codedeploy/runtimeConfig.ts
+++ b/clients/client-codedeploy/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
@@ -206,6 +206,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codeguru-reviewer/runtimeConfig.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
@@ -242,6 +242,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codeguruprofiler/runtimeConfig.browser.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codeguruprofiler/runtimeConfig.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codepipeline/CodePipelineClient.ts
+++ b/clients/client-codepipeline/CodePipelineClient.ts
@@ -317,7 +317,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codepipeline/CodePipelineClient.ts
+++ b/clients/client-codepipeline/CodePipelineClient.ts
@@ -314,6 +314,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codepipeline/runtimeConfig.browser.ts
+++ b/clients/client-codepipeline/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codepipeline/runtimeConfig.ts
+++ b/clients/client-codepipeline/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codestar-connections/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/CodeStarConnectionsClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codestar-connections/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/CodeStarConnectionsClient.ts
@@ -176,6 +176,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codestar-connections/runtimeConfig.browser.ts
+++ b/clients/client-codestar-connections/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codestar-connections/runtimeConfig.ts
+++ b/clients/client-codestar-connections/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codestar-notifications/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/CodestarNotificationsClient.ts
@@ -194,6 +194,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codestar-notifications/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/CodestarNotificationsClient.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codestar-notifications/runtimeConfig.browser.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codestar-notifications/runtimeConfig.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codestar/CodeStarClient.ts
+++ b/clients/client-codestar/CodeStarClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-codestar/CodeStarClient.ts
+++ b/clients/client-codestar/CodeStarClient.ts
@@ -200,6 +200,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-codestar/runtimeConfig.browser.ts
+++ b/clients/client-codestar/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-codestar/runtimeConfig.ts
+++ b/clients/client-codestar/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -603,7 +603,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -600,6 +600,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cognito-identity-provider/runtimeConfig.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cognito-identity/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/CognitoIdentityClient.ts
@@ -234,6 +234,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cognito-identity/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/CognitoIdentityClient.ts
@@ -237,7 +237,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cognito-identity/runtimeConfig.ts
+++ b/clients/client-cognito-identity/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cognito-sync/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/CognitoSyncClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cognito-sync/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/CognitoSyncClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cognito-sync/runtimeConfig.browser.ts
+++ b/clients/client-cognito-sync/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cognito-sync/runtimeConfig.ts
+++ b/clients/client-cognito-sync/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-comprehend/ComprehendClient.ts
+++ b/clients/client-comprehend/ComprehendClient.ts
@@ -461,6 +461,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-comprehend/ComprehendClient.ts
+++ b/clients/client-comprehend/ComprehendClient.ts
@@ -464,7 +464,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-comprehend/runtimeConfig.browser.ts
+++ b/clients/client-comprehend/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-comprehend/runtimeConfig.ts
+++ b/clients/client-comprehend/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-comprehendmedical/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/ComprehendMedicalClient.ts
@@ -248,6 +248,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-comprehendmedical/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/ComprehendMedicalClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-comprehendmedical/runtimeConfig.browser.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-comprehendmedical/runtimeConfig.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-compute-optimizer/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/ComputeOptimizerClient.ts
@@ -206,7 +206,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-compute-optimizer/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/ComputeOptimizerClient.ts
@@ -203,6 +203,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-compute-optimizer/runtimeConfig.browser.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-compute-optimizer/runtimeConfig.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-config-service/ConfigServiceClient.ts
+++ b/clients/client-config-service/ConfigServiceClient.ts
@@ -617,6 +617,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-config-service/ConfigServiceClient.ts
+++ b/clients/client-config-service/ConfigServiceClient.ts
@@ -620,7 +620,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-config-service/runtimeConfig.browser.ts
+++ b/clients/client-config-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-config-service/runtimeConfig.ts
+++ b/clients/client-config-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-connect-contact-lens/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/ConnectContactLensClient.ts
@@ -150,7 +150,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-connect-contact-lens/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/ConnectContactLensClient.ts
@@ -147,6 +147,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-connect-contact-lens/runtimeConfig.browser.ts
+++ b/clients/client-connect-contact-lens/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-connect-contact-lens/runtimeConfig.ts
+++ b/clients/client-connect-contact-lens/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-connect/ConnectClient.ts
+++ b/clients/client-connect/ConnectClient.ts
@@ -629,6 +629,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-connect/ConnectClient.ts
+++ b/clients/client-connect/ConnectClient.ts
@@ -632,7 +632,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-connect/runtimeConfig.browser.ts
+++ b/clients/client-connect/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-connect/runtimeConfig.ts
+++ b/clients/client-connect/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-connectparticipant/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/ConnectParticipantClient.ts
@@ -179,6 +179,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-connectparticipant/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/ConnectParticipantClient.ts
@@ -182,7 +182,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-connectparticipant/runtimeConfig.browser.ts
+++ b/clients/client-connectparticipant/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-connectparticipant/runtimeConfig.ts
+++ b/clients/client-connectparticipant/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
@@ -161,6 +161,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cost-explorer/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/CostExplorerClient.ts
@@ -296,7 +296,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-cost-explorer/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/CostExplorerClient.ts
@@ -293,6 +293,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-cost-explorer/runtimeConfig.browser.ts
+++ b/clients/client-cost-explorer/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-cost-explorer/runtimeConfig.ts
+++ b/clients/client-cost-explorer/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-customer-profiles/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/CustomerProfilesClient.ts
@@ -263,7 +263,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-customer-profiles/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/CustomerProfilesClient.ts
@@ -260,6 +260,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-customer-profiles/runtimeConfig.browser.ts
+++ b/clients/client-customer-profiles/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-customer-profiles/runtimeConfig.ts
+++ b/clients/client-customer-profiles/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-data-pipeline/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/DataPipelineClient.ts
@@ -206,6 +206,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-data-pipeline/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/DataPipelineClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-data-pipeline/runtimeConfig.browser.ts
+++ b/clients/client-data-pipeline/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-data-pipeline/runtimeConfig.ts
+++ b/clients/client-data-pipeline/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
@@ -431,7 +431,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
@@ -428,6 +428,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-database-migration-service/runtimeConfig.browser.ts
+++ b/clients/client-database-migration-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-database-migration-service/runtimeConfig.ts
+++ b/clients/client-database-migration-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-databrew/DataBrewClient.ts
+++ b/clients/client-databrew/DataBrewClient.ts
@@ -269,6 +269,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-databrew/DataBrewClient.ts
+++ b/clients/client-databrew/DataBrewClient.ts
@@ -272,7 +272,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-databrew/runtimeConfig.browser.ts
+++ b/clients/client-databrew/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-databrew/runtimeConfig.ts
+++ b/clients/client-databrew/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dataexchange/DataExchangeClient.ts
+++ b/clients/client-dataexchange/DataExchangeClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-dataexchange/DataExchangeClient.ts
+++ b/clients/client-dataexchange/DataExchangeClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-dataexchange/runtimeConfig.browser.ts
+++ b/clients/client-dataexchange/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dataexchange/runtimeConfig.ts
+++ b/clients/client-dataexchange/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-datasync/DataSyncClient.ts
+++ b/clients/client-datasync/DataSyncClient.ts
@@ -278,6 +278,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-datasync/DataSyncClient.ts
+++ b/clients/client-datasync/DataSyncClient.ts
@@ -281,7 +281,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-datasync/runtimeConfig.browser.ts
+++ b/clients/client-datasync/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-datasync/runtimeConfig.ts
+++ b/clients/client-datasync/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dax/DAXClient.ts
+++ b/clients/client-dax/DAXClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-dax/DAXClient.ts
+++ b/clients/client-dax/DAXClient.ts
@@ -224,6 +224,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-dax/runtimeConfig.browser.ts
+++ b/clients/client-dax/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dax/runtimeConfig.ts
+++ b/clients/client-dax/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-detective/DetectiveClient.ts
+++ b/clients/client-detective/DetectiveClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-detective/DetectiveClient.ts
+++ b/clients/client-detective/DetectiveClient.ts
@@ -191,6 +191,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-detective/runtimeConfig.browser.ts
+++ b/clients/client-detective/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-detective/runtimeConfig.ts
+++ b/clients/client-detective/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-device-farm/DeviceFarmClient.ts
+++ b/clients/client-device-farm/DeviceFarmClient.ts
@@ -464,6 +464,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-device-farm/DeviceFarmClient.ts
+++ b/clients/client-device-farm/DeviceFarmClient.ts
@@ -467,7 +467,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-device-farm/runtimeConfig.browser.ts
+++ b/clients/client-device-farm/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-device-farm/runtimeConfig.ts
+++ b/clients/client-device-farm/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-devops-guru/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/DevOpsGuruClient.ts
@@ -245,6 +245,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-devops-guru/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/DevOpsGuruClient.ts
@@ -248,7 +248,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-devops-guru/runtimeConfig.browser.ts
+++ b/clients/client-devops-guru/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-devops-guru/runtimeConfig.ts
+++ b/clients/client-devops-guru/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-direct-connect/DirectConnectClient.ts
+++ b/clients/client-direct-connect/DirectConnectClient.ts
@@ -437,6 +437,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-direct-connect/DirectConnectClient.ts
+++ b/clients/client-direct-connect/DirectConnectClient.ts
@@ -440,7 +440,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-direct-connect/runtimeConfig.browser.ts
+++ b/clients/client-direct-connect/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-direct-connect/runtimeConfig.ts
+++ b/clients/client-direct-connect/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-directory-service/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/DirectoryServiceClient.ts
@@ -404,6 +404,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-directory-service/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/DirectoryServiceClient.ts
@@ -407,7 +407,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-directory-service/runtimeConfig.browser.ts
+++ b/clients/client-directory-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-directory-service/runtimeConfig.ts
+++ b/clients/client-directory-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dlm/DLMClient.ts
+++ b/clients/client-dlm/DLMClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-dlm/DLMClient.ts
+++ b/clients/client-dlm/DLMClient.ts
@@ -176,6 +176,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-dlm/runtimeConfig.browser.ts
+++ b/clients/client-dlm/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dlm/runtimeConfig.ts
+++ b/clients/client-dlm/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-docdb/DocDBClient.ts
+++ b/clients/client-docdb/DocDBClient.ts
@@ -350,6 +350,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-docdb/DocDBClient.ts
+++ b/clients/client-docdb/DocDBClient.ts
@@ -353,7 +353,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-docdb/runtimeConfig.browser.ts
+++ b/clients/client-docdb/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-docdb/runtimeConfig.ts
+++ b/clients/client-docdb/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
@@ -149,6 +149,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-dynamodb-streams/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dynamodb-streams/runtimeConfig.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -350,7 +350,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -347,6 +347,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-dynamodb/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -29,6 +29,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-dynamodb/runtimeConfig.ts
+++ b/clients/client-dynamodb/runtimeConfig.ts
@@ -5,7 +5,7 @@ import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aw
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
 import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ebs/EBSClient.ts
+++ b/clients/client-ebs/EBSClient.ts
@@ -158,7 +158,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ebs/EBSClient.ts
+++ b/clients/client-ebs/EBSClient.ts
@@ -155,6 +155,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ebs/runtimeConfig.browser.ts
+++ b/clients/client-ebs/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ebs/runtimeConfig.ts
+++ b/clients/client-ebs/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
@@ -142,6 +142,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ec2-instance-connect/runtimeConfig.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ec2/EC2Client.ts
+++ b/clients/client-ec2/EC2Client.ts
@@ -2531,7 +2531,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ec2/EC2Client.ts
+++ b/clients/client-ec2/EC2Client.ts
@@ -2528,6 +2528,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ec2/runtimeConfig.browser.ts
+++ b/clients/client-ec2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ec2/runtimeConfig.ts
+++ b/clients/client-ec2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ecr-public/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/ECRPUBLICClient.ts
@@ -245,6 +245,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ecr-public/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/ECRPUBLICClient.ts
@@ -248,7 +248,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ecr-public/runtimeConfig.browser.ts
+++ b/clients/client-ecr-public/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ecr-public/runtimeConfig.ts
+++ b/clients/client-ecr-public/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ecr/ECRClient.ts
+++ b/clients/client-ecr/ECRClient.ts
@@ -296,7 +296,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ecr/ECRClient.ts
+++ b/clients/client-ecr/ECRClient.ts
@@ -293,6 +293,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ecr/runtimeConfig.browser.ts
+++ b/clients/client-ecr/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ecr/runtimeConfig.ts
+++ b/clients/client-ecr/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ecs/ECSClient.ts
+++ b/clients/client-ecs/ECSClient.ts
@@ -371,6 +371,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ecs/ECSClient.ts
+++ b/clients/client-ecs/ECSClient.ts
@@ -374,7 +374,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ecs/runtimeConfig.browser.ts
+++ b/clients/client-ecs/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ecs/runtimeConfig.ts
+++ b/clients/client-ecs/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-efs/EFSClient.ts
+++ b/clients/client-efs/EFSClient.ts
@@ -248,6 +248,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-efs/EFSClient.ts
+++ b/clients/client-efs/EFSClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-efs/runtimeConfig.browser.ts
+++ b/clients/client-efs/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-efs/runtimeConfig.ts
+++ b/clients/client-efs/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-eks/EKSClient.ts
+++ b/clients/client-eks/EKSClient.ts
@@ -278,6 +278,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-eks/EKSClient.ts
+++ b/clients/client-eks/EKSClient.ts
@@ -281,7 +281,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-eks/runtimeConfig.browser.ts
+++ b/clients/client-eks/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-eks/runtimeConfig.ts
+++ b/clients/client-eks/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
@@ -395,6 +395,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
@@ -398,7 +398,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-beanstalk/runtimeConfig.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-inference/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/ElasticInferenceClient.ts
@@ -167,6 +167,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-elastic-inference/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/ElasticInferenceClient.ts
@@ -170,7 +170,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-elastic-inference/runtimeConfig.browser.ts
+++ b/clients/client-elastic-inference/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-inference/runtimeConfig.ts
+++ b/clients/client-elastic-inference/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
@@ -278,7 +278,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
@@ -275,6 +275,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
@@ -296,6 +296,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
@@ -299,7 +299,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-load-balancing/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
@@ -194,6 +194,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-elastic-transcoder/runtimeConfig.browser.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elastic-transcoder/runtimeConfig.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elasticache/ElastiCacheClient.ts
+++ b/clients/client-elasticache/ElastiCacheClient.ts
@@ -464,6 +464,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-elasticache/ElastiCacheClient.ts
+++ b/clients/client-elasticache/ElastiCacheClient.ts
@@ -467,7 +467,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-elasticache/runtimeConfig.browser.ts
+++ b/clients/client-elasticache/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elasticache/runtimeConfig.ts
+++ b/clients/client-elasticache/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
@@ -341,6 +341,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
@@ -344,7 +344,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-elasticsearch-service/runtimeConfig.browser.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-elasticsearch-service/runtimeConfig.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-emr-containers/EMRContainersClient.ts
+++ b/clients/client-emr-containers/EMRContainersClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-emr-containers/EMRContainersClient.ts
+++ b/clients/client-emr-containers/EMRContainersClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-emr-containers/runtimeConfig.browser.ts
+++ b/clients/client-emr-containers/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-emr-containers/runtimeConfig.ts
+++ b/clients/client-emr-containers/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-emr/EMRClient.ts
+++ b/clients/client-emr/EMRClient.ts
@@ -356,7 +356,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-emr/EMRClient.ts
+++ b/clients/client-emr/EMRClient.ts
@@ -353,6 +353,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-emr/runtimeConfig.browser.ts
+++ b/clients/client-emr/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-emr/runtimeConfig.ts
+++ b/clients/client-emr/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-eventbridge/EventBridgeClient.ts
+++ b/clients/client-eventbridge/EventBridgeClient.ts
@@ -341,7 +341,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-eventbridge/EventBridgeClient.ts
+++ b/clients/client-eventbridge/EventBridgeClient.ts
@@ -338,6 +338,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-eventbridge/runtimeConfig.browser.ts
+++ b/clients/client-eventbridge/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-eventbridge/runtimeConfig.ts
+++ b/clients/client-eventbridge/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-finspace-data/FinspaceDataClient.ts
+++ b/clients/client-finspace-data/FinspaceDataClient.ts
@@ -149,6 +149,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-finspace-data/FinspaceDataClient.ts
+++ b/clients/client-finspace-data/FinspaceDataClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-finspace-data/runtimeConfig.browser.ts
+++ b/clients/client-finspace-data/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-finspace-data/runtimeConfig.ts
+++ b/clients/client-finspace-data/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-finspace/FinspaceClient.ts
+++ b/clients/client-finspace/FinspaceClient.ts
@@ -164,6 +164,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-finspace/FinspaceClient.ts
+++ b/clients/client-finspace/FinspaceClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-finspace/runtimeConfig.browser.ts
+++ b/clients/client-finspace/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-finspace/runtimeConfig.ts
+++ b/clients/client-finspace/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-firehose/FirehoseClient.ts
+++ b/clients/client-firehose/FirehoseClient.ts
@@ -197,6 +197,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-firehose/FirehoseClient.ts
+++ b/clients/client-firehose/FirehoseClient.ts
@@ -200,7 +200,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-firehose/runtimeConfig.browser.ts
+++ b/clients/client-firehose/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-firehose/runtimeConfig.ts
+++ b/clients/client-firehose/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-fis/FisClient.ts
+++ b/clients/client-fis/FisClient.ts
@@ -197,6 +197,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-fis/FisClient.ts
+++ b/clients/client-fis/FisClient.ts
@@ -200,7 +200,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-fis/runtimeConfig.browser.ts
+++ b/clients/client-fis/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-fis/runtimeConfig.ts
+++ b/clients/client-fis/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-fms/FMSClient.ts
+++ b/clients/client-fms/FMSClient.ts
@@ -248,6 +248,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-fms/FMSClient.ts
+++ b/clients/client-fms/FMSClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-fms/runtimeConfig.browser.ts
+++ b/clients/client-fms/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-fms/runtimeConfig.ts
+++ b/clients/client-fms/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-forecast/ForecastClient.ts
+++ b/clients/client-forecast/ForecastClient.ts
@@ -284,6 +284,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-forecast/ForecastClient.ts
+++ b/clients/client-forecast/ForecastClient.ts
@@ -287,7 +287,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-forecast/runtimeConfig.browser.ts
+++ b/clients/client-forecast/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-forecast/runtimeConfig.ts
+++ b/clients/client-forecast/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-forecastquery/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/ForecastqueryClient.ts
@@ -138,6 +138,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-forecastquery/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/ForecastqueryClient.ts
@@ -141,7 +141,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-forecastquery/runtimeConfig.browser.ts
+++ b/clients/client-forecastquery/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-forecastquery/runtimeConfig.ts
+++ b/clients/client-forecastquery/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-frauddetector/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/FraudDetectorClient.ts
@@ -356,6 +356,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-frauddetector/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/FraudDetectorClient.ts
@@ -359,7 +359,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-frauddetector/runtimeConfig.browser.ts
+++ b/clients/client-frauddetector/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-frauddetector/runtimeConfig.ts
+++ b/clients/client-frauddetector/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-fsx/FSxClient.ts
+++ b/clients/client-fsx/FSxClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-fsx/FSxClient.ts
+++ b/clients/client-fsx/FSxClient.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-fsx/runtimeConfig.browser.ts
+++ b/clients/client-fsx/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-fsx/runtimeConfig.ts
+++ b/clients/client-fsx/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-gamelift/GameLiftClient.ts
+++ b/clients/client-gamelift/GameLiftClient.ts
@@ -593,6 +593,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-gamelift/GameLiftClient.ts
+++ b/clients/client-gamelift/GameLiftClient.ts
@@ -596,7 +596,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-gamelift/runtimeConfig.browser.ts
+++ b/clients/client-gamelift/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-gamelift/runtimeConfig.ts
+++ b/clients/client-gamelift/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-glacier/GlacierClient.ts
+++ b/clients/client-glacier/GlacierClient.ts
@@ -289,7 +289,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-glacier/GlacierClient.ts
+++ b/clients/client-glacier/GlacierClient.ts
@@ -286,6 +286,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-glacier/runtimeConfig.browser.ts
+++ b/clients/client-glacier/runtimeConfig.browser.ts
@@ -4,7 +4,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -30,6 +30,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-glacier/runtimeConfig.ts
+++ b/clients/client-glacier/runtimeConfig.ts
@@ -5,7 +5,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-global-accelerator/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/GlobalAcceleratorClient.ts
@@ -371,6 +371,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-global-accelerator/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/GlobalAcceleratorClient.ts
@@ -374,7 +374,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-global-accelerator/runtimeConfig.browser.ts
+++ b/clients/client-global-accelerator/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-global-accelerator/runtimeConfig.ts
+++ b/clients/client-global-accelerator/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-glue/GlueClient.ts
+++ b/clients/client-glue/GlueClient.ts
@@ -749,6 +749,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-glue/GlueClient.ts
+++ b/clients/client-glue/GlueClient.ts
@@ -752,7 +752,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-glue/runtimeConfig.browser.ts
+++ b/clients/client-glue/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-glue/runtimeConfig.ts
+++ b/clients/client-glue/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-greengrass/GreengrassClient.ts
+++ b/clients/client-greengrass/GreengrassClient.ts
@@ -644,7 +644,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-greengrass/GreengrassClient.ts
+++ b/clients/client-greengrass/GreengrassClient.ts
@@ -641,6 +641,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-greengrass/runtimeConfig.browser.ts
+++ b/clients/client-greengrass/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-greengrass/runtimeConfig.ts
+++ b/clients/client-greengrass/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-greengrassv2/GreengrassV2Client.ts
+++ b/clients/client-greengrassv2/GreengrassV2Client.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-greengrassv2/GreengrassV2Client.ts
+++ b/clients/client-greengrassv2/GreengrassV2Client.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-greengrassv2/runtimeConfig.browser.ts
+++ b/clients/client-greengrassv2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-greengrassv2/runtimeConfig.ts
+++ b/clients/client-greengrassv2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-groundstation/GroundStationClient.ts
+++ b/clients/client-groundstation/GroundStationClient.ts
@@ -242,7 +242,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-groundstation/GroundStationClient.ts
+++ b/clients/client-groundstation/GroundStationClient.ts
@@ -239,6 +239,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-groundstation/runtimeConfig.browser.ts
+++ b/clients/client-groundstation/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-groundstation/runtimeConfig.ts
+++ b/clients/client-groundstation/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-guardduty/GuardDutyClient.ts
+++ b/clients/client-guardduty/GuardDutyClient.ts
@@ -386,7 +386,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-guardduty/GuardDutyClient.ts
+++ b/clients/client-guardduty/GuardDutyClient.ts
@@ -383,6 +383,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-guardduty/runtimeConfig.browser.ts
+++ b/clients/client-guardduty/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-guardduty/runtimeConfig.ts
+++ b/clients/client-guardduty/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-health/HealthClient.ts
+++ b/clients/client-health/HealthClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-health/HealthClient.ts
+++ b/clients/client-health/HealthClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-health/runtimeConfig.browser.ts
+++ b/clients/client-health/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-health/runtimeConfig.ts
+++ b/clients/client-health/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-healthlake/HealthLakeClient.ts
+++ b/clients/client-healthlake/HealthLakeClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-healthlake/HealthLakeClient.ts
+++ b/clients/client-healthlake/HealthLakeClient.ts
@@ -176,6 +176,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-healthlake/runtimeConfig.browser.ts
+++ b/clients/client-healthlake/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-healthlake/runtimeConfig.ts
+++ b/clients/client-healthlake/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-honeycode/HoneycodeClient.ts
+++ b/clients/client-honeycode/HoneycodeClient.ts
@@ -194,6 +194,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-honeycode/HoneycodeClient.ts
+++ b/clients/client-honeycode/HoneycodeClient.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-honeycode/runtimeConfig.browser.ts
+++ b/clients/client-honeycode/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-honeycode/runtimeConfig.ts
+++ b/clients/client-honeycode/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iam/IAMClient.ts
+++ b/clients/client-iam/IAMClient.ts
@@ -836,6 +836,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iam/IAMClient.ts
+++ b/clients/client-iam/IAMClient.ts
@@ -839,7 +839,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iam/runtimeConfig.browser.ts
+++ b/clients/client-iam/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iam/runtimeConfig.ts
+++ b/clients/client-iam/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-identitystore/IdentitystoreClient.ts
+++ b/clients/client-identitystore/IdentitystoreClient.ts
@@ -149,6 +149,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-identitystore/IdentitystoreClient.ts
+++ b/clients/client-identitystore/IdentitystoreClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-identitystore/runtimeConfig.browser.ts
+++ b/clients/client-identitystore/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-identitystore/runtimeConfig.ts
+++ b/clients/client-identitystore/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-imagebuilder/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/ImagebuilderClient.ts
@@ -362,6 +362,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-imagebuilder/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/ImagebuilderClient.ts
@@ -365,7 +365,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-imagebuilder/runtimeConfig.browser.ts
+++ b/clients/client-imagebuilder/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-imagebuilder/runtimeConfig.ts
+++ b/clients/client-imagebuilder/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-inspector/InspectorClient.ts
+++ b/clients/client-inspector/InspectorClient.ts
@@ -326,6 +326,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-inspector/InspectorClient.ts
+++ b/clients/client-inspector/InspectorClient.ts
@@ -329,7 +329,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-inspector/runtimeConfig.browser.ts
+++ b/clients/client-inspector/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-inspector/runtimeConfig.ts
+++ b/clients/client-inspector/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
@@ -191,7 +191,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
@@ -188,6 +188,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-1click-devices-service/runtimeConfig.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
@@ -197,6 +197,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
@@ -200,7 +200,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot-1click-projects/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-1click-projects/runtimeConfig.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -161,6 +161,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-events-data/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/IoTEventsDataClient.ts
@@ -155,7 +155,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot-events-data/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/IoTEventsDataClient.ts
@@ -152,6 +152,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot-events-data/runtimeConfig.browser.ts
+++ b/clients/client-iot-events-data/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-events-data/runtimeConfig.ts
+++ b/clients/client-iot-events-data/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-events/IoTEventsClient.ts
+++ b/clients/client-iot-events/IoTEventsClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot-events/IoTEventsClient.ts
+++ b/clients/client-iot-events/IoTEventsClient.ts
@@ -224,6 +224,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot-events/runtimeConfig.browser.ts
+++ b/clients/client-iot-events/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-events/runtimeConfig.ts
+++ b/clients/client-iot-events/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
@@ -158,6 +158,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
@@ -161,7 +161,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-wireless/IoTWirelessClient.ts
+++ b/clients/client-iot-wireless/IoTWirelessClient.ts
@@ -398,6 +398,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot-wireless/IoTWirelessClient.ts
+++ b/clients/client-iot-wireless/IoTWirelessClient.ts
@@ -401,7 +401,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot-wireless/runtimeConfig.browser.ts
+++ b/clients/client-iot-wireless/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot-wireless/runtimeConfig.ts
+++ b/clients/client-iot-wireless/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot/IoTClient.ts
+++ b/clients/client-iot/IoTClient.ts
@@ -1202,6 +1202,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iot/IoTClient.ts
+++ b/clients/client-iot/IoTClient.ts
@@ -1205,7 +1205,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iot/runtimeConfig.browser.ts
+++ b/clients/client-iot/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iot/runtimeConfig.ts
+++ b/clients/client-iot/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotanalytics/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/IoTAnalyticsClient.ts
@@ -266,7 +266,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iotanalytics/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/IoTAnalyticsClient.ts
@@ -263,6 +263,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iotanalytics/runtimeConfig.browser.ts
+++ b/clients/client-iotanalytics/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotanalytics/runtimeConfig.ts
+++ b/clients/client-iotanalytics/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
+++ b/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
+++ b/clients/client-iotdeviceadvisor/IotDeviceAdvisorClient.ts
@@ -191,6 +191,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iotdeviceadvisor/runtimeConfig.browser.ts
+++ b/clients/client-iotdeviceadvisor/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotdeviceadvisor/runtimeConfig.ts
+++ b/clients/client-iotdeviceadvisor/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotfleethub/IoTFleetHubClient.ts
+++ b/clients/client-iotfleethub/IoTFleetHubClient.ts
@@ -167,6 +167,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iotfleethub/IoTFleetHubClient.ts
+++ b/clients/client-iotfleethub/IoTFleetHubClient.ts
@@ -170,7 +170,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iotfleethub/runtimeConfig.browser.ts
+++ b/clients/client-iotfleethub/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotfleethub/runtimeConfig.ts
+++ b/clients/client-iotfleethub/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
@@ -161,6 +161,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotsecuretunneling/runtimeConfig.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotsitewise/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/IoTSiteWiseClient.ts
@@ -368,7 +368,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iotsitewise/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/IoTSiteWiseClient.ts
@@ -365,6 +365,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iotsitewise/runtimeConfig.browser.ts
+++ b/clients/client-iotsitewise/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotsitewise/runtimeConfig.ts
+++ b/clients/client-iotsitewise/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
@@ -305,6 +305,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
@@ -308,7 +308,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-iotthingsgraph/runtimeConfig.browser.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-iotthingsgraph/runtimeConfig.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ivs/IvsClient.ts
+++ b/clients/client-ivs/IvsClient.ts
@@ -242,7 +242,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ivs/IvsClient.ts
+++ b/clients/client-ivs/IvsClient.ts
@@ -239,6 +239,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ivs/runtimeConfig.browser.ts
+++ b/clients/client-ivs/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ivs/runtimeConfig.ts
+++ b/clients/client-ivs/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kafka/KafkaClient.ts
+++ b/clients/client-kafka/KafkaClient.ts
@@ -278,7 +278,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kafka/KafkaClient.ts
+++ b/clients/client-kafka/KafkaClient.ts
@@ -275,6 +275,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kafka/runtimeConfig.browser.ts
+++ b/clients/client-kafka/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kafka/runtimeConfig.ts
+++ b/clients/client-kafka/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kendra/KendraClient.ts
+++ b/clients/client-kendra/KendraClient.ts
@@ -242,7 +242,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kendra/KendraClient.ts
+++ b/clients/client-kendra/KendraClient.ts
@@ -239,6 +239,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kendra/runtimeConfig.browser.ts
+++ b/clients/client-kendra/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kendra/runtimeConfig.ts
+++ b/clients/client-kendra/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
@@ -302,7 +302,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
@@ -299,6 +299,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
@@ -233,6 +233,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kinesis-analytics/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-analytics/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
@@ -161,6 +161,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
@@ -138,6 +138,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
@@ -141,7 +141,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kinesis-video-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -148,6 +148,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -151,7 +151,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video-signaling/runtimeConfig.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/KinesisVideoClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kinesis-video/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/KinesisVideoClient.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kinesis-video/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis-video/runtimeConfig.ts
+++ b/clients/client-kinesis-video/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis/KinesisClient.ts
+++ b/clients/client-kinesis/KinesisClient.ts
@@ -266,7 +266,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kinesis/KinesisClient.ts
+++ b/clients/client-kinesis/KinesisClient.ts
@@ -263,6 +263,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kinesis/runtimeConfig.browser.ts
+++ b/clients/client-kinesis/runtimeConfig.browser.ts
@@ -4,7 +4,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -30,6 +30,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kinesis/runtimeConfig.ts
+++ b/clients/client-kinesis/runtimeConfig.ts
@@ -5,7 +5,7 @@ import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aw
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kms/KMSClient.ts
+++ b/clients/client-kms/KMSClient.ts
@@ -320,6 +320,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-kms/KMSClient.ts
+++ b/clients/client-kms/KMSClient.ts
@@ -323,7 +323,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-kms/runtimeConfig.browser.ts
+++ b/clients/client-kms/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-kms/runtimeConfig.ts
+++ b/clients/client-kms/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lakeformation/LakeFormationClient.ts
+++ b/clients/client-lakeformation/LakeFormationClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lakeformation/LakeFormationClient.ts
+++ b/clients/client-lakeformation/LakeFormationClient.ts
@@ -233,6 +233,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lakeformation/runtimeConfig.browser.ts
+++ b/clients/client-lakeformation/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lakeformation/runtimeConfig.ts
+++ b/clients/client-lakeformation/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lambda/LambdaClient.ts
+++ b/clients/client-lambda/LambdaClient.ts
@@ -416,7 +416,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lambda/LambdaClient.ts
+++ b/clients/client-lambda/LambdaClient.ts
@@ -413,6 +413,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lambda/runtimeConfig.browser.ts
+++ b/clients/client-lambda/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lambda/runtimeConfig.ts
+++ b/clients/client-lambda/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
@@ -284,6 +284,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
@@ -287,7 +287,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lex-model-building-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-model-building-service/runtimeConfig.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-models-v2/LexModelsV2Client.ts
+++ b/clients/client-lex-models-v2/LexModelsV2Client.ts
@@ -266,7 +266,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lex-models-v2/LexModelsV2Client.ts
+++ b/clients/client-lex-models-v2/LexModelsV2Client.ts
@@ -263,6 +263,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lex-models-v2/runtimeConfig.browser.ts
+++ b/clients/client-lex-models-v2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-models-v2/runtimeConfig.ts
+++ b/clients/client-lex-models-v2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
@@ -155,7 +155,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
@@ -152,6 +152,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lex-runtime-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-runtime-service/runtimeConfig.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
+++ b/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
@@ -167,6 +167,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
+++ b/clients/client-lex-runtime-v2/LexRuntimeV2Client.ts
@@ -170,7 +170,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lex-runtime-v2/runtimeConfig.browser.ts
+++ b/clients/client-lex-runtime-v2/runtimeConfig.browser.ts
@@ -4,7 +4,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction, invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lex-runtime-v2/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/runtimeConfig.ts
@@ -6,7 +6,7 @@ import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credentia
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttp2Handler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -35,6 +35,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttp2Handler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-license-manager/LicenseManagerClient.ts
+++ b/clients/client-license-manager/LicenseManagerClient.ts
@@ -317,7 +317,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-license-manager/LicenseManagerClient.ts
+++ b/clients/client-license-manager/LicenseManagerClient.ts
@@ -314,6 +314,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-license-manager/runtimeConfig.browser.ts
+++ b/clients/client-license-manager/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-license-manager/runtimeConfig.ts
+++ b/clients/client-license-manager/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lightsail/LightsailClient.ts
+++ b/clients/client-lightsail/LightsailClient.ts
@@ -773,6 +773,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lightsail/LightsailClient.ts
+++ b/clients/client-lightsail/LightsailClient.ts
@@ -776,7 +776,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lightsail/runtimeConfig.browser.ts
+++ b/clients/client-lightsail/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lightsail/runtimeConfig.ts
+++ b/clients/client-lightsail/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-location/LocationClient.ts
+++ b/clients/client-location/LocationClient.ts
@@ -287,6 +287,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-location/LocationClient.ts
+++ b/clients/client-location/LocationClient.ts
@@ -290,7 +290,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-location/runtimeConfig.browser.ts
+++ b/clients/client-location/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-location/runtimeConfig.ts
+++ b/clients/client-location/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lookoutequipment/LookoutEquipmentClient.ts
+++ b/clients/client-lookoutequipment/LookoutEquipmentClient.ts
@@ -242,7 +242,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lookoutequipment/LookoutEquipmentClient.ts
+++ b/clients/client-lookoutequipment/LookoutEquipmentClient.ts
@@ -239,6 +239,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lookoutequipment/runtimeConfig.browser.ts
+++ b/clients/client-lookoutequipment/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lookoutequipment/runtimeConfig.ts
+++ b/clients/client-lookoutequipment/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lookoutmetrics/LookoutMetricsClient.ts
+++ b/clients/client-lookoutmetrics/LookoutMetricsClient.ts
@@ -245,6 +245,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lookoutmetrics/LookoutMetricsClient.ts
+++ b/clients/client-lookoutmetrics/LookoutMetricsClient.ts
@@ -248,7 +248,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lookoutmetrics/runtimeConfig.browser.ts
+++ b/clients/client-lookoutmetrics/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lookoutmetrics/runtimeConfig.ts
+++ b/clients/client-lookoutmetrics/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lookoutvision/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/LookoutVisionClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-lookoutvision/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/LookoutVisionClient.ts
@@ -200,6 +200,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-lookoutvision/runtimeConfig.browser.ts
+++ b/clients/client-lookoutvision/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-lookoutvision/runtimeConfig.ts
+++ b/clients/client-lookoutvision/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-machine-learning/MachineLearningClient.ts
+++ b/clients/client-machine-learning/MachineLearningClient.ts
@@ -254,6 +254,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-machine-learning/MachineLearningClient.ts
+++ b/clients/client-machine-learning/MachineLearningClient.ts
@@ -257,7 +257,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-machine-learning/runtimeConfig.browser.ts
+++ b/clients/client-machine-learning/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-machine-learning/runtimeConfig.ts
+++ b/clients/client-machine-learning/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-macie/MacieClient.ts
+++ b/clients/client-macie/MacieClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-macie/MacieClient.ts
+++ b/clients/client-macie/MacieClient.ts
@@ -170,6 +170,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-macie/runtimeConfig.browser.ts
+++ b/clients/client-macie/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-macie/runtimeConfig.ts
+++ b/clients/client-macie/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-macie2/Macie2Client.ts
+++ b/clients/client-macie2/Macie2Client.ts
@@ -398,6 +398,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-macie2/Macie2Client.ts
+++ b/clients/client-macie2/Macie2Client.ts
@@ -401,7 +401,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-macie2/runtimeConfig.browser.ts
+++ b/clients/client-macie2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-macie2/runtimeConfig.ts
+++ b/clients/client-macie2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-managedblockchain/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/ManagedBlockchainClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-managedblockchain/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/ManagedBlockchainClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-managedblockchain/runtimeConfig.browser.ts
+++ b/clients/client-managedblockchain/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-managedblockchain/runtimeConfig.ts
+++ b/clients/client-managedblockchain/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
@@ -158,7 +158,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
@@ -155,6 +155,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-marketplace-catalog/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-catalog/runtimeConfig.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
@@ -142,6 +142,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
@@ -138,6 +138,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
@@ -141,7 +141,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
@@ -149,6 +149,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-marketplace-metering/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-marketplace-metering/runtimeConfig.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediaconnect/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/MediaConnectClient.ts
@@ -242,7 +242,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mediaconnect/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/MediaConnectClient.ts
@@ -239,6 +239,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mediaconnect/runtimeConfig.browser.ts
+++ b/clients/client-mediaconnect/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediaconnect/runtimeConfig.ts
+++ b/clients/client-mediaconnect/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediaconvert/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/MediaConvertClient.ts
@@ -224,7 +224,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mediaconvert/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/MediaConvertClient.ts
@@ -221,6 +221,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mediaconvert/runtimeConfig.browser.ts
+++ b/clients/client-mediaconvert/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediaconvert/runtimeConfig.ts
+++ b/clients/client-mediaconvert/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-medialive/MediaLiveClient.ts
+++ b/clients/client-medialive/MediaLiveClient.ts
@@ -368,7 +368,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-medialive/MediaLiveClient.ts
+++ b/clients/client-medialive/MediaLiveClient.ts
@@ -365,6 +365,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-medialive/runtimeConfig.browser.ts
+++ b/clients/client-medialive/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-medialive/runtimeConfig.ts
+++ b/clients/client-medialive/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediapackage-vod/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/MediaPackageVodClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mediapackage-vod/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/MediaPackageVodClient.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mediapackage-vod/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediapackage-vod/runtimeConfig.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediapackage/MediaPackageClient.ts
+++ b/clients/client-mediapackage/MediaPackageClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mediapackage/MediaPackageClient.ts
+++ b/clients/client-mediapackage/MediaPackageClient.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mediapackage/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediapackage/runtimeConfig.ts
+++ b/clients/client-mediapackage/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediastore-data/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/MediaStoreDataClient.ts
@@ -155,7 +155,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mediastore-data/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/MediaStoreDataClient.ts
@@ -152,6 +152,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mediastore-data/runtimeConfig.browser.ts
+++ b/clients/client-mediastore-data/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediastore-data/runtimeConfig.ts
+++ b/clients/client-mediastore-data/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediastore/MediaStoreClient.ts
+++ b/clients/client-mediastore/MediaStoreClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mediastore/MediaStoreClient.ts
+++ b/clients/client-mediastore/MediaStoreClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mediastore/runtimeConfig.browser.ts
+++ b/clients/client-mediastore/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediastore/runtimeConfig.ts
+++ b/clients/client-mediastore/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediatailor/MediaTailorClient.ts
+++ b/clients/client-mediatailor/MediaTailorClient.ts
@@ -266,7 +266,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mediatailor/MediaTailorClient.ts
+++ b/clients/client-mediatailor/MediaTailorClient.ts
@@ -263,6 +263,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mediatailor/runtimeConfig.browser.ts
+++ b/clients/client-mediatailor/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mediatailor/runtimeConfig.ts
+++ b/clients/client-mediatailor/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mgn/MgnClient.ts
+++ b/clients/client-mgn/MgnClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mgn/MgnClient.ts
+++ b/clients/client-mgn/MgnClient.ts
@@ -257,6 +257,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mgn/runtimeConfig.browser.ts
+++ b/clients/client-mgn/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mgn/runtimeConfig.ts
+++ b/clients/client-mgn/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-migration-hub/MigrationHubClient.ts
+++ b/clients/client-migration-hub/MigrationHubClient.ts
@@ -239,7 +239,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-migration-hub/MigrationHubClient.ts
+++ b/clients/client-migration-hub/MigrationHubClient.ts
@@ -236,6 +236,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-migration-hub/runtimeConfig.browser.ts
+++ b/clients/client-migration-hub/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-migration-hub/runtimeConfig.ts
+++ b/clients/client-migration-hub/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-migrationhub-config/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/MigrationHubConfigClient.ts
@@ -155,7 +155,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-migrationhub-config/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/MigrationHubConfigClient.ts
@@ -152,6 +152,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-migrationhub-config/runtimeConfig.browser.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-migrationhub-config/runtimeConfig.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mobile/MobileClient.ts
+++ b/clients/client-mobile/MobileClient.ts
@@ -164,6 +164,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mobile/MobileClient.ts
+++ b/clients/client-mobile/MobileClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mobile/runtimeConfig.browser.ts
+++ b/clients/client-mobile/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mobile/runtimeConfig.ts
+++ b/clients/client-mobile/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mq/MqClient.ts
+++ b/clients/client-mq/MqClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mq/MqClient.ts
+++ b/clients/client-mq/MqClient.ts
@@ -224,6 +224,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mq/runtimeConfig.browser.ts
+++ b/clients/client-mq/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mq/runtimeConfig.ts
+++ b/clients/client-mq/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mturk/MTurkClient.ts
+++ b/clients/client-mturk/MTurkClient.ts
@@ -317,6 +317,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mturk/MTurkClient.ts
+++ b/clients/client-mturk/MTurkClient.ts
@@ -320,7 +320,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mturk/runtimeConfig.browser.ts
+++ b/clients/client-mturk/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mturk/runtimeConfig.ts
+++ b/clients/client-mturk/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mwaa/MWAAClient.ts
+++ b/clients/client-mwaa/MWAAClient.ts
@@ -179,7 +179,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-mwaa/MWAAClient.ts
+++ b/clients/client-mwaa/MWAAClient.ts
@@ -176,6 +176,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-mwaa/runtimeConfig.browser.ts
+++ b/clients/client-mwaa/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-mwaa/runtimeConfig.ts
+++ b/clients/client-mwaa/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-neptune/NeptuneClient.ts
+++ b/clients/client-neptune/NeptuneClient.ts
@@ -473,6 +473,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-neptune/NeptuneClient.ts
+++ b/clients/client-neptune/NeptuneClient.ts
@@ -476,7 +476,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-neptune/runtimeConfig.browser.ts
+++ b/clients/client-neptune/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-neptune/runtimeConfig.ts
+++ b/clients/client-neptune/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-network-firewall/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/NetworkFirewallClient.ts
@@ -275,7 +275,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-network-firewall/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/NetworkFirewallClient.ts
@@ -272,6 +272,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-network-firewall/runtimeConfig.browser.ts
+++ b/clients/client-network-firewall/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-network-firewall/runtimeConfig.ts
+++ b/clients/client-network-firewall/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-networkmanager/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/NetworkManagerClient.ts
@@ -287,6 +287,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-networkmanager/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/NetworkManagerClient.ts
@@ -290,7 +290,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-networkmanager/runtimeConfig.browser.ts
+++ b/clients/client-networkmanager/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-networkmanager/runtimeConfig.ts
+++ b/clients/client-networkmanager/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-nimble/NimbleClient.ts
+++ b/clients/client-nimble/NimbleClient.ts
@@ -356,7 +356,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-nimble/NimbleClient.ts
+++ b/clients/client-nimble/NimbleClient.ts
@@ -353,6 +353,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-nimble/runtimeConfig.browser.ts
+++ b/clients/client-nimble/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-nimble/runtimeConfig.ts
+++ b/clients/client-nimble/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-opsworks/OpsWorksClient.ts
+++ b/clients/client-opsworks/OpsWorksClient.ts
@@ -437,6 +437,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-opsworks/OpsWorksClient.ts
+++ b/clients/client-opsworks/OpsWorksClient.ts
@@ -440,7 +440,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-opsworks/runtimeConfig.browser.ts
+++ b/clients/client-opsworks/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-opsworks/runtimeConfig.ts
+++ b/clients/client-opsworks/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-opsworkscm/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/OpsWorksCMClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-opsworkscm/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/OpsWorksCMClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-opsworkscm/runtimeConfig.browser.ts
+++ b/clients/client-opsworkscm/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-opsworkscm/runtimeConfig.ts
+++ b/clients/client-opsworkscm/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-organizations/OrganizationsClient.ts
+++ b/clients/client-organizations/OrganizationsClient.ts
@@ -368,7 +368,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-organizations/OrganizationsClient.ts
+++ b/clients/client-organizations/OrganizationsClient.ts
@@ -365,6 +365,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-organizations/runtimeConfig.browser.ts
+++ b/clients/client-organizations/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-organizations/runtimeConfig.ts
+++ b/clients/client-organizations/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-outposts/OutpostsClient.ts
+++ b/clients/client-outposts/OutpostsClient.ts
@@ -176,7 +176,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-outposts/OutpostsClient.ts
+++ b/clients/client-outposts/OutpostsClient.ts
@@ -173,6 +173,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-outposts/runtimeConfig.browser.ts
+++ b/clients/client-outposts/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-outposts/runtimeConfig.ts
+++ b/clients/client-outposts/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-personalize-events/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/PersonalizeEventsClient.ts
@@ -140,6 +140,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-personalize-events/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/PersonalizeEventsClient.ts
@@ -143,7 +143,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-personalize-events/runtimeConfig.browser.ts
+++ b/clients/client-personalize-events/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-personalize-events/runtimeConfig.ts
+++ b/clients/client-personalize-events/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
@@ -142,6 +142,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-personalize-runtime/runtimeConfig.browser.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-personalize-runtime/runtimeConfig.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-personalize/PersonalizeClient.ts
+++ b/clients/client-personalize/PersonalizeClient.ts
@@ -320,6 +320,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-personalize/PersonalizeClient.ts
+++ b/clients/client-personalize/PersonalizeClient.ts
@@ -323,7 +323,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-personalize/runtimeConfig.browser.ts
+++ b/clients/client-personalize/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-personalize/runtimeConfig.ts
+++ b/clients/client-personalize/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pi/PIClient.ts
+++ b/clients/client-pi/PIClient.ts
@@ -142,6 +142,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-pi/PIClient.ts
+++ b/clients/client-pi/PIClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-pi/runtimeConfig.browser.ts
+++ b/clients/client-pi/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pi/runtimeConfig.ts
+++ b/clients/client-pi/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pinpoint-email/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/PinpointEmailClient.ts
@@ -371,7 +371,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-pinpoint-email/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/PinpointEmailClient.ts
@@ -368,6 +368,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-pinpoint-email/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pinpoint-email/runtimeConfig.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -182,6 +182,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -185,7 +185,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pinpoint/PinpointClient.ts
+++ b/clients/client-pinpoint/PinpointClient.ts
@@ -584,7 +584,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-pinpoint/PinpointClient.ts
+++ b/clients/client-pinpoint/PinpointClient.ts
@@ -581,6 +581,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-pinpoint/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pinpoint/runtimeConfig.ts
+++ b/clients/client-pinpoint/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-polly/PollyClient.ts
+++ b/clients/client-polly/PollyClient.ts
@@ -176,7 +176,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-polly/PollyClient.ts
+++ b/clients/client-polly/PollyClient.ts
@@ -173,6 +173,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-polly/runtimeConfig.browser.ts
+++ b/clients/client-polly/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-polly/runtimeConfig.ts
+++ b/clients/client-polly/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pricing/PricingClient.ts
+++ b/clients/client-pricing/PricingClient.ts
@@ -143,6 +143,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-pricing/PricingClient.ts
+++ b/clients/client-pricing/PricingClient.ts
@@ -146,7 +146,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-pricing/runtimeConfig.browser.ts
+++ b/clients/client-pricing/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-pricing/runtimeConfig.ts
+++ b/clients/client-pricing/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-qldb-session/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/QLDBSessionClient.ts
@@ -138,6 +138,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-qldb-session/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/QLDBSessionClient.ts
@@ -141,7 +141,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-qldb-session/runtimeConfig.browser.ts
+++ b/clients/client-qldb-session/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-qldb-session/runtimeConfig.ts
+++ b/clients/client-qldb-session/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-qldb/runtimeConfig.browser.ts
+++ b/clients/client-qldb/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-qldb/runtimeConfig.ts
+++ b/clients/client-qldb/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-quicksight/QuickSightClient.ts
+++ b/clients/client-quicksight/QuickSightClient.ts
@@ -551,7 +551,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-quicksight/QuickSightClient.ts
+++ b/clients/client-quicksight/QuickSightClient.ts
@@ -548,6 +548,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-quicksight/runtimeConfig.browser.ts
+++ b/clients/client-quicksight/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-quicksight/runtimeConfig.ts
+++ b/clients/client-quicksight/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ram/RAMClient.ts
+++ b/clients/client-ram/RAMClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ram/RAMClient.ts
+++ b/clients/client-ram/RAMClient.ts
@@ -257,6 +257,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ram/runtimeConfig.browser.ts
+++ b/clients/client-ram/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ram/runtimeConfig.ts
+++ b/clients/client-ram/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-rds-data/RDSDataClient.ts
+++ b/clients/client-rds-data/RDSDataClient.ts
@@ -164,7 +164,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-rds-data/RDSDataClient.ts
+++ b/clients/client-rds-data/RDSDataClient.ts
@@ -161,6 +161,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-rds-data/runtimeConfig.browser.ts
+++ b/clients/client-rds-data/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-rds-data/runtimeConfig.ts
+++ b/clients/client-rds-data/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-rds/RDSClient.ts
+++ b/clients/client-rds/RDSClient.ts
@@ -854,6 +854,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-rds/RDSClient.ts
+++ b/clients/client-rds/RDSClient.ts
@@ -857,7 +857,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-rds/runtimeConfig.browser.ts
+++ b/clients/client-rds/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-rds/runtimeConfig.ts
+++ b/clients/client-rds/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-redshift-data/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/RedshiftDataClient.ts
@@ -164,6 +164,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-redshift-data/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/RedshiftDataClient.ts
@@ -167,7 +167,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-redshift-data/runtimeConfig.browser.ts
+++ b/clients/client-redshift-data/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-redshift-data/runtimeConfig.ts
+++ b/clients/client-redshift-data/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-redshift/RedshiftClient.ts
+++ b/clients/client-redshift/RedshiftClient.ts
@@ -692,7 +692,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-redshift/RedshiftClient.ts
+++ b/clients/client-redshift/RedshiftClient.ts
@@ -689,6 +689,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-redshift/runtimeConfig.browser.ts
+++ b/clients/client-redshift/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-redshift/runtimeConfig.ts
+++ b/clients/client-redshift/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-rekognition/RekognitionClient.ts
+++ b/clients/client-rekognition/RekognitionClient.ts
@@ -356,6 +356,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-rekognition/RekognitionClient.ts
+++ b/clients/client-rekognition/RekognitionClient.ts
@@ -359,7 +359,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-rekognition/runtimeConfig.browser.ts
+++ b/clients/client-rekognition/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-rekognition/runtimeConfig.ts
+++ b/clients/client-rekognition/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
@@ -173,7 +173,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
@@ -170,6 +170,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-resource-groups/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/ResourceGroupsClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-resource-groups/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/ResourceGroupsClient.ts
@@ -191,6 +191,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-resource-groups/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-resource-groups/runtimeConfig.ts
+++ b/clients/client-resource-groups/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-robomaker/RoboMakerClient.ts
+++ b/clients/client-robomaker/RoboMakerClient.ts
@@ -422,6 +422,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-robomaker/RoboMakerClient.ts
+++ b/clients/client-robomaker/RoboMakerClient.ts
@@ -425,7 +425,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-robomaker/runtimeConfig.browser.ts
+++ b/clients/client-robomaker/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-robomaker/runtimeConfig.ts
+++ b/clients/client-robomaker/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-route-53-domains/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/Route53DomainsClient.ts
@@ -278,6 +278,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-route-53-domains/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/Route53DomainsClient.ts
@@ -281,7 +281,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-route-53-domains/runtimeConfig.browser.ts
+++ b/clients/client-route-53-domains/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-route-53-domains/runtimeConfig.ts
+++ b/clients/client-route-53-domains/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-route-53/Route53Client.ts
+++ b/clients/client-route-53/Route53Client.ts
@@ -464,6 +464,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-route-53/Route53Client.ts
+++ b/clients/client-route-53/Route53Client.ts
@@ -467,7 +467,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-route-53/runtimeConfig.browser.ts
+++ b/clients/client-route-53/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-route-53/runtimeConfig.ts
+++ b/clients/client-route-53/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-route53resolver/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/Route53ResolverClient.ts
@@ -461,6 +461,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-route53resolver/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/Route53ResolverClient.ts
@@ -464,7 +464,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-route53resolver/runtimeConfig.browser.ts
+++ b/clients/client-route53resolver/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-route53resolver/runtimeConfig.ts
+++ b/clients/client-route53resolver/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-s3-control/S3ControlClient.ts
+++ b/clients/client-s3-control/S3ControlClient.ts
@@ -379,7 +379,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-s3-control/S3ControlClient.ts
+++ b/clients/client-s3-control/S3ControlClient.ts
@@ -376,6 +376,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-s3-control/runtimeConfig.browser.ts
+++ b/clients/client-s3-control/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-s3-control/runtimeConfig.ts
+++ b/clients/client-s3-control/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -584,7 +584,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -581,6 +581,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-s3/runtimeConfig.browser.ts
+++ b/clients/client-s3/runtimeConfig.browser.ts
@@ -6,7 +6,7 @@ import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { blobHasher as streamHasher } from "@aws-sdk/hash-blob-browser";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { Md5 } from "@aws-sdk/md5-js";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   md5: Md5,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   streamHasher,

--- a/clients/client-s3/runtimeConfig.ts
+++ b/clients/client-s3/runtimeConfig.ts
@@ -7,7 +7,7 @@ import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
 import { Hash } from "@aws-sdk/hash-node";
 import { fileStreamHasher as streamHasher } from "@aws-sdk/hash-stream-node";
 import { NODE_USE_ARN_REGION_CONFIG_OPTIONS } from "@aws-sdk/middleware-bucket-endpoint";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HashConstructor as __HashConstructor } from "@aws-sdk/types";
@@ -37,6 +37,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   md5: Hash.bind(null, "md5"),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   streamHasher,

--- a/clients/client-s3outposts/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/S3OutpostsClient.ts
@@ -140,6 +140,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-s3outposts/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/S3OutpostsClient.ts
@@ -143,7 +143,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-s3outposts/runtimeConfig.browser.ts
+++ b/clients/client-s3outposts/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-s3outposts/runtimeConfig.ts
+++ b/clients/client-s3outposts/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
@@ -155,7 +155,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
@@ -152,6 +152,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
@@ -142,6 +142,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/SagemakerEdgeClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sagemaker-edge/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-edge/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-edge/runtimeConfig.ts
+++ b/clients/client-sagemaker-edge/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
@@ -140,6 +140,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/SageMakerFeatureStoreRuntimeClient.ts
@@ -143,7 +143,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sagemaker-featurestore-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-featurestore-runtime/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-featurestore-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-featurestore-runtime/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
@@ -138,6 +138,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
@@ -141,7 +141,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker/SageMakerClient.ts
+++ b/clients/client-sagemaker/SageMakerClient.ts
@@ -1172,7 +1172,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sagemaker/SageMakerClient.ts
+++ b/clients/client-sagemaker/SageMakerClient.ts
@@ -1169,6 +1169,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sagemaker/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sagemaker/runtimeConfig.ts
+++ b/clients/client-sagemaker/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-savingsplans/SavingsplansClient.ts
+++ b/clients/client-savingsplans/SavingsplansClient.ts
@@ -182,6 +182,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-savingsplans/SavingsplansClient.ts
+++ b/clients/client-savingsplans/SavingsplansClient.ts
@@ -185,7 +185,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-savingsplans/runtimeConfig.browser.ts
+++ b/clients/client-savingsplans/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-savingsplans/runtimeConfig.ts
+++ b/clients/client-savingsplans/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-schemas/SchemasClient.ts
+++ b/clients/client-schemas/SchemasClient.ts
@@ -248,6 +248,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-schemas/SchemasClient.ts
+++ b/clients/client-schemas/SchemasClient.ts
@@ -251,7 +251,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-schemas/runtimeConfig.browser.ts
+++ b/clients/client-schemas/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-schemas/runtimeConfig.ts
+++ b/clients/client-schemas/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-secrets-manager/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/SecretsManagerClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-secrets-manager/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/SecretsManagerClient.ts
@@ -224,6 +224,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-secrets-manager/runtimeConfig.browser.ts
+++ b/clients/client-secrets-manager/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-secrets-manager/runtimeConfig.ts
+++ b/clients/client-secrets-manager/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-securityhub/SecurityHubClient.ts
+++ b/clients/client-securityhub/SecurityHubClient.ts
@@ -362,6 +362,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-securityhub/SecurityHubClient.ts
+++ b/clients/client-securityhub/SecurityHubClient.ts
@@ -365,7 +365,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-securityhub/runtimeConfig.browser.ts
+++ b/clients/client-securityhub/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-securityhub/runtimeConfig.ts
+++ b/clients/client-securityhub/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
@@ -206,7 +206,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
@@ -203,6 +203,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
@@ -233,6 +233,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-service-catalog-appregistry/runtimeConfig.browser.ts
+++ b/clients/client-service-catalog-appregistry/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-service-catalog-appregistry/runtimeConfig.ts
+++ b/clients/client-service-catalog-appregistry/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-service-catalog/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/ServiceCatalogClient.ts
@@ -584,6 +584,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-service-catalog/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/ServiceCatalogClient.ts
@@ -587,7 +587,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-service-catalog/runtimeConfig.browser.ts
+++ b/clients/client-service-catalog/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-service-catalog/runtimeConfig.ts
+++ b/clients/client-service-catalog/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-service-quotas/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/ServiceQuotasClient.ts
@@ -239,7 +239,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-service-quotas/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/ServiceQuotasClient.ts
@@ -236,6 +236,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-service-quotas/runtimeConfig.browser.ts
+++ b/clients/client-service-quotas/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-service-quotas/runtimeConfig.ts
+++ b/clients/client-service-quotas/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-servicediscovery/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/ServiceDiscoveryClient.ts
@@ -227,7 +227,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-servicediscovery/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/ServiceDiscoveryClient.ts
@@ -224,6 +224,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-servicediscovery/runtimeConfig.browser.ts
+++ b/clients/client-servicediscovery/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-servicediscovery/runtimeConfig.ts
+++ b/clients/client-servicediscovery/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ses/SESClient.ts
+++ b/clients/client-ses/SESClient.ts
@@ -503,7 +503,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ses/SESClient.ts
+++ b/clients/client-ses/SESClient.ts
@@ -500,6 +500,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ses/runtimeConfig.browser.ts
+++ b/clients/client-ses/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ses/runtimeConfig.ts
+++ b/clients/client-ses/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sesv2/SESv2Client.ts
+++ b/clients/client-sesv2/SESv2Client.ts
@@ -554,7 +554,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sesv2/SESv2Client.ts
+++ b/clients/client-sesv2/SESv2Client.ts
@@ -551,6 +551,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sesv2/runtimeConfig.browser.ts
+++ b/clients/client-sesv2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sesv2/runtimeConfig.ts
+++ b/clients/client-sesv2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sfn/SFNClient.ts
+++ b/clients/client-sfn/SFNClient.ts
@@ -221,7 +221,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sfn/SFNClient.ts
+++ b/clients/client-sfn/SFNClient.ts
@@ -218,6 +218,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sfn/runtimeConfig.browser.ts
+++ b/clients/client-sfn/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sfn/runtimeConfig.ts
+++ b/clients/client-sfn/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-shield/ShieldClient.ts
+++ b/clients/client-shield/ShieldClient.ts
@@ -296,6 +296,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-shield/ShieldClient.ts
+++ b/clients/client-shield/ShieldClient.ts
@@ -299,7 +299,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-shield/runtimeConfig.browser.ts
+++ b/clients/client-shield/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-shield/runtimeConfig.ts
+++ b/clients/client-shield/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-signer/SignerClient.ts
+++ b/clients/client-signer/SignerClient.ts
@@ -212,6 +212,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-signer/SignerClient.ts
+++ b/clients/client-signer/SignerClient.ts
@@ -215,7 +215,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-signer/runtimeConfig.browser.ts
+++ b/clients/client-signer/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-signer/runtimeConfig.ts
+++ b/clients/client-signer/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sms/SMSClient.ts
+++ b/clients/client-sms/SMSClient.ts
@@ -305,7 +305,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sms/SMSClient.ts
+++ b/clients/client-sms/SMSClient.ts
@@ -302,6 +302,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sms/runtimeConfig.browser.ts
+++ b/clients/client-sms/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sms/runtimeConfig.ts
+++ b/clients/client-sms/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-snowball/SnowballClient.ts
+++ b/clients/client-snowball/SnowballClient.ts
@@ -236,7 +236,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-snowball/SnowballClient.ts
+++ b/clients/client-snowball/SnowballClient.ts
@@ -233,6 +233,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-snowball/runtimeConfig.browser.ts
+++ b/clients/client-snowball/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-snowball/runtimeConfig.ts
+++ b/clients/client-snowball/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sns/SNSClient.ts
+++ b/clients/client-sns/SNSClient.ts
@@ -284,6 +284,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sns/SNSClient.ts
+++ b/clients/client-sns/SNSClient.ts
@@ -287,7 +287,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sns/runtimeConfig.browser.ts
+++ b/clients/client-sns/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sns/runtimeConfig.ts
+++ b/clients/client-sns/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -206,6 +206,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sqs/runtimeConfig.browser.ts
+++ b/clients/client-sqs/runtimeConfig.browser.ts
@@ -4,7 +4,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { Md5 } from "@aws-sdk/md5-js";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -30,6 +30,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   md5: Md5,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sqs/runtimeConfig.ts
+++ b/clients/client-sqs/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HashConstructor as __HashConstructor } from "@aws-sdk/types";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   md5: Hash.bind(null, "md5"),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ssm-contacts/SSMContactsClient.ts
+++ b/clients/client-ssm-contacts/SSMContactsClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ssm-contacts/SSMContactsClient.ts
+++ b/clients/client-ssm-contacts/SSMContactsClient.ts
@@ -242,6 +242,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ssm-contacts/runtimeConfig.browser.ts
+++ b/clients/client-ssm-contacts/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ssm-contacts/runtimeConfig.ts
+++ b/clients/client-ssm-contacts/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ssm-incidents/SSMIncidentsClient.ts
+++ b/clients/client-ssm-incidents/SSMIncidentsClient.ts
@@ -266,6 +266,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ssm-incidents/SSMIncidentsClient.ts
+++ b/clients/client-ssm-incidents/SSMIncidentsClient.ts
@@ -269,7 +269,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ssm-incidents/runtimeConfig.browser.ts
+++ b/clients/client-ssm-incidents/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ssm-incidents/runtimeConfig.ts
+++ b/clients/client-ssm-incidents/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ssm/SSMClient.ts
+++ b/clients/client-ssm/SSMClient.ts
@@ -815,7 +815,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-ssm/SSMClient.ts
+++ b/clients/client-ssm/SSMClient.ts
@@ -812,6 +812,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-ssm/runtimeConfig.browser.ts
+++ b/clients/client-ssm/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-ssm/runtimeConfig.ts
+++ b/clients/client-ssm/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sso-admin/SSOAdminClient.ts
+++ b/clients/client-sso-admin/SSOAdminClient.ts
@@ -314,7 +314,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sso-admin/SSOAdminClient.ts
+++ b/clients/client-sso-admin/SSOAdminClient.ts
@@ -311,6 +311,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sso-admin/runtimeConfig.browser.ts
+++ b/clients/client-sso-admin/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sso-admin/runtimeConfig.ts
+++ b/clients/client-sso-admin/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -142,6 +142,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sso-oidc/runtimeConfig.browser.ts
+++ b/clients/client-sso-oidc/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -27,6 +27,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sso-oidc/runtimeConfig.ts
+++ b/clients/client-sso-oidc/runtimeConfig.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -142,6 +142,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -145,7 +145,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sso/runtimeConfig.browser.ts
+++ b/clients/client-sso/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -27,6 +27,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sso/runtimeConfig.ts
+++ b/clients/client-sso/runtimeConfig.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-storage-gateway/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/StorageGatewayClient.ts
@@ -554,6 +554,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-storage-gateway/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/StorageGatewayClient.ts
@@ -557,7 +557,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-storage-gateway/runtimeConfig.browser.ts
+++ b/clients/client-storage-gateway/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-storage-gateway/runtimeConfig.ts
+++ b/clients/client-storage-gateway/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -162,6 +162,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -165,7 +165,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-sts/runtimeConfig.browser.ts
+++ b/clients/client-sts/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-sts/runtimeConfig.ts
+++ b/clients/client-sts/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "./defaultStsRoleAssumers";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-support/SupportClient.ts
+++ b/clients/client-support/SupportClient.ts
@@ -206,6 +206,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-support/SupportClient.ts
+++ b/clients/client-support/SupportClient.ts
@@ -209,7 +209,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-support/runtimeConfig.browser.ts
+++ b/clients/client-support/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-support/runtimeConfig.ts
+++ b/clients/client-support/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-swf/SWFClient.ts
+++ b/clients/client-swf/SWFClient.ts
@@ -332,6 +332,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-swf/SWFClient.ts
+++ b/clients/client-swf/SWFClient.ts
@@ -335,7 +335,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-swf/runtimeConfig.browser.ts
+++ b/clients/client-swf/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-swf/runtimeConfig.ts
+++ b/clients/client-swf/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-synthetics/SyntheticsClient.ts
+++ b/clients/client-synthetics/SyntheticsClient.ts
@@ -185,6 +185,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-synthetics/SyntheticsClient.ts
+++ b/clients/client-synthetics/SyntheticsClient.ts
@@ -188,7 +188,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-synthetics/runtimeConfig.browser.ts
+++ b/clients/client-synthetics/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-synthetics/runtimeConfig.ts
+++ b/clients/client-synthetics/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-textract/TextractClient.ts
+++ b/clients/client-textract/TextractClient.ts
@@ -167,6 +167,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-textract/TextractClient.ts
+++ b/clients/client-textract/TextractClient.ts
@@ -170,7 +170,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-textract/runtimeConfig.browser.ts
+++ b/clients/client-textract/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-textract/runtimeConfig.ts
+++ b/clients/client-textract/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -149,6 +149,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -152,7 +152,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-timestream-query/runtimeConfig.browser.ts
+++ b/clients/client-timestream-query/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -29,6 +29,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-timestream-query/runtimeConfig.ts
+++ b/clients/client-timestream-query/runtimeConfig.ts
@@ -5,7 +5,7 @@ import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aw
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
 import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -194,6 +194,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -197,7 +197,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-timestream-write/runtimeConfig.browser.ts
+++ b/clients/client-timestream-write/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -29,6 +29,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-timestream-write/runtimeConfig.ts
+++ b/clients/client-timestream-write/runtimeConfig.ts
@@ -5,7 +5,7 @@ import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aw
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
 import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -33,6 +33,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
@@ -163,6 +163,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
@@ -166,7 +166,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-transcribe-streaming/runtimeConfig.browser.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.browser.ts
@@ -4,7 +4,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { WebSocketHandler, eventStreamPayloadHandler } from "@aws-sdk/middleware-sdk-transcribe-streaming";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
@@ -32,6 +32,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new WebSocketHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-transcribe-streaming/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.ts
@@ -6,7 +6,7 @@ import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credentia
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttp2Handler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -35,6 +35,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttp2Handler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-transcribe/TranscribeClient.ts
+++ b/clients/client-transcribe/TranscribeClient.ts
@@ -281,6 +281,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-transcribe/TranscribeClient.ts
+++ b/clients/client-transcribe/TranscribeClient.ts
@@ -284,7 +284,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-transcribe/runtimeConfig.browser.ts
+++ b/clients/client-transcribe/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-transcribe/runtimeConfig.ts
+++ b/clients/client-transcribe/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-transfer/TransferClient.ts
+++ b/clients/client-transfer/TransferClient.ts
@@ -212,7 +212,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-transfer/TransferClient.ts
+++ b/clients/client-transfer/TransferClient.ts
@@ -209,6 +209,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-transfer/runtimeConfig.browser.ts
+++ b/clients/client-transfer/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-transfer/runtimeConfig.ts
+++ b/clients/client-transfer/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-translate/TranslateClient.ts
+++ b/clients/client-translate/TranslateClient.ts
@@ -194,7 +194,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-translate/TranslateClient.ts
+++ b/clients/client-translate/TranslateClient.ts
@@ -191,6 +191,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-translate/runtimeConfig.browser.ts
+++ b/clients/client-translate/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-translate/runtimeConfig.ts
+++ b/clients/client-translate/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-waf-regional/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/WAFRegionalClient.ts
@@ -485,6 +485,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-waf-regional/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/WAFRegionalClient.ts
@@ -488,7 +488,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-waf-regional/runtimeConfig.browser.ts
+++ b/clients/client-waf-regional/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-waf-regional/runtimeConfig.ts
+++ b/clients/client-waf-regional/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-waf/WAFClient.ts
+++ b/clients/client-waf/WAFClient.ts
@@ -467,6 +467,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-waf/WAFClient.ts
+++ b/clients/client-waf/WAFClient.ts
@@ -470,7 +470,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-waf/runtimeConfig.browser.ts
+++ b/clients/client-waf/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-waf/runtimeConfig.ts
+++ b/clients/client-waf/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-wafv2/WAFV2Client.ts
+++ b/clients/client-wafv2/WAFV2Client.ts
@@ -314,7 +314,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-wafv2/WAFV2Client.ts
+++ b/clients/client-wafv2/WAFV2Client.ts
@@ -311,6 +311,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-wafv2/runtimeConfig.browser.ts
+++ b/clients/client-wafv2/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-wafv2/runtimeConfig.ts
+++ b/clients/client-wafv2/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-wellarchitected/WellArchitectedClient.ts
+++ b/clients/client-wellarchitected/WellArchitectedClient.ts
@@ -260,7 +260,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-wellarchitected/WellArchitectedClient.ts
+++ b/clients/client-wellarchitected/WellArchitectedClient.ts
@@ -257,6 +257,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-wellarchitected/runtimeConfig.browser.ts
+++ b/clients/client-wellarchitected/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-wellarchitected/runtimeConfig.ts
+++ b/clients/client-wellarchitected/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workdocs/WorkDocsClient.ts
+++ b/clients/client-workdocs/WorkDocsClient.ts
@@ -308,6 +308,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-workdocs/WorkDocsClient.ts
+++ b/clients/client-workdocs/WorkDocsClient.ts
@@ -311,7 +311,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-workdocs/runtimeConfig.browser.ts
+++ b/clients/client-workdocs/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workdocs/runtimeConfig.ts
+++ b/clients/client-workdocs/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-worklink/WorkLinkClient.ts
+++ b/clients/client-worklink/WorkLinkClient.ts
@@ -296,6 +296,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-worklink/WorkLinkClient.ts
+++ b/clients/client-worklink/WorkLinkClient.ts
@@ -299,7 +299,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-worklink/runtimeConfig.browser.ts
+++ b/clients/client-worklink/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-worklink/runtimeConfig.ts
+++ b/clients/client-worklink/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workmail/WorkMailClient.ts
+++ b/clients/client-workmail/WorkMailClient.ts
@@ -380,6 +380,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-workmail/WorkMailClient.ts
+++ b/clients/client-workmail/WorkMailClient.ts
@@ -383,7 +383,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-workmail/runtimeConfig.browser.ts
+++ b/clients/client-workmail/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workmail/runtimeConfig.ts
+++ b/clients/client-workmail/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
@@ -148,7 +148,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
@@ -145,6 +145,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-workmailmessageflow/runtimeConfig.browser.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workmailmessageflow/runtimeConfig.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workspaces/WorkSpacesClient.ts
+++ b/clients/client-workspaces/WorkSpacesClient.ts
@@ -395,6 +395,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-workspaces/WorkSpacesClient.ts
+++ b/clients/client-workspaces/WorkSpacesClient.ts
@@ -398,7 +398,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-workspaces/runtimeConfig.browser.ts
+++ b/clients/client-workspaces/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-workspaces/runtimeConfig.ts
+++ b/clients/client-workspaces/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-xray/XRayClient.ts
+++ b/clients/client-xray/XRayClient.ts
@@ -245,7 +245,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/clients/client-xray/XRayClient.ts
+++ b/clients/client-xray/XRayClient.ts
@@ -242,6 +242,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/clients/client-xray/runtimeConfig.browser.ts
+++ b/clients/client-xray/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/clients/client-xray/runtimeConfig.ts
+++ b/clients/client-xray/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -50,6 +50,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  *     <li>region: The AWS region to which this client will send requests</li>
  *     <li>maxAttempts: Provides value for how many times a request will be
  *     made at most in case of retry.</li>
+ *     <li>retryModeProvider: Specifies provider for retry algorithm to use.</li>
  *     <li>logger: Optional logger for logging debug/info/warn/error.</li>
  * </ul>
  *
@@ -61,6 +62,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  *      environment variables and the AWS config file.</li>
  *     <li>maxAttempts: Uses the default maxAttempts provider that checks things
  *     like environment variables and the AWS config file.</li>
+ *     <li>retryModeProvider: Specifies provider for retry algorithm to use.</li>
  *     <li>logger: Sets to empty as logger is passed in client configuration</li>
  * </ul>
  *
@@ -72,6 +74,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  *     be explicitly provided in the browser (environment variables and
  *     the shared config can't be resolved from the browser).</li>
  *     <li>maxAttempts: Returns default value of 3.</li>
+ *     <li>retryModeProvider: Provider which returns DEFAULT_RETRY_MODE.</li>
  *     <li>logger: Sets to empty as logger is passed in client configuration</li>
  * </ul>
  */
@@ -100,6 +103,8 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         }
         writer.writeDocs("Value for how many times a request will be made at most in case of retry.")
                 .write("maxAttempts?: number | __Provider<number>;\n");
+        writer.writeDocs("Specifies provider for retry algorithm to use.\n@internal")
+                .write("retryModeProvider: __Provider<string>;\n");
         writer.writeDocs("Optional logger for logging debug/info/warn/error.")
                 .write("logger?: __Logger;\n");
     }
@@ -160,6 +165,12 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                             TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
                     writer.write("maxAttempts: DEFAULT_MAX_ATTEMPTS,");
                 });
+                defaultConfigs.put("retryModeProvider", writer -> {
+                    writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);
+                    writer.addImport("DEFAULT_RETRY_MODE", "DEFAULT_RETRY_MODE",
+                            TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
+                    writer.write("retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),");
+                });
                 return defaultConfigs;
             case NODE:
                 if (isSigV4Service) {
@@ -184,6 +195,15 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                     writer.addImport("NODE_MAX_ATTEMPT_CONFIG_OPTIONS", "NODE_MAX_ATTEMPT_CONFIG_OPTIONS",
                         TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
                     writer.write("maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),");
+                });
+                defaultConfigs.put("retryModeProvider", writer -> {
+                    writer.addDependency(AwsDependency.NODE_CONFIG_PROVIDER);
+                    writer.addImport("loadConfig", "loadNodeConfig",
+                            AwsDependency.NODE_CONFIG_PROVIDER.packageName);
+                    writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);
+                    writer.addImport("NODE_RETRY_MODE_CONFIG_OPTIONS", "NODE_RETRY_MODE_CONFIG_OPTIONS",
+                            TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
+                    writer.write("retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),");
                 });
                 return defaultConfigs;
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -104,7 +104,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         writer.writeDocs("Value for how many times a request will be made at most in case of retry.")
                 .write("maxAttempts?: number | __Provider<number>;\n");
         writer.writeDocs("Specifies provider for retry algorithm to use.\n@internal")
-                .write("retryModeProvider: __Provider<string>;\n");
+                .write("retryModeProvider?: __Provider<string>;\n");
         writer.writeDocs("Optional logger for logging debug/info/warn/error.")
                 .write("logger?: __Logger;\n");
     }

--- a/protocol_tests/aws-ec2/EC2ProtocolClient.ts
+++ b/protocol_tests/aws-ec2/EC2ProtocolClient.ts
@@ -203,7 +203,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/protocol_tests/aws-ec2/EC2ProtocolClient.ts
+++ b/protocol_tests/aws-ec2/EC2ProtocolClient.ts
@@ -200,6 +200,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/protocol_tests/aws-ec2/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -25,6 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-ec2/runtimeConfig.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.ts
@@ -1,7 +1,7 @@
 import packageInfo from "./package.json";
 
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -26,6 +26,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-json/JsonProtocolClient.ts
+++ b/protocol_tests/aws-json/JsonProtocolClient.ts
@@ -179,6 +179,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/protocol_tests/aws-json/JsonProtocolClient.ts
+++ b/protocol_tests/aws-json/JsonProtocolClient.ts
@@ -182,7 +182,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/protocol_tests/aws-json/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-json/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidProvider } from "@aws-sdk/invalid-dependency";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -28,6 +28,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-json/runtimeConfig.ts
+++ b/protocol_tests/aws-json/runtimeConfig.ts
@@ -4,7 +4,7 @@ import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -31,6 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-query/QueryProtocolClient.ts
+++ b/protocol_tests/aws-query/QueryProtocolClient.ts
@@ -230,6 +230,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/protocol_tests/aws-query/QueryProtocolClient.ts
+++ b/protocol_tests/aws-query/QueryProtocolClient.ts
@@ -233,7 +233,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/protocol_tests/aws-query/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-query/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -25,6 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-query/runtimeConfig.ts
+++ b/protocol_tests/aws-query/runtimeConfig.ts
@@ -1,7 +1,7 @@
 import packageInfo from "./package.json";
 
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -26,6 +26,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
+++ b/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
@@ -323,6 +323,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
+++ b/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
@@ -326,7 +326,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/protocol_tests/aws-restjson/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -25,6 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-restjson/runtimeConfig.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.ts
@@ -1,7 +1,7 @@
 import packageInfo from "./package.json";
 
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -26,6 +26,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
@@ -362,6 +362,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: __Provider<string>;
+
+  /**
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;

--- a/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
@@ -365,7 +365,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Specifies provider for retry algorithm to use.
    * @internal
    */
-  retryModeProvider: __Provider<string>;
+  retryModeProvider?: __Provider<string>;
 
   /**
    * Optional logger for logging debug/info/warn/error.

--- a/protocol_tests/aws-restxml/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
@@ -25,6 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   requestHandler: new FetchHttpHandler(),
+  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
   sha256: Sha256,
   streamCollector,
   utf8Decoder: fromUtf8,

--- a/protocol_tests/aws-restxml/runtimeConfig.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.ts
@@ -1,7 +1,7 @@
 import packageInfo from "./package.json";
 
 import { Hash } from "@aws-sdk/hash-node";
-import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
+import { NODE_MAX_ATTEMPT_CONFIG_OPTIONS, NODE_RETRY_MODE_CONFIG_OPTIONS } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
@@ -26,6 +26,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   }),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   requestHandler: new NodeHttpHandler(),
+  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,
   utf8Decoder: fromUtf8,


### PR DESCRIPTION
### Issue
Internal JS-2635

### Description
Adds retryModeProvider in runtimeConfig for clients.
This provider is going to be used in middleware-retry to call adaptive retry strategy if provided in the environment or shared ini configurations.

### Testing
Testing will be done when middleware-retry is updated.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
