### PR TITLE
test(codegen): add unit tests for recent changes to integrations

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPluginTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPluginTest.java
@@ -1,0 +1,131 @@
+package software.amazon.smithy.aws.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
+
+public class AddAwsAuthPluginTest {
+    @Test
+    public void awsClient() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("NotSame.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#OriginalName"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check dependencies
+        assertThat(manifest.getFileString("package.json").get(),
+                containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
+
+        // Check config interface fields
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("credentialDefaultProvider?"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), not(containsString("signingName")));
+
+        // Check config files
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(),
+                containsString("credentialDefaultProvider: decorateDefaultCredentialProvider"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
+        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
+
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveAwsAuthConfig"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getAwsAuthPlugin"));
+    }
+
+    @Test
+    public void sigV4GenericClient() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check dependencies
+        assertThat(manifest.getFileString("package.json").get(),
+                containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
+
+        // Check config interface fields
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("credentialDefaultProvider?"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("signingName?"));
+
+        // Check config files
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(),
+                containsString("credentialDefaultProvider: decorateDefaultCredentialProvider"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
+        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), containsString("signingName:"));
+
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveSigV4AuthConfig"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getSigV4AuthPlugin"));
+    }
+
+    @Test
+    public void notSigV4GenericClient() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("SsdkExample.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#SsdkExample"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check dependencies
+        assertThat(manifest.getFileString("package.json").get(),
+                not(containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName)));
+
+        // Check config interface fields
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("credentialDefaultProvider?")));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("signingName?")));
+
+        // Check config files
+        assertThat(manifest.getFileString("runtimeConfig.ts").get(),
+                not(containsString("credentialDefaultProvider: decorateDefaultCredentialProvider")));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), not(containsString("Credential is missing")));
+        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
+
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("resolveSigV4AuthConfig")));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("resolveAwsV4AuthConfig")));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPluginsTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPluginsTest.java
@@ -1,0 +1,104 @@
+package software.amazon.smithy.aws.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
+
+public class AddBuiltinPluginsTest {
+    @Test
+    public void awsClient() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("NotSame.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#OriginalName"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveRegionConfig"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveEndpointsConfig"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveRetryConfig"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getRetryPlugin"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getContentLengthPlugin"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getHostHeaderPlugin"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getLoggerPlugin"));
+    }
+
+    @Test
+    public void sigV4GenericClient() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveRegionConfig"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveCustomEndpointsConfig"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveRetryConfig"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getRetryPlugin"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getContentLengthPlugin"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getHostHeaderPlugin"));
+        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getLoggerPlugin"));
+    }
+
+    @Test
+    public void notSigV4GenericClient() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("SsdkExample.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#SsdkExample"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+        new TypeScriptCodegenPlugin().execute(context);
+
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("resolveRegionConfig")));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("resolveCustomEndpointsConfig"));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("resolveRetryConfig"));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getRetryPlugin"));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getContentLengthPlugin"));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getHostHeaderPlugin"));
+        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getLoggerPlugin"));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
@@ -13,7 +13,7 @@ import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
 public class AddUserAgentDependencyTest {
     @Test
-    public void addsUserAgentForAwsService() {
+    public void awsClient() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("NotSame.smithy"))
                 .discoverModels()
@@ -32,11 +32,14 @@ public class AddUserAgentDependencyTest {
                 .build();
         new TypeScriptCodegenPlugin().execute(context);
 
-        // Check that one of the many dependencies was added.
+        // Check dependencies
         assertThat(manifest.getFileString("package.json").get(),
                    containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
 
-        // Check that both the config files were updated.
+        // Check config interface fields
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("defaultUserAgentProvider?"));
+
+        // Check config files
         assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("defaultUserAgent"));
         assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("packageInfo.version"));
         assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("ClientSharedValues.serviceId"));
@@ -45,12 +48,13 @@ public class AddUserAgentDependencyTest {
         assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
         assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("ClientSharedValues.serviceId"));
 
-        // Check that the dependency interface was updated.
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("defaultUserAgentProvider?"));
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveUserAgentConfig"));
+        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getUserAgentPlugin"));
     }
 
     @Test
-    public void addsUserAgentForNonAwsService() {
+    public void genericClient() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("NonAwsService.smithy"))
                 .discoverModels()
@@ -69,11 +73,14 @@ public class AddUserAgentDependencyTest {
                 .build();
         new TypeScriptCodegenPlugin().execute(context);
 
-        // Check that one of the many dependencies was added.
+        // Check dependencies
         assertThat(manifest.getFileString("package.json").get(),
                 containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
 
-        // Check that both the config files were updated.
+        // Check config interface fields
+        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("defaultUserAgentProvider?"));
+
+        // Check config files
         assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("defaultUserAgent"));
         assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("packageInfo.version"));
         assertThat(manifest.getFileString("runtimeConfig.ts").get(), not(containsString("ClientSharedValues.serviceId")));
@@ -82,7 +89,8 @@ public class AddUserAgentDependencyTest {
         assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
         assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), not(containsString("ClientSharedValues.serviceId")));
 
-        // Check that the dependency interface was updated.
-        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("defaultUserAgentProvider?"));
+        // Check the config resolution and middleware plugin
+        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("resolveUserAgentConfig"));
+        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("getUserAgentPlugin"));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/SsdkExample.smithy
+++ b/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/SsdkExample.smithy
@@ -1,0 +1,22 @@
+namespace smithy.example
+
+use aws.protocols#restJson1
+
+@restJson1
+service SsdkExample {
+    version: "2019-10-15",
+    operations: [GetFoo]
+}
+
+@http(method: "GET", uri:"/foo")
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
+structure GetFooInput {}
+structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}

--- a/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/SsdkExampleSigV4.smithy
+++ b/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/SsdkExampleSigV4.smithy
@@ -1,0 +1,23 @@
+namespace smithy.example
+
+use aws.protocols#restJson1
+
+@restJson1
+@aws.auth#sigv4(name: "ssdk-example")
+service SsdkExampleSigV4 {
+    version: "2019-10-15",
+    operations: [GetFoo]
+}
+
+@http(method: "GET", uri:"/foo")
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
+structure GetFooInput {}
+structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}


### PR DESCRIPTION
### Description
I had touched test TypescriptIntegrations for adding support for
generic non-AWS clients. Adding unit tests for them.

### Testing
`gradle build`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
