### PR TITLE
fix(@aws-sdk/lib-dynamodb): use correct homepage URL in `package.json`

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -40,7 +40,7 @@
       ]
     }
   },
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/lib/lib-dynamodb",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/lib/lib-dynamodb",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
I've noticed that from `npm` website the link to the homepage was broken. This PR is to update the link with the correct one.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
