### PR TITLE
fix(s3-request-presigner): remove x-amz-user-agent header

### DIFF
--- a/packages/s3-request-presigner/src/getSignedUrl.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.ts
@@ -24,6 +24,8 @@ export const getSignedUrl = async <
       // Retry information headers are not meaningful in presigned URLs
       delete request.headers["amz-sdk-invocation-id"];
       delete request.headers["amz-sdk-request"];
+      // User agent header would leak sensitive information
+      delete request.headers["x-amz-user-agent"];
 
       const presigned = await s3Presigner.presign(request, {
         ...options,


### PR DESCRIPTION
### Issue
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2383

### Description
Remove `x-amz-user-agent` header when presign the request.

### Testing
Unit test & manual test with S3 GET and PUT request

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
