### PR TITLE
fix(util-dynamodb): unmarshall JavaScript Maps

### DIFF
--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -128,11 +128,24 @@ describe("convertToNative", () => {
         {
           input: [
             { M: { nullKey: { NULL: true }, boolKey: { BOOL: false } } },
-            { M: { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "9007199254740996" } } },
+            {
+              M: {
+                stringKey: { S: "one" },
+                numberKey: { N: "1.01" },
+                bigintKey: { N: "9007199254740996" },
+              },
+            },
           ],
           output: [
-            { nullKey: null, boolKey: false },
-            { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(9007199254740996) },
+            new Map<string, any>([
+              ["nullKey", null],
+              ["boolKey", false],
+            ]),
+            new Map<string, any>([
+              ["stringKey", "one"],
+              ["numberKey", 1.01],
+              ["bigintKey", BigInt(9007199254740996)],
+            ]),
           ],
         },
         {
@@ -171,22 +184,35 @@ describe("convertToNative", () => {
       [
         {
           input: { nullKey: { NULL: true }, boolKey: { BOOL: false } },
-          output: { nullKey: null, boolKey: false },
+          output: new Map<string, any>([
+            ["nullKey", null],
+            ["boolKey", false],
+          ]),
         },
         {
           input: { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "9007199254740996" } },
-          output: { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(9007199254740996) },
+          output: new Map<string, any>([
+            ["stringKey", "one"],
+            ["numberKey", 1.01],
+            ["bigintKey", BigInt(9007199254740996)],
+          ]),
         },
         {
           input: { uint8Arr1Key: { B: uint8Arr1 }, uint8Arr2Key: { B: uint8Arr2 } },
-          output: { uint8Arr1Key: uint8Arr1, uint8Arr2Key: uint8Arr2 },
+          output: new Map<string, any>([
+            ["uint8Arr1Key", uint8Arr1],
+            ["uint8Arr2Key", uint8Arr2],
+          ]),
         },
         {
           input: {
             list1: { L: [{ NULL: true }, { BOOL: false }] },
             list2: { L: [{ S: "one" }, { N: "1.01" }, { N: "9007199254740996" }] },
           },
-          output: { list1: [null, false], list2: ["one", 1.01, BigInt(9007199254740996)] },
+          output: new Map<string, any>([
+            ["list1", [null, false]],
+            ["list2", ["one", 1.01, BigInt(9007199254740996)]],
+          ]),
         },
         {
           input: {
@@ -195,12 +221,33 @@ describe("convertToNative", () => {
             binarySet: { BS: [uint8Arr1, uint8Arr2] },
             stringSet: { SS: ["one", "two", "three"] },
           },
-          output: {
-            numberSet: new Set([1, 2, 3]),
-            bigintSet: new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
-            binarySet: new Set([uint8Arr1, uint8Arr2]),
-            stringSet: new Set(["one", "two", "three"]),
+          output: new Map<string, any>([
+            ["numberSet", new Set([1, 2, 3])],
+            ["bigintSet", new Set([BigInt(9007199254740996), BigInt(-9007199254740996)])],
+            ["binarySet", new Set([uint8Arr1, uint8Arr2])],
+            ["stringSet", new Set(["one", "two", "three"])],
+          ]),
+        },
+        {
+          input: {
+            map: {
+              M: {
+                stringKey: { S: "one" },
+                numberKey: { N: "1.01" },
+                bigintKey: { N: "9007199254740996" },
+              },
+            },
           },
+          output: new Map<string, any>([
+            [
+              "map",
+              new Map<string, any>([
+                ["stringKey", "one"],
+                ["numberKey", 1.01],
+                ["bigintKey", BigInt(9007199254740996)],
+              ]),
+            ],
+          ]),
         },
       ] as { input: { [key: string]: AttributeValue }; output: { [key: string]: NativeAttributeValue } }[]
     ).forEach(({ input, output }) => {
@@ -211,7 +258,10 @@ describe("convertToNative", () => {
 
     it(`testing map with options.wrapNumbers=true`, () => {
       const input = { numberKey: { N: "1.01" }, bigintKey: { N: "9007199254740996" } };
-      const output = { numberKey: { value: "1.01" }, bigintKey: { value: "9007199254740996" } };
+      const output = new Map<string, any>([
+        ["numberKey", { value: "1.01" }],
+        ["bigintKey", { value: "9007199254740996" }],
+      ]);
       expect(convertToNative({ M: input }, { wrapNumbers: true })).toEqual(output);
     });
   });

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -72,11 +72,9 @@ const convertList = (list: AttributeValue[], options?: unmarshallOptions): Nativ
 const convertMap = (
   map: { [key: string]: AttributeValue },
   options?: unmarshallOptions
-): { [key: string]: NativeAttributeValue } =>
+): Map<string, NativeAttributeValue> =>
   Object.entries(map).reduce(
-    (acc: { [key: string]: NativeAttributeValue }, [key, value]: [string, AttributeValue]) => ({
-      ...acc,
-      [key]: convertToNative(value, options),
-    }),
-    {}
+    (acc: Map<string, NativeAttributeValue>, [key, value]: [string, AttributeValue]) =>
+      acc.set(key, convertToNative(value, options)),
+    new Map<string, NativeAttributeValue>()
   );


### PR DESCRIPTION
### Issue
No issue created for it

### Description
In the DynamoDB document client, by means of https://github.com/aws/aws-sdk-js-v3/pull/2010, the marshalling of JavaScript Maps was implemented.

However, the opposite direction does not return a `Map` and therefore, from the API perspective, it is cumbersome to work with, as it is no symmetrical. 

DISCLAIMER: I am relatively new to TypeScript, so some sloppiness ahead of you.

Example (semi-pseudo) code:

```
const dynamoDBClient = new DynamoDBClient({ region: appConfig.awsRegion });
const documentClient = DynamoDBDocumentClient.from(dynamoDBClient, {
  marshallOptions: {
    removeUndefinedValues: true,
  },
});

interface Person {
  pk: string;
  properties: Map<string, any>;
}

const person: Person = {
  pk: '1',
  properties: new Map<string, any>(
    [
      ['age': 42],
      ['name': 'Arthur Dent'],
    ]),
};

console.log(person.properties); // Map(2) { 'age' => 41, 'name' => 'Arthur Dent' }

const command = new PutCommand({
  TableName: 'persons',
  Item: person,
});

// This leads to a nested property that has the type 'M'. So far, so good.
await documentClient.send(command);

// This seems to be the point where the type is different after we have read
// it from DynamoDB again. 
const retrievalCommand = {} // Some command that retrieves the person
const retrievedPerson = await documentClient.send(command);

console.log(retrievedPerson.properties); // { age: 41, name: 'Arthur Dent' }
```

### Testing
I have amended the unit tests as they were to ensure that they return a `Map` when needed. I also added a test case where a `Map` is nested inside another `Map`, which appeared to be missing.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
