### PR TITLE
feat(lib): change higher level libs use peer deps on clients

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -30,6 +30,10 @@
     "@aws-sdk/util-dynamodb": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "3.18.0",
+    "@aws-sdk/smithy-client": "3.18.0",
+    "@aws-sdk/types": "3.18.0",
+    "@aws-sdk/util-dynamodb": "3.18.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^14.11.2",
     "jest": "^26.4.2",

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -21,11 +21,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "3.18.0",
-    "@aws-sdk/smithy-client": "3.18.0",
-    "@aws-sdk/types": "3.18.0",
-    "@aws-sdk/util-dynamodb": "3.18.0",
     "tslib": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/smithy-client": "^3.0.0",
+    "@aws-sdk/types": "^3.0.0",
+    "@aws-sdk/util-dynamodb": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -30,6 +30,8 @@
     "@aws-sdk/client-s3": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/abort-controller": "3.18.0",
+    "@aws-sdk/client-s3": "3.18.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^14.11.2",
     "jasmine-core": "^3.6.0",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -21,11 +21,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/abort-controller": "3.18.0",
-    "@aws-sdk/client-s3": "3.18.0",
     "buffer": "^5.6.0",
     "stream-browserify": "^3.0.0",
     "tslib": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/abort-controller": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
- Going forward: All higher order libs that allow users to "bring their own client" should declare that client as a peer dep.

Changes lib/storage and lib/dynamodb to use peer dependencies instead of pinned dependencies over their clients.

This fixes a bunch of type errors where the libs would expect the latest types without actually needing them. This caused customer pain when attempting to use packages modularly because the version of the lib would always have to be the same version as the client passed into the lib. 

CC: @AllanZhengYP and I worked on this yesterday. This probably solves several issues in the backlog too.

### Testing
How was this change tested?
- Published to local verdaccio. Verified that the libs are using the version of s3 that I supplied and not the latest. No type errors.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
