### PR TITLE
chore(clients): convert second argument of resolve to options

### DIFF
--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -454,7 +454,9 @@ export class DynamoDBClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, DescribeEndpointsCommand);
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, {
+      endpointDiscoveryCommandCtor: DescribeEndpointsCommand,
+    });
     super(_config_7);
     this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -244,7 +244,7 @@ export class STSClient extends __Client<
     let _config_2 = resolveEndpointsConfig(_config_1);
     let _config_3 = resolveRetryConfig(_config_2);
     let _config_4 = resolveHostHeaderConfig(_config_3);
-    let _config_5 = resolveStsAuthConfig(_config_4, STSClient);
+    let _config_5 = resolveStsAuthConfig(_config_4, { stsClientCtor: STSClient });
     let _config_6 = resolveUserAgentConfig(_config_5);
     super(_config_6);
     this.config = _config_6;

--- a/clients/client-timestream-query/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/TimestreamQueryClient.ts
@@ -240,7 +240,9 @@ export class TimestreamQueryClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, DescribeEndpointsCommand);
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, {
+      endpointDiscoveryCommandCtor: DescribeEndpointsCommand,
+    });
     super(_config_7);
     this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/clients/client-timestream-write/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/TimestreamWriteClient.ts
@@ -283,7 +283,9 @@ export class TimestreamWriteClient extends __Client<
     let _config_4 = resolveHostHeaderConfig(_config_3);
     let _config_5 = resolveAwsAuthConfig(_config_4);
     let _config_6 = resolveUserAgentConfig(_config_5);
-    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, DescribeEndpointsCommand);
+    let _config_7 = resolveEndpointDiscoveryConfig(_config_6, {
+      endpointDiscoveryCommandCtor: DescribeEndpointsCommand,
+    });
     super(_config_7);
     this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -107,7 +107,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
                     .withConventions(AwsDependency.STS_MIDDLEWARE.dependency,
                             "StsAuth", HAS_CONFIG)
                     .additionalResolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
-                        put("STSClient", Symbol.builder().name("STSClient").build());
+                        put("stsClientCtor", Symbol.builder().name("STSClient").build());
                     }})
                     .servicePredicate((m, s) -> testServiceId(s, "STS"))
                     .build(),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -71,7 +71,8 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                                 "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
                         // ToDo: The Endpoint Discovery Command Name needs to be read from ClientEndpointDiscoveryTrait.
                         .additionalResolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
-                            put("DescribeEndpointsCommand", Symbol.builder().name("DescribeEndpointsCommand").build());
+                            put("endpointDiscoveryCommandCtor",
+                                    Symbol.builder().name("DescribeEndpointsCommand").build());
                         }})
                         .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
                         .build(),

--- a/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.spec.ts
+++ b/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.spec.ts
@@ -17,7 +17,7 @@ describe(resolveEndpointDiscoveryConfig.name, () => {
   });
 
   it("assigns endpointDiscoveryCommandCtor in resolvedConfig", () => {
-    const resolvedConfig = resolveEndpointDiscoveryConfig(mockInput, endpointDiscoveryCommandCtor);
+    const resolvedConfig = resolveEndpointDiscoveryConfig(mockInput, { endpointDiscoveryCommandCtor });
     expect(resolvedConfig.endpointDiscoveryCommandCtor).toStrictEqual(endpointDiscoveryCommandCtor);
   });
 
@@ -29,13 +29,13 @@ describe(resolveEndpointDiscoveryConfig.name, () => {
           ...mockInput,
           endpointCacheSize,
         },
-        endpointDiscoveryCommandCtor
+        { endpointDiscoveryCommandCtor }
       );
       expect(EndpointCache).toBeCalledWith(endpointCacheSize);
     });
 
     it("creates cache of size 1000 if endpointCacheSize not passed", () => {
-      resolveEndpointDiscoveryConfig(mockInput, endpointDiscoveryCommandCtor);
+      resolveEndpointDiscoveryConfig(mockInput, { endpointDiscoveryCommandCtor });
       expect(EndpointCache).toBeCalledWith(1000);
     });
   });
