### PR TITLE
chore(middleware-retry): export DefaultRateLimiter

### DIFF
--- a/packages/middleware-retry/src/index.ts
+++ b/packages/middleware-retry/src/index.ts
@@ -5,5 +5,6 @@ export * from "./AdaptiveRetryStrategy";
 export * from "./config";
 export * from "./configurations";
 export * from "./delayDecider";
+export * from "./DefaultRateLimiter";
 export * from "./retryDecider";
 export * from "./types";


### PR DESCRIPTION
### Issue
Follow-up to:
* https://github.com/aws/aws-sdk-js-v3/pull/2439
* https://github.com/aws/aws-sdk-js-v3/pull/2454

### Description
Export DefaultRateLimiter, so that customer can use it for creating a custom AdaptiveRetryStrategy as follows:

```js
import { AdaptiveRetryStrategy, DefaultRateLimiter } from "@aws-sdk/middleware-retry";

...
const client = new DynamoDB({
  region,
  retryStrategy: new AdaptiveRetryStrategy({
    rateLimiter: new DefaultRateLimiter({ beta: 0.5 })
  }),
});
...
```

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
