### PR TITLE
fix(protocol_tests): format files using prettier v2.3.0

### DIFF
--- a/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
+++ b/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
@@ -1763,7 +1763,11 @@ it("Ec2XmlLists:Response", async () => {
 
       stringSet: ["foo", "bar"],
 
-      integerList: [1, 2],
+      integerList: [
+        1,
+
+        2,
+      ],
 
       booleanList: [true, false],
 

--- a/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
+++ b/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
@@ -2339,7 +2339,11 @@ it("QueryXmlLists:Response", async () => {
 
       stringSet: ["foo", "bar"],
 
-      integerList: [1, 2],
+      integerList: [
+        1,
+
+        2,
+      ],
 
       booleanList: [true, false],
 

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -197,9 +197,21 @@ it("RestJsonAllQueryStringTypes:Request", async () => {
 
     queryInteger: 3,
 
-    queryIntegerList: [1, 2, 3],
+    queryIntegerList: [
+      1,
 
-    queryIntegerSet: [1, 2, 3],
+      2,
+
+      3,
+    ],
+
+    queryIntegerSet: [
+      1,
+
+      2,
+
+      3,
+    ],
 
     queryLong: 4,
 
@@ -207,7 +219,13 @@ it("RestJsonAllQueryStringTypes:Request", async () => {
 
     queryDouble: 1.1,
 
-    queryDoubleList: [1.1, 2.1, 3.1],
+    queryDoubleList: [
+      1.1,
+
+      2.1,
+
+      3.1,
+    ],
 
     queryBoolean: true,
 
@@ -2163,7 +2181,13 @@ it("RestJsonInputAndOutputWithNumericHeaders:Request", async () => {
 
     headerDouble: 1.1,
 
-    headerIntegerList: [1, 2, 3],
+    headerIntegerList: [
+      1,
+
+      2,
+
+      3,
+    ],
   } as any);
   try {
     await client.send(command);
@@ -2386,7 +2410,13 @@ it("RestJsonInputAndOutputWithNumericHeaders:Response", async () => {
 
       headerDouble: 1.1,
 
-      headerIntegerList: [1, 2, 3],
+      headerIntegerList: [
+        1,
+
+        2,
+
+        3,
+      ],
     },
   ][0];
   Object.keys(paramsToValidate).forEach((param) => {
@@ -2729,7 +2759,11 @@ it("RestJsonLists:Request", async () => {
 
     stringSet: ["foo", "bar"],
 
-    integerList: [1, 2],
+    integerList: [
+      1,
+
+      2,
+    ],
 
     booleanList: [true, false],
 
@@ -2983,7 +3017,11 @@ it("RestJsonLists:Response", async () => {
 
       stringSet: ["foo", "bar"],
 
-      integerList: [1, 2],
+      integerList: [
+        1,
+
+        2,
+      ],
 
       booleanList: [true, false],
 

--- a/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
@@ -208,9 +208,21 @@ it("AllQueryStringTypes:Request", async () => {
 
     queryInteger: 3,
 
-    queryIntegerList: [1, 2, 3],
+    queryIntegerList: [
+      1,
 
-    queryIntegerSet: [1, 2, 3],
+      2,
+
+      3,
+    ],
+
+    queryIntegerSet: [
+      1,
+
+      2,
+
+      3,
+    ],
 
     queryLong: 4,
 
@@ -218,7 +230,13 @@ it("AllQueryStringTypes:Request", async () => {
 
     queryDouble: 1.1,
 
-    queryDoubleList: [1.1, 2.1, 3.1],
+    queryDoubleList: [
+      1.1,
+
+      2.1,
+
+      3.1,
+    ],
 
     queryBoolean: true,
 
@@ -2119,7 +2137,13 @@ it("InputAndOutputWithNumericHeaders:Request", async () => {
 
     headerDouble: 1.1,
 
-    headerIntegerList: [1, 2, 3],
+    headerIntegerList: [
+      1,
+
+      2,
+
+      3,
+    ],
   } as any);
   try {
     await client.send(command);
@@ -2352,7 +2376,13 @@ it("InputAndOutputWithNumericHeaders:Response", async () => {
 
       headerDouble: 1.1,
 
-      headerIntegerList: [1, 2, 3],
+      headerIntegerList: [
+        1,
+
+        2,
+
+        3,
+      ],
     },
   ][0];
   Object.keys(paramsToValidate).forEach((param) => {
@@ -4495,7 +4525,11 @@ it("XmlLists:Request", async () => {
 
     stringSet: ["foo", "bar"],
 
-    integerList: [1, 2],
+    integerList: [
+      1,
+
+      2,
+    ],
 
     booleanList: [true, false],
 
@@ -4728,7 +4762,11 @@ it("XmlLists:Response", async () => {
 
       stringSet: ["foo", "bar"],
 
-      integerList: [1, 2],
+      integerList: [
+        1,
+
+        2,
+      ],
 
       booleanList: [true, false],
 


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2464

### Description
The protocol_tests were mistakenly formatted using prettier v2.2.1 in the workspace for PR https://github.com/aws/aws-sdk-js-v3/pull/2464
The prettier version was bumped to v2.3.0 in https://github.com/aws/aws-sdk-js-v3/pull/2444

### Testing
Verified the prettier v2.3.0 was installed before running `yarn generate-clients` as follows:
```console
$ ./node_modules/.bin/prettier --version
2.3.0
```
Verified that prettier formatting for protocol_tests is same as that in https://github.com/aws/aws-sdk-js-v3/pull/2444

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
