### PR TITLE
chore(codegen): read Endpoint Discovery Command from trait

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointDiscoveryPlugin.java
@@ -69,10 +69,9 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_ENDPOINT_DISCOVERY.dependency,
                                 "EndpointDiscovery", RuntimeClientPlugin.Convention.HAS_CONFIG)
-                        // ToDo: The Endpoint Discovery Command Name needs to be read from ClientEndpointDiscoveryTrait.
                         .additionalResolveFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
                             put("endpointDiscoveryCommandCtor",
-                                    Symbol.builder().name("DescribeEndpointsCommand").build());
+                                    Symbol.builder().name(getClientDiscoveryCommand(s)).build());
                         }})
                         .servicePredicate((m, s) -> hasClientEndpointDiscovery(s))
                         .build(),
@@ -160,5 +159,14 @@ public class AddEndpointDiscoveryPlugin implements TypeScriptIntegration  {
             return !operation.getTrait(ClientDiscoveredEndpointTrait.class).orElse(null).isRequired();
         }
         return false;
+    }
+
+    private static String getClientDiscoveryCommand(ServiceShape service) {
+        if (!hasClientEndpointDiscovery(service)) {
+            throw new CodegenException(
+                "EndpointDiscovery command discovery attempt for service without endpoint discovery"
+            );
+        }
+        return service.getTrait(ClientEndpointDiscoveryTrait.class).orElse(null).getOperation().getName() + "Command";
     }
 }


### PR DESCRIPTION
### Issue
* Refs: https://github.com/awslabs/smithy-typescript/pull/353
* Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2395

### Description
While introducing Endpoint Discovery support, we had hardcoded the Endpoint Discovery Command.
This code change replaces it with Command name described in ClientDiscoveredEndpointTrait. 

### Testing
Verified that `yarn generate-clients` did not override the clients.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
