### PR TITLE
chore(clients): call EndpointDiscoveryPlugin with isDiscoveredEndpointRequired

### DIFF
--- a/clients/client-timestream-query/commands/CancelQueryCommand.ts
+++ b/clients/client-timestream-query/commands/CancelQueryCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0CancelQueryCommand,
   serializeAws_json1_0CancelQueryCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -65,7 +65,9 @@ export class CancelQueryCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CancelQueryCommandInput, CancelQueryCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-query/commands/QueryCommand.ts
+++ b/clients/client-timestream-query/commands/QueryCommand.ts
@@ -1,7 +1,7 @@
 import { ServiceInputTypes, ServiceOutputTypes, TimestreamQueryClientResolvedConfig } from "../TimestreamQueryClient";
 import { QueryRequest, QueryResponse } from "../models/models_0";
 import { deserializeAws_json1_0QueryCommand, serializeAws_json1_0QueryCommand } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -56,7 +56,9 @@ export class QueryCommand extends $Command<QueryCommandInput, QueryCommandOutput
     options?: __HttpHandlerOptions
   ): Handler<QueryCommandInput, QueryCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/CreateDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/CreateDatabaseCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0CreateDatabaseCommand,
   serializeAws_json1_0CreateDatabaseCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -64,7 +64,9 @@ export class CreateDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateDatabaseCommandInput, CreateDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/CreateTableCommand.ts
+++ b/clients/client-timestream-write/commands/CreateTableCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0CreateTableCommand,
   serializeAws_json1_0CreateTableCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -68,7 +68,9 @@ export class CreateTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateTableCommandInput, CreateTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DeleteDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/DeleteDatabaseCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0DeleteDatabaseCommand,
   serializeAws_json1_0DeleteDatabaseCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -69,7 +69,9 @@ export class DeleteDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteDatabaseCommandInput, DeleteDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DeleteTableCommand.ts
+++ b/clients/client-timestream-write/commands/DeleteTableCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0DeleteTableCommand,
   serializeAws_json1_0DeleteTableCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -66,7 +66,9 @@ export class DeleteTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteTableCommandInput, DeleteTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DescribeDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/DescribeDatabaseCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0DescribeDatabaseCommand,
   serializeAws_json1_0DescribeDatabaseCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -63,7 +63,9 @@ export class DescribeDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeDatabaseCommandInput, DescribeDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/DescribeTableCommand.ts
+++ b/clients/client-timestream-write/commands/DescribeTableCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0DescribeTableCommand,
   serializeAws_json1_0DescribeTableCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -64,7 +64,9 @@ export class DescribeTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeTableCommandInput, DescribeTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/ListDatabasesCommand.ts
+++ b/clients/client-timestream-write/commands/ListDatabasesCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0ListDatabasesCommand,
   serializeAws_json1_0ListDatabasesCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -63,7 +63,9 @@ export class ListDatabasesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListDatabasesCommandInput, ListDatabasesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/ListTablesCommand.ts
+++ b/clients/client-timestream-write/commands/ListTablesCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0ListTablesCommand,
   serializeAws_json1_0ListTablesCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -62,7 +62,9 @@ export class ListTablesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListTablesCommandInput, ListTablesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/ListTagsForResourceCommand.ts
+++ b/clients/client-timestream-write/commands/ListTagsForResourceCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0ListTagsForResourceCommand,
   serializeAws_json1_0ListTagsForResourceCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -63,7 +63,9 @@ export class ListTagsForResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListTagsForResourceCommandInput, ListTagsForResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/TagResourceCommand.ts
+++ b/clients/client-timestream-write/commands/TagResourceCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0TagResourceCommand,
   serializeAws_json1_0TagResourceCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -65,7 +65,9 @@ export class TagResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<TagResourceCommandInput, TagResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/UntagResourceCommand.ts
+++ b/clients/client-timestream-write/commands/UntagResourceCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0UntagResourceCommand,
   serializeAws_json1_0UntagResourceCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -63,7 +63,9 @@ export class UntagResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UntagResourceCommandInput, UntagResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/UpdateDatabaseCommand.ts
+++ b/clients/client-timestream-write/commands/UpdateDatabaseCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0UpdateDatabaseCommand,
   serializeAws_json1_0UpdateDatabaseCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -65,7 +65,9 @@ export class UpdateDatabaseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateDatabaseCommandInput, UpdateDatabaseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/UpdateTableCommand.ts
+++ b/clients/client-timestream-write/commands/UpdateTableCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0UpdateTableCommand,
   serializeAws_json1_0UpdateTableCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -67,7 +67,9 @@ export class UpdateTableCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateTableCommandInput, UpdateTableCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-timestream-write/commands/WriteRecordsCommand.ts
+++ b/clients/client-timestream-write/commands/WriteRecordsCommand.ts
@@ -4,7 +4,7 @@ import {
   deserializeAws_json1_0WriteRecordsCommand,
   serializeAws_json1_0WriteRecordsCommand,
 } from "../protocols/Aws_json1_0";