@@ -47,7 +47,7 @@ describe(resolveEndpointDiscoveryConfig.name, () => {
           ...mockInput,
           endpointDiscoveryEnabled,
         },
-        endpointDiscoveryCommandCtor
+        { endpointDiscoveryCommandCtor }
       );
       expect(resolvedConfig.endpointDiscoveryEnabled()).resolves.toBe(endpointDiscoveryEnabled);
       expect(mockInput.endpointDiscoveryEnabledProvider).not.toHaveBeenCalled();
@@ -55,7 +55,7 @@ describe(resolveEndpointDiscoveryConfig.name, () => {
     });
 
     it(`sets to endpointDiscoveryEnabledProvider if value is not passed`, () => {
-      const resolvedConfig = resolveEndpointDiscoveryConfig(mockInput, endpointDiscoveryCommandCtor);
+      const resolvedConfig = resolveEndpointDiscoveryConfig(mockInput, { endpointDiscoveryCommandCtor });
       expect(resolvedConfig.endpointDiscoveryEnabled).toBe(mockInput.endpointDiscoveryEnabledProvider);
       expect(resolvedConfig.isClientEndpointDiscoveryEnabled).toStrictEqual(false);
     });

--- a/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
+++ b/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
@@ -60,10 +60,10 @@ export interface EndpointDiscoveryConfigOptions {
 
 export const resolveEndpointDiscoveryConfig = <T>(
   input: T & PreviouslyResolved & EndpointDiscoveryInputConfig,
-  options: EndpointDiscoveryConfigOptions
+  { endpointDiscoveryCommandCtor }: EndpointDiscoveryConfigOptions
 ): T & EndpointDiscoveryResolvedConfig => ({
   ...input,
-  endpointDiscoveryCommandCtor: options.endpointDiscoveryCommandCtor,
+  endpointDiscoveryCommandCtor,
   endpointCache: new EndpointCache(input.endpointCacheSize ?? 1000),
   endpointDiscoveryEnabled:
     input.endpointDiscoveryEnabled !== undefined

--- a/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
+++ b/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
@@ -51,12 +51,19 @@ export interface EndpointDiscoveryResolvedConfig {
   isClientEndpointDiscoveryEnabled: boolean;
 }
 
+export interface EndpointDiscoveryConfigOptions {
+  /**
+   * The constructor of the Command used for discovering endpoints.
+   */
+  endpointDiscoveryCommandCtor: new (comandConfig: any) => any;
+}
+
 export const resolveEndpointDiscoveryConfig = <T>(
   input: T & PreviouslyResolved & EndpointDiscoveryInputConfig,
-  endpointDiscoveryCommandCtor: new (comandConfig: any) => any
+  options: EndpointDiscoveryConfigOptions
 ): T & EndpointDiscoveryResolvedConfig => ({
   ...input,
-  endpointDiscoveryCommandCtor,
+  endpointDiscoveryCommandCtor: options.endpointDiscoveryCommandCtor,
   endpointCache: new EndpointCache(input.endpointCacheSize ?? 1000),
   endpointDiscoveryEnabled:
     input.endpointDiscoveryEnabled !== undefined

--- a/packages/middleware-sdk-sts/src/index.ts
+++ b/packages/middleware-sdk-sts/src/index.ts
@@ -18,6 +18,13 @@ export interface StsAuthResolvedConfig extends AwsAuthResolvedConfig {
   stsClientCtor: new (clientConfig: any) => Client<any, any, any>;
 }
 
+export interface StsAuthConfigOptions {
+  /**
+   * Reference to STSClient class constructor.
+   */
+  stsClientCtor: new (clientConfig: any) => Client<any, any, any>;
+}
+
 /**
  * Set STS client constructor to `stsClientCtor` config parameter. It is used
  * for role assumers for STS client internally. See `clients/client-sts/defaultStsRoleAssumers.ts`
@@ -25,10 +32,9 @@ export interface StsAuthResolvedConfig extends AwsAuthResolvedConfig {
  */
 export const resolveStsAuthConfig = <T>(
   input: T & PreviouslyResolved & StsAuthInputConfig,
-  stsClientCtor: new (clientConfig: any) => Client<any, any, any>
-): T & StsAuthResolvedConfig => {
-  return resolveAwsAuthConfig({
+  { stsClientCtor }: StsAuthConfigOptions
+): T & StsAuthResolvedConfig =>
+  resolveAwsAuthConfig({
     ...input,
     stsClientCtor,
   });
-};


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/372

### Description
Convert second argument of resolve to options

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
