### PR TITLE
fix(smithy-client): use uppercase for percent encodings

### DIFF
--- a/packages/smithy-client/src/extended-encode-uri-component.spec.ts
+++ b/packages/smithy-client/src/extended-encode-uri-component.spec.ts
@@ -1,0 +1,20 @@
+import { extendedEncodeURIComponent } from "./extended-encode-uri-component";
+
+describe(extendedEncodeURIComponent.name, () => {
+  const encodedValues: [string, string][] = [
+    ["!", "%21"],
+    ["'", "%27"],
+    ["(", "%28"],
+    [")", "%29"],
+    ["*", "%2A"],
+  ];
+
+  const verify = (table: [string, string][]) => {
+    it.each(table)(`encodes %s as %s`, (input, output) => {
+      expect(extendedEncodeURIComponent(input)).toStrictEqual(output);
+    });
+  };
+
+  verify(encodedValues);
+  verify([encodedValues.reduce((acc, [input, output]) => [acc[0].concat(input), acc[1].concat(output)], ["", ""])]);
+});

--- a/packages/smithy-client/src/extended-encode-uri-component.ts
+++ b/packages/smithy-client/src/extended-encode-uri-component.ts
@@ -4,6 +4,6 @@
  */
 export function extendedEncodeURIComponent(str: string): string {
   return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
-    return "%" + c.charCodeAt(0).toString(16);
+    return "%" + c.charCodeAt(0).toString(16).toUpperCase();
   });
 }


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2499#issuecomment-864117029

### Description
Use uppercase for percent encodings

As per [rfc3986 section 2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1), it should be `"%2A"`

> The uppercase hexadecimal digits 'A' through 'F' are equivalent to
   the lowercase digits 'a' through 'f', respectively.  If two URIs
   differ only in the case of hexadecimal digits used in percent-encoded
   octets, they are equivalent.  For consistency, URI producers and
   normalizers should use uppercase hexadecimal digits for all percent-
   encodings.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
