### PR TITLE
chore(protocol_tests): remove @aws-sdk/types from devDeps

### DIFF
--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -59,7 +59,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.16.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.16.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -59,7 +59,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.16.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.16.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.16.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",


### PR DESCRIPTION
### Issue
* Refs: https://github.com/aws/aws-sdk-js-v3/pull/2440#issuecomment-850410316
* `@aws-sdk/types` were moved to deps in https://github.com/aws/aws-sdk-js-v3/pull/1902 for clients, but weren't removed from protocol_tests.

### Description
Removes @aws-sdk/types from devDeps, as it's present in deps.

### Testing
* CI
* Verified that running `yarn generate-clients` does not add `@aws-sdk/types` in devDeps.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
