### PR TITLE
docs(lib-storage): add "js" syntax highlighting to code block

### DIFF
--- a/lib/lib-storage/README.md
+++ b/lib/lib-storage/README.md
@@ -7,7 +7,7 @@
 
 Upload allows for easy and efficient uploading of buffers, blobs, or streams, using a configurable amount of concurrency to perform multipart uploads where possible. This abstraction enables uploading large files or streams of unknown size due to the use of multipart uploads under the hood.
 
-```
+```js
   import { Upload } from "@aws-sdk/lib-storage";
   import { S3Client, S3 } from "@aws-sdk/client-s3";
 


### PR DESCRIPTION
### Issue
N/A

### Description
Add JavaScript syntax highlighting to code block

### Testing
README now has JavaScript syntax highlighting on GitHub

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
