### PR TITLE
chore: generate client name according to sdkId

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -13,8 +13,18 @@
  * permissions and limitations under the License.
  */
 
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.gradle.tasks.SmithyBuild
+import software.amazon.smithy.aws.traits.ServiceTrait
+import kotlin.streams.toList
+
+buildscript {
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-aws-traits:[1.5.1,2.0.0[")
+    }
+}
 
 plugins {
     id("software.amazon.smithy") version "0.5.3"
@@ -44,8 +54,27 @@ tasks.register("generate-smithy-build") {
         val modelsDirProp: String by project
         val models = project.file(modelsDirProp);
 
-        fileTree(models).filter { it.isFile }.files.forEach { file ->
-            val (sdkId, version, remaining) = file.name.split(".")
+        fileTree(models).filter { it.isFile }.files.forEach eachFile@{ file ->
+            val model = Model.assembler()
+                    .addImport(file.absolutePath)
+                    // Grab the result directly rather than worrying about checking for errors via unwrap.
+                    // All we care about here is the service shape, any unchecked errors will be exposed
+                    // as part of the actual build task done by the smithy gradle plugin.
+                    .assemble().result.get();
+            val services = model.shapes(ServiceShape::class.javaObjectType).sorted().toList();
+            if (services.size != 1) {
+                throw Exception("There must be exactly one service in each aws model file, but found " +
+                        "${services.size} in ${file.name}: ${services.map { it.id }}");
+            }
+            val service = services[0]
+
+            val serviceTrait = service.getTrait(ServiceTrait::class.javaObjectType).get();
+
+            val sdkId = serviceTrait.sdkId
+                    .replace(" ", "-")
+                    .toLowerCase();
+            val version = service.version.toLowerCase();
+
             val clientName = sdkId.split("-").toTypedArray()
                     .map { it.capitalize() }
                     .joinToString(separator = " ")

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -57,9 +57,6 @@ tasks.register("generate-smithy-build") {
         fileTree(models).filter { it.isFile }.files.forEach eachFile@{ file ->
             val model = Model.assembler()
                     .addImport(file.absolutePath)
-                    // Grab the result directly rather than worrying about checking for errors via unwrap.
-                    // All we care about here is the service shape, any unchecked errors will be exposed
-                    // as part of the actual build task done by the smithy gradle plugin.
                     .assemble().result.get();
             val services = model.shapes(ServiceShape::class.javaObjectType).sorted().toList();
             if (services.size != 1) {
@@ -88,7 +85,7 @@ tasks.register("generate-smithy-build") {
                             .withMember("typescript-codegen", Node.objectNodeBuilder()
                                     .withMember("package", "@aws-sdk/client-" + sdkId.toLowerCase())
                                     // Note that this version is replaced by Lerna when publishing.
-                                    .withMember("packageVersion", "1.0.0-rc.1")
+                                    .withMember("packageVersion", "3.0.0")
                                     .withMember("packageJson", manifestOverwrites)
                                     .withMember("packageDescription", "AWS SDK for JavaScript "
                                         + clientName + " Client for Node.js, Browser and React Native")

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -14,7 +14,12 @@ const { prettifyCode } = require("./code-prettify");
 const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
 const PROTOCOL_TESTS_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "protocol_tests"));
 
-const { models, globs, output: clientsDir } = yargs
+const {
+  models,
+  globs,
+  output: clientsDir,
+  noProtocolTest,
+} = yargs
   .alias("m", "models")
   .string("m")
   .describe("m", "The path to directory with models.")
@@ -26,21 +31,24 @@ const { models, globs, output: clientsDir } = yargs
   .string("o")
   .describe("o", "The output directory for built clients")
   .default("o", SDK_CLIENTS_DIR)
+  .alias("n", "noProtocolTest")
+  .boolean("n")
+  .describe("n", "Disable generating protocol test files")
   .help().argv;
 
 (async () => {
   try {
     await generateClients(models || globs);
-    await generateProtocolTests();
+    if (!noProtocolTest) await generateProtocolTests();
 
     await prettifyCode(CODE_GEN_SDK_OUTPUT_DIR);
-    await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+    if (!noProtocolTest) await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
 
     await copyToClients(CODE_GEN_SDK_OUTPUT_DIR, clientsDir);
-    await copyToClients(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);
+    if (!noProtocolTest) await copyToClients(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);
 
     emptyDirSync(CODE_GEN_SDK_OUTPUT_DIR);
-    emptyDirSync(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+    if (!noProtocolTest) emptyDirSync(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
     emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
 
     rmdirSync(TEMP_CODE_GEN_INPUT_DIR);


### PR DESCRIPTION
### Issue
Right now all SDK clients are generated with name specified in `aws-models` folder. Even though model file names are generated from the model's `sdkId`, mistakenly renaming these model files could result in generating new clients. 

Instead clients shuold be generated irrelavant of the file name. This change generates the package name from the model directly. It has also been fixed in [Go v2 SDK](https://github.com/aws/aws-sdk-go-v2/blob/main/codegen/sdk-codegen/build.gradle.kts#L64-L86).

This change also:
* Add a `-n` option to `generate-clients` script to disable generating protocol tests. It eliminating protocol test clients generation when developer wants to generate a single model.
* New clients are now generated with version `3.0.0`, previously it was `1.0.0-rc.1`

### Description
What does this implement/fix? Explain your changes.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
