### PR TITLE
fix: replace prepublishOnly script with downlevel-dts

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -14,7 +14,8 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -13,7 +13,8 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -13,7 +13,8 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -13,7 +13,8 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -14,7 +14,8 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -15,7 +15,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "postbuild": "cp test/speech.wav dist/cjs/test"
+    "postbuild": "cp test/speech.wav dist/cjs/test",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "pretest": "yarn build",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -12,7 +12,8 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -6,7 +6,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -9,6 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "engines": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -6,7 +6,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -9,6 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "engines": {

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -6,7 +6,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -9,6 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/body-checksum-browser",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/body-checksum-node",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/chunked-blob-reader-native",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/chunked-blob-reader",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/chunked-stream-reader-node",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/client-documentation-generator",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/config-resolver",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/core-packages-documentation-generator",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/credential-provider-cognito-identity",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -8,7 +8,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -11,6 +11,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "keywords": [

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/endpoint-cache",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/eventstream-handler-node",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/eventstream-marshaller",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/eventstream-serde-browser",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/eventstream-serde-config-resolver",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/eventstream-serde-node",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/eventstream-serde-universal",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage && karma start karma.conf.js"
   },
   "author": {

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -3,7 +3,6 @@
   "version": "3.18.0",
   "description": "Provides a way to make requests",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "karma start karma.conf.js"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/hash-blob-browser",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/hash-node",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/hash-stream-node",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/invalid-dependency",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -3,7 +3,6 @@
   "version": "3.18.0",
   "description": "Provides a function for detecting if an argument is an ArrayBuffer",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/karma-credential-loader",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/md5-js",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-apply-body-checksum",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-bucket-endpoint",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-content-length",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-endpoint-discovery",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-eventstream",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-expect-continue",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-header-default",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-host-header",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-location-constraint",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-logger",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-retry",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-api-gateway",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-ec2",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-glacier",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-machinelearning",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-rds",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-route53",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-s3-control",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-s3",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-sqs",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-sdk-sts",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -8,7 +8,6 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --passWithNoTests"
   },

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --passWithNoTests"
   },

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-serde",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-signing",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-ssec",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -3,7 +3,6 @@
   "version": "3.18.0",
   "description": "Provides a means for composing multiple middleware functions into a single handler",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/middleware-user-agent",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -3,7 +3,6 @@
   "version": "3.19.0",
   "description": "Load config default values from ini config files and environmental variable",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },
   "author": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -3,7 +3,6 @@
   "version": "3.18.0",
   "description": "Provides a way to make requests",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/polly-request-presigner",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/property-provider",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/protocol-http",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/querystring-builder",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/querystring-parser",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/s3-presigned-post",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/s3-request-presigner",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/service-error-classification",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/sha256-tree-hash",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -11,7 +11,6 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -14,6 +14,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -9,7 +9,6 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --coverage"
   },

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -9,6 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --coverage"
   },

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/smithy-client",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,7 +9,6 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,6 +12,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },
   "author": {

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/url-parser",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -3,7 +3,6 @@
   "description": "Determines the length of a request body in browsers",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -3,7 +3,6 @@
   "description": "Determines the length of a request body in node.js",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-buffer-from",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-create-request",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-dynamodb",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-format-url",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -3,7 +3,6 @@
   "version": "3.18.0",
   "description": "Converts binary buffers to and from lowercase hexadecimal encoding",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -6,6 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-locate-window",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-uri-escape",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-user-agent-browser",
   "version": "3.18.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -2,7 +2,6 @@
   "name": "@aws-sdk/util-user-agent-node",
   "version": "3.19.0",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -5,6 +5,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -8,6 +8,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -13,7 +13,6 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -16,6 +16,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -11,7 +11,6 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -14,6 +14,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "author": {

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2474

### Description
The `prepublishOnly` script was running in our release automation with the following error:
```
npm WARN lifecycle @aws-sdk/util-dynamodb@3.19.0~prepublishOnly: cannot run in wd @aws-sdk/util-dynamodb@3.19.0 yarn build && downlevel-dts dist/types dist/types/ts3.4 (wd=.)
```

Due to this error, the downlevelled types were not getting published.
This happened as we ran `npm publish` script using package directory in our release automation, and npm cli ran `prepublishOnly` script from root directory.

The fix is to rename `prepublishOnly` to `downlevel-dts` and call it explicitly from our release automation. The `yarn build` is not required as `dist` folder is already present.

### Testing
* Similar change was tested by explicitly calling `prepublishOnly` script with package directory in release automation scripts.
* This change will be tested post merge by replacing `prepublishOnly` call with `downlevel-dts`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
