### PR TITLE
docs(node-config-provider): fix package name in README

### DIFF
--- a/packages/node-config-provider/README.md
+++ b/packages/node-config-provider/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/node-http-handler
+# @aws-sdk/node-config-provider
 
-[![NPM version](https://img.shields.io/npm/v/@aws-sdk/node-http-handler/latest.svg)](https://www.npmjs.com/package/@aws-sdk/node-http-handler)
-[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/node-http-handler.svg)](https://www.npmjs.com/package/@aws-sdk/node-http-handler)
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/node-config-provider/latest.svg)](https://www.npmjs.com/package/@aws-sdk/node-config-provider)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/node-config-provider.svg)](https://www.npmjs.com/package/@aws-sdk/node-config-provider)


### PR DESCRIPTION

### Description
This PR fixes the package name. As of now, it is `@aws-sdk/node-http-handler` but should be `@aws-sdk/node-config-provider`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
