### PR TITLE
fix(protocol_tests): add downlevel-dts script to aws-json-10

### DIFF
--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -12,7 +12,8 @@
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",


### PR DESCRIPTION
### Issue
The scripts were updated in https://github.com/aws/aws-sdk-js-v3/pull/2537
They were missed in aws-json-10 package, as it was created in parallel https://github.com/aws/aws-sdk-js-v3/pull/2529

### Description
add downlevel-dts script and removes prepublishOnly script from aws-json-10

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
