### PR TITLE
chore: bump java version to 0.4.0

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.3.0"
+    version = "0.4.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("software.amazon.smithy:smithy-waiters:[1.9.0, 1.10.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.9.0, 1.10.0[")
     api("software.amazon.smithy:smithy-protocol-test-traits:[1.9.0, 1.10.0[")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.3.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.4.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
### Issue

n/a

### Description

This bumps the version of the java code generator to 0.4.0 so a new release can be cut.

### Testing

Built with the version bump, no changes

### Additional context

n/a

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
