### PR TITLE
fix(clients): documentation for config.region for new clients

### DIFF
--- a/clients/client-applicationcostprofiler/ApplicationCostProfilerClient.ts
+++ b/clients/client-applicationcostprofiler/ApplicationCostProfilerClient.ts
@@ -163,7 +163,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-apprunner/AppRunnerClient.ts
+++ b/clients/client-apprunner/AppRunnerClient.ts
@@ -217,7 +217,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ssm-contacts/SSMContactsClient.ts
+++ b/clients/client-ssm-contacts/SSMContactsClient.ts
@@ -232,7 +232,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 

--- a/clients/client-ssm-incidents/SSMIncidentsClient.ts
+++ b/clients/client-ssm-incidents/SSMIncidentsClient.ts
@@ -256,7 +256,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   serviceId?: string;
 
   /**
-   * The AWS region to which this client will send requests or use as signingRegion
+   * The AWS region to which this client will send requests
    */
   region?: string | __Provider<string>;
 


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2464

### Description
The documentation for config.region for new clients is different.
For example, for new client `client-applicationcostprofiler` it has suffix ` or use as signingRegion` https://github.com/aws/aws-sdk-js-v3/blob/72cc2dc89f89b6f3290bed623ebb43e5725bed0d/clients/client-applicationcostprofiler/ApplicationCostProfilerClient.ts#L165-L168

The suffix is missing in old clients: https://github.com/aws/aws-sdk-js-v3/blob/72cc2dc89f89b6f3290bed623ebb43e5725bed0d/clients/client-dynamodb/DynamoDBClient.ts#L339-L342

It's likely that this suffix was mistakenly added when clients were updated in https://github.com/aws/aws-sdk-js-v3/pull/2464

### Testing
Verified that the documentation for region is for new clients is same as that in previous clients.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
