### PR TITLE
chore: support programmatically generating and skipping protocol tests

### DIFF
--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -16,7 +16,7 @@
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
 plugins {
-    id("software.amazon.smithy") version "0.5.2"
+    id("software.amazon.smithy") version "0.5.3"
 }
 
 dependencies {

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -17,7 +17,7 @@ import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
 plugins {
-    id("software.amazon.smithy") version "0.5.2"
+    id("software.amazon.smithy") version "0.5.3"
 }
 
 dependencies {

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -22,5 +22,6 @@ dependencies {
     api("software.amazon.smithy:smithy-aws-traits:[1.8.0, 1.9.0[")
     api("software.amazon.smithy:smithy-waiters:[1.8.0, 1.9.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.8.0, 1.9.0[")
+    api("software.amazon.smithy:smithy-protocol-test-traits:[1.8.0, 1.9.0[")
     api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.3.0")
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -167,4 +167,9 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
         writer.write("contents = $L;",
                 outputStructure.accept(new XmlMemberDeserVisitor(context, "data", Format.DATE_TIME)));
     }
+
+    @Override
+    public void generateProtocolTests(GenerationContext context) {
+        AwsProtocolUtils.generateProtocolTests(this, context);
+    }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -33,8 +33,10 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.model.traits.XmlNamespaceTrait;
+import software.amazon.smithy.typescript.codegen.HttpProtocolTestGenerator;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -273,5 +275,9 @@ final class AwsProtocolUtils {
         HttpBindingIndex httpIndex = HttpBindingIndex.of(context.getModel());
         TimestampFormatTrait.Format format = httpIndex.determineTimestampFormat(memberShape, DOCUMENT, defaultFormat);
         return HttpProtocolGeneratorUtils.getTimestampInputParam(context, inputLocation, memberShape, format);
+    }
+
+    static void generateProtocolTests(ProtocolGenerator generator, GenerationContext context) {
+        new HttpProtocolTestGenerator(context, generator).run();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -33,7 +33,9 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.model.traits.XmlNamespaceTrait;
+import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase;
 import software.amazon.smithy.typescript.codegen.HttpProtocolTestGenerator;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
@@ -278,6 +280,19 @@ final class AwsProtocolUtils {
     }
 
     static void generateProtocolTests(ProtocolGenerator generator, GenerationContext context) {
-        new HttpProtocolTestGenerator(context, generator).run();
+        new HttpProtocolTestGenerator(context, generator, AwsProtocolUtils::filterProtocolTests).run();
+    }
+
+    private static boolean filterProtocolTests(
+            ServiceShape service,
+            OperationShape operation,
+            HttpMessageTestCase testCase,
+            TypeScriptSettings settings
+    ) {
+        // TODO: Consume AWSQueryError trait as a follow-up.
+        if (testCase.getId().equals("QueryCustomizedError")) {
+            return true;
+        }
+        return false;
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -168,4 +168,9 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
         writer.write("contents = $L;",
                 outputStructure.accept(new XmlMemberDeserVisitor(context, dataSource, Format.DATE_TIME)));
     }
+
+    @Override
+    public void generateProtocolTests(GenerationContext context) {
+        AwsProtocolUtils.generateProtocolTests(this, context);
+    }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -350,4 +350,9 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             });
         }
     }
+
+    @Override
+    public void generateProtocolTests(GenerationContext context) {
+        AwsProtocolUtils.generateProtocolTests(this, context);
+    }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -141,4 +141,9 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
         return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
     }
+
+    @Override
+    public void generateProtocolTests(GenerationContext context) {
+        AwsProtocolUtils.generateProtocolTests(this, context);
+    }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -341,4 +341,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
         return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
     }
+
+    @Override
+    public void generateProtocolTests(GenerationContext context) {
+        AwsProtocolUtils.generateProtocolTests(this, context);
+    }
 }

--- a/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
+++ b/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
@@ -548,8 +548,6 @@ it("QueryInvalidGreetingError:Error:GreetingWithErrors", async () => {
 /**
  * Parses customized XML errors
  */
-// Manually skipping to unblock smithy-1.8.x update.
-// TODO: Consume AWSQueryError trait as a follow-up.
 it.skip("QueryCustomizedError:Error:GreetingWithErrors", async () => {
   const client = new QueryProtocolClient({
     ...clientParams,


### PR DESCRIPTION
### Issue

n/a

### Description

This updates the protocol support to use the new `generateProtocolTests` interface method. This allows making use of the `skip` functionality in https://github.com/awslabs/smithy-typescript/pull/360 to temporarily skip known test failures.

### Testing

Clients were regenerated, see the final commit for the diff

### Additional context

https://github.com/awslabs/smithy-typescript/pull/360

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
