### PR TITLE
chore(middleware-retry): move constants to constants.ts

### DIFF
--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -1,7 +1,8 @@
 import { LoadedConfigSelectors } from "@aws-sdk/node-config-provider";
 import { Provider, RetryStrategy } from "@aws-sdk/types";
 
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE, StandardRetryStrategy } from "./defaultStrategy";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "./constants";
+import { StandardRetryStrategy } from "./defaultStrategy";
 
 export const ENV_MAX_ATTEMPTS = "AWS_MAX_ATTEMPTS";
 export const CONFIG_MAX_ATTEMPTS = "max_attempts";

--- a/packages/middleware-retry/src/constants.ts
+++ b/packages/middleware-retry/src/constants.ts
@@ -47,3 +47,14 @@ export const INVOCATION_ID_HEADER = "amz-sdk-invocation-id";
  * Header name for request retry information.
  */
 export const REQUEST_HEADER = "amz-sdk-request";
+
+/**
+ * The default value for how many HTTP requests an SDK should make for a
+ * single SDK operation invocation before giving up
+ */
+export const DEFAULT_MAX_ATTEMPTS = 3;
+
+/**
+ * The default retry algorithm to use.
+ */
+export const DEFAULT_RETRY_MODE = "standard";

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -5,7 +5,9 @@ import { FinalizeHandler, FinalizeHandlerArguments, MetadataBearer, Provider, Re
 import { v4 } from "uuid";
 
 import {
+  DEFAULT_MAX_ATTEMPTS,
   DEFAULT_RETRY_DELAY_BASE,
+  DEFAULT_RETRY_MODE,
   INITIAL_RETRY_TOKENS,
   INVOCATION_ID_HEADER,
   REQUEST_HEADER,
@@ -15,17 +17,6 @@ import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
 import { DelayDecider, RetryDecider, RetryQuota } from "./types";
-
-/**
- * The default value for how many HTTP requests an SDK should make for a
- * single SDK operation invocation before giving up
- */
-export const DEFAULT_MAX_ATTEMPTS = 3;
-
-/**
- * The default retry algorithm to use.
- */
-export const DEFAULT_RETRY_MODE = "standard";
 
 /**
  * Strategy options to be passed to StandardRetryStrategy


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2435

### Description
Moves constants to constants.ts in middleware-retry.
This is part of cleanup before introducing adaptive retry strategy.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
