### PR TITLE
chore(codegen): use function supplier in RuntimeClientPlugin

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -21,6 +21,7 @@ import static software.amazon.smithy.typescript.codegen.integration.RuntimeClien
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -104,7 +105,9 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.STS_MIDDLEWARE.dependency,
                             "StsAuth", HAS_CONFIG)
-                    .additionalResolveFunctionParameters("STSClient")
+                    .resolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                        put("STSClient", "STSClient"); 
+                    }})
                     .servicePredicate((m, s) -> testServiceId(s, "STS"))
                     .build(),
             RuntimeClientPlugin.builder()

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
@@ -106,7 +107,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
                     .withConventions(AwsDependency.STS_MIDDLEWARE.dependency,
                             "StsAuth", HAS_CONFIG)
                     .resolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
-                        put("STSClient", "STSClient"); 
+                        put("STSClient", Symbol.builder().name("STSClient").build());
                     }})
                     .servicePredicate((m, s) -> testServiceId(s, "STS"))
                     .build(),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -106,7 +106,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
             RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.STS_MIDDLEWARE.dependency,
                             "StsAuth", HAS_CONFIG)
-                    .resolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                    .additionalResolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
                         put("STSClient", Symbol.builder().name("STSClient").build());
                     }})
                     .servicePredicate((m, s) -> testServiceId(s, "STS"))

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientDiscoveredEndpointTrait;
 import software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryTrait;
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -70,7 +71,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                                 "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
                         // ToDo: The Endpoint Discovery Command Name needs to be read from ClientEndpointDiscoveryTrait.
                         .resolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
-                            put("DescribeEndpointsCommand", "DescribeEndpointsCommand"); 
+                            put("DescribeEndpointsCommand", Symbol.builder().name("DescribeEndpointsCommand").build());
                         }})
                         .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
                         .build(),
@@ -80,8 +81,8 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryRequired", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
                         .pluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
-                            put("clientStack", "clientStack");
-                            put("options", "options"); 
+                            put("clientStack", Symbol.builder().name("clientStack").build());
+                            put("options", Symbol.builder().name("options").build());
                         }})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointRequired(s, o))
                         .build(),
@@ -89,8 +90,8 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryOptional", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
                         .pluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
-                            put("clientStack", "clientStack");
-                            put("options", "options"); 
+                            put("clientStack", Symbol.builder().name("clientStack").build());
+                            put("options", Symbol.builder().name("options").build());
                         }})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointOptional(s, o))
                         .build()

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -70,7 +70,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
                         // ToDo: The Endpoint Discovery Command Name needs to be read from ClientEndpointDiscoveryTrait.
-                        .resolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                        .additionalResolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
                             put("DescribeEndpointsCommand", Symbol.builder().name("DescribeEndpointsCommand").build());
                         }})
                         .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
@@ -80,7 +80,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryRequired", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .pluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                        .additionalPluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
                             put("clientStack", Symbol.builder().name("clientStack").build());
                             put("options", Symbol.builder().name("options").build());
                         }})
@@ -89,7 +89,7 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryOptional", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .pluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                        .additionalPluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
                             put("clientStack", Symbol.builder().name("clientStack").build());
                             put("options", Symbol.builder().name("options").build());
                         }})

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -68,7 +69,9 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
                         // ToDo: The Endpoint Discovery Command Name needs to be read from ClientEndpointDiscoveryTrait.
-                        .additionalResolveFunctionParameters("DescribeEndpointsCommand")
+                        .resolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                            put("DescribeEndpointsCommand", "DescribeEndpointsCommand"); 
+                        }})
                         .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
                         .build(),
                 // ToDo: The value ClientDiscoveredEndpointTrait.isRequired() needs to be passed to Plugin instead
@@ -76,13 +79,19 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryRequired", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .additionalPluginFunctionParameters(new String[]{"clientStack", "options"})
+                        .pluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                            put("clientStack", "clientStack");
+                            put("options", "options"); 
+                        }})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointRequired(s, o))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscoveryOptional", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .additionalPluginFunctionParameters(new String[]{"clientStack", "options"})
+                        .pluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                            put("clientStack", "clientStack");
+                            put("options", "options"); 
+                        }})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointOptional(s, o))
                         .build()
         );


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/353

### Description
uses function supplier in RuntimeClientPlugin instead of static function parameters.

### Testing
Verified that `yarn generate-clients` did not update the RuntimeClientPlugin functions in clients.

### Additional context
Refs: https://github.com/awslabs/smithy-typescript/issues/352

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
