### PR TITLE
feat(middleware-retry): call retry strategy based on value in retryMode

### DIFF
--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -72,7 +72,7 @@ export const resolveRetryConfig = <T>(input: T & PreviouslyResolved & RetryInput
         return input.retryStrategy;
       }
       const retryMode = input.retryMode || (await input.retryModeProvider());
-      if (retryMode === RETRY_MODES.adaptive) {
+      if (retryMode === RETRY_MODES.ADAPTIVE) {
         return new AdaptiveRetryStrategy(maxAttempts);
       }
       return new StandardRetryStrategy(maxAttempts);

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -1,7 +1,8 @@
 import { LoadedConfigSelectors } from "@aws-sdk/node-config-provider";
 import { Provider, RetryStrategy } from "@aws-sdk/types";
 
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "./config";
+import { AdaptiveRetryStrategy } from "./AdaptiveRetryStrategy";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE, RETRY_MODES } from "./config";
 import { StandardRetryStrategy } from "./StandardRetryStrategy";
 
 export const ENV_MAX_ATTEMPTS = "AWS_MAX_ATTEMPTS";
@@ -38,6 +39,15 @@ export interface RetryInputConfig {
    * The strategy to retry the request. Using built-in exponential backoff strategy by default.
    */
   retryStrategy?: RetryStrategy;
+  /**
+   * Specifies which retry algorithm to use.
+   */
+  retryMode?: string;
+  /**
+   * Specifies provider for retry algorithm to use.
+   * @internal
+   */
+  retryModeProvider: Provider<string>;
 }
 
 interface PreviouslyResolved {}
@@ -49,7 +59,7 @@ export interface RetryResolvedConfig {
   /**
    * Resolved value for input config {@link RetryInputConfig.retryStrategy}
    */
-  retryStrategy: RetryStrategy;
+  retryStrategy: Provider<RetryStrategy>;
 }
 
 export const resolveRetryConfig = <T>(input: T & PreviouslyResolved & RetryInputConfig): T & RetryResolvedConfig => {
@@ -57,7 +67,16 @@ export const resolveRetryConfig = <T>(input: T & PreviouslyResolved & RetryInput
   return {
     ...input,
     maxAttempts,
-    retryStrategy: input.retryStrategy || new StandardRetryStrategy(maxAttempts),
+    retryStrategy: async () => {
+      if (input.retryStrategy) {
+        return input.retryStrategy;
+      }
+      const retryMode = input.retryMode || (await input.retryModeProvider());
+      if (retryMode === RETRY_MODES.adaptive) {
+        return new AdaptiveRetryStrategy(maxAttempts);
+      }
+      return new StandardRetryStrategy(maxAttempts);
+    },
   };
 };
 

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -43,6 +43,9 @@ export interface RetryInputConfig {
    * Specifies which retry algorithm to use.
    */
   retryMode?: string;
+}
+
+interface PreviouslyResolved {
   /**
    * Specifies provider for retry algorithm to use.
    * @internal
@@ -50,7 +53,6 @@ export interface RetryInputConfig {
   retryModeProvider: Provider<string>;
 }
 
-interface PreviouslyResolved {}
 export interface RetryResolvedConfig {
   /**
    * Resolved value for input config {@link RetryInputConfig.maxAttempts}

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -18,9 +18,9 @@ export const retryMiddleware =
     context: HandlerExecutionContext
   ): FinalizeHandler<any, Output> =>
   async (args: FinalizeHandlerArguments<any>): Promise<FinalizeHandlerOutput<Output>> => {
-    if (options?.retryStrategy?.mode)
-      context.userAgent = [...(context.userAgent || []), ["cfg/retry-mode", options.retryStrategy.mode]];
-    return options.retryStrategy.retry(next, args);
+    const retryStrategy = await options.retryStrategy();
+    if (retryStrategy?.mode) context.userAgent = [...(context.userAgent || []), ["cfg/retry-mode", retryStrategy.mode]];
+    return retryStrategy.retry(next, args);
   };
 
 export const retryMiddlewareOptions: FinalizeRequestHandlerOptions & AbsoluteLocation = {


### PR DESCRIPTION
### Issue
Internal JS-2636

### Description
Call retry strategy based on value in retryMode.

### Testing
Verified that adaptive retry strategy is called when retryMode is passed:

```js
const { DynamoDB } = require("../aws-sdk-js-v3/clients/client-dynamodb");

(async () => {
  const client = new DynamoDB({ retryMode: "adaptive" });
  await client.listTables({ Limit: 1 });
})();

```

Verified that retryStrategy.mode was `"adaptive"` in retryMiddleware using console.log

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
