### PR TITLE
fix(clients): parse status code bindings in rest protocols

### DIFF
--- a/clients/client-glacier/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1.ts
@@ -2621,6 +2621,9 @@ export const deserializeAws_restJson1GetJobOutputCommand = async (
   }
   const data: any = output.body;
   contents.body = data;
+  if (contents.status === undefined) {
+    contents.status = output.statusCode;
+  }
   return Promise.resolve(contents);
 };
 

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -5420,6 +5420,9 @@ export const deserializeAws_restJson1InvokeCommand = async (
   }
   const data: any = await collectBody(output.body, context);
   contents.Payload = data;
+  if (contents.StatusCode === undefined) {
+    contents.StatusCode = output.statusCode;
+  }
   return Promise.resolve(contents);
 };
 

--- a/clients/client-mediastore-data/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1.ts
@@ -389,6 +389,9 @@ export const deserializeAws_restJson1GetObjectCommand = async (
   }
   const data: any = output.body;
   contents.Body = data;
+  if (contents.StatusCode === undefined) {
+    contents.StatusCode = output.statusCode;
+  }
   return Promise.resolve(contents);
 };
 


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-js-v3/issues/2021
Related to https://github.com/awslabs/smithy-typescript/pull/354

### Description
parse the status code traits for rest protocols.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
