### PR TITLE
chore(smithy-client): remove in-line import in types

### DIFF
--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -1,5 +1,5 @@
 import { constructStack } from "@aws-sdk/middleware-stack";
-import { Client as IClient, Command, MetadataBearer, RequestHandler } from "@aws-sdk/types";
+import { Client as IClient, Command, MetadataBearer, MiddlewareStack, RequestHandler } from "@aws-sdk/types";
 
 export interface SmithyConfiguration<HandlerOptions> {
   requestHandler: RequestHandler<any, any, HandlerOptions>;
@@ -20,7 +20,7 @@ export class Client<
   ResolvedClientConfiguration extends SmithyResolvedConfiguration<HandlerOptions>
 > implements IClient<ClientInput, ClientOutput, ResolvedClientConfiguration>
 {
-  public middlewareStack = constructStack<ClientInput, ClientOutput>();
+  public middlewareStack: MiddlewareStack<ClientInput, ClientOutput> = constructStack<ClientInput, ClientOutput>();
   readonly config: ResolvedClientConfiguration;
   constructor(config: ResolvedClientConfiguration) {
     this.config = config;


### PR DESCRIPTION
### Description
Currently the built `.d.ts` to the smithy client looks like
```typescript
export declare class Client<HandlerOptions, ClientInput extends object, ClientOutput extends MetadataBearer, ResolvedClientConfiguration extends SmithyResolvedConfiguration<HandlerOptions>> implements IClient<ClientInput, ClientOutput, ResolvedClientConfiguration> {
    middlewareStack: import("@aws-sdk/types").MiddlewareStack<ClientInput, ClientOutput>; // <== incorrect!
```

This annoys the API-Extractor.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