-import { getEndpointDiscoveryRequiredPlugin } from "@aws-sdk/middleware-endpoint-discovery";
+import { getEndpointDiscoveryPlugin } from "@aws-sdk/middleware-endpoint-discovery";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -74,7 +74,9 @@ export class WriteRecordsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<WriteRecordsCommandInput, WriteRecordsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getEndpointDiscoveryRequiredPlugin(configuration, { clientStack, options }));
+    this.middlewareStack.use(
+      getEndpointDiscoveryPlugin(configuration, { clientStack, options, isDiscoveredEndpointRequired: true })
+    );
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -75,25 +75,16 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                         }})
                         .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
                         .build(),
-                // ToDo: The value ClientDiscoveredEndpointTrait.isRequired() needs to be passed to Plugin instead
-                // of creating two functions Required and Optional. The map of identifiers also needs to be passed.
+                // ToDo: Pass the map of identifiers to the EndpointDiscovery plugin.
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
-                                "EndpointDiscoveryRequired", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
+                                "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
                         .additionalPluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
                             put("clientStack", Symbol.builder().name("clientStack").build());
                             put("options", Symbol.builder().name("options").build());
+                            put("isDiscoveredEndpointRequired", isClientDiscoveredEndpointRequired(s, o));
                         }})
                         .operationPredicate((m, s, o) -> isClientDiscoveredEndpointRequired(s, o))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
-                                "EndpointDiscoveryOptional", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .additionalPluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
-                            put("clientStack", Symbol.builder().name("clientStack").build());
-                            put("options", Symbol.builder().name("options").build());
-                        }})
-                        .operationPredicate((m, s, o) -> isClientDiscoveredEndpointOptional(s, o))
                         .build()
         );
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -84,8 +84,9 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                             put("options", Symbol.builder().name("options").build());
                             put("isDiscoveredEndpointRequired", isClientDiscoveredEndpointRequired(s, o));
                         }})
-                        .operationPredicate((m, s, o) -> isClientDiscoveredEndpointRequired(s, o))
-                        .build()
+                        .operationPredicate((m, s, o) ->
+                            isClientDiscoveredEndpointRequired(s, o) || isClientDiscoveredEndpointOptional(s, o)
+                        ).build()
         );
     }
 

--- a/packages/middleware-endpoint-discovery/src/getEndpointDiscoveryPlugin.ts
+++ b/packages/middleware-endpoint-discovery/src/getEndpointDiscoveryPlugin.ts
@@ -26,6 +26,9 @@ export const getEndpointDiscoveryPlugin = (
   },
 });
 
+/**
+ * @deprecated Use getEndpointDiscoveryPlugin
+ */
 export const getEndpointDiscoveryRequiredPlugin = (
   pluginConfig: EndpointDiscoveryResolvedConfig & PreviouslyResolved,
   middlewareConfig: Omit<EndpointDiscoveryMiddlewareConfig, "isDiscoveredEndpointRequired">
@@ -38,6 +41,9 @@ export const getEndpointDiscoveryRequiredPlugin = (
   },
 });
 
+/**
+ * @deprecated Use getEndpointDiscoveryPlugin
+ */
 export const getEndpointDiscoveryOptionalPlugin = (
   pluginConfig: EndpointDiscoveryResolvedConfig & PreviouslyResolved,
   middlewareConfig: Omit<EndpointDiscoveryMiddlewareConfig, "isDiscoveredEndpointRequired">


### PR DESCRIPTION
### Issue
Internal JS-2654

### Description
Calls EndpointDiscoveryPlugin from client, and passes boolean value `isDiscoveredEndpointRequired` to it.

### Testing
Tested with the following code:

```js
import { TimestreamQuery } from "../aws-sdk-js-v3/clients/client-timestream-query/dist/cjs/index.js";

const region = "us-west-2";
const client = new TimestreamQuery({ region, logger: console });

const DatabaseName = `Database1619998684282`;
const TableName = `Table1619998684282`;
const QueryString = `SELECT * FROM ${DatabaseName}.${TableName} ORDER BY time LIMIT 2`;

await client.query({ QueryString });
```

Output: DescribeEndpointsCommand is called before QueryCommand
```console
{{
  clientName: 'TimestreamQueryClient',
  commandName: 'DescribeEndpointsCommand',
  input: { Operation: 'Query', Identifiers: undefined },
  output: { Endpoints: [ [Object] ] },
  metadata: {
    httpStatusCode: 200,
    requestId: 'ff91df7b-6b79-4e25-9206-c9b8d6269bd9',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
{
  clientName: 'TimestreamQueryClient',
  commandName: 'QueryCommand',
  input: { QueryString: '***SensitiveInformation***' },
  output: {
    ColumnInfo: [ [Object], [Object], [Object], [Object], [Object], [Object] ],
    NextToken: undefined,
    QueryId: 'AEDACAM5FLUWJPIG3OVRSI3UQJ3ZQHV3AOE2NSCUKHFPBQX7LAX5GFJESJMRSEI',
    QueryStatus: {
      CumulativeBytesMetered: 10000000,
      CumulativeBytesScanned: 0,
      ProgressPercentage: 100
    },
    Rows: []
  },
  metadata: {
    httpStatusCode: 200,
    requestId: 'JBIN54AZECC7QFWXWGEB22KLGY',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
```

### Additional context
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2521
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2470

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
