### PR TITLE
fix(client-sts): duplicate stripInternal entry in tsconfig

### DIFF
--- a/clients/client-sts/tsconfig.json
+++ b/clients/client-sts/tsconfig.json
@@ -23,7 +23,6 @@
     "ignoreCompilerErrors": true,
     "includeDeclarations": true,
     "stripInternal": true,
-    "stripInternal": true,
     "readme": "./README.md",
     "mode": "file",
     "out": "./docs",


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

No issue

### Description
What does this implement/fix? Explain your changes.

This caused a warning for me when bundling with esbuild
```
> node_modules/@aws-sdk/client-ecs/node_modules/@aws-sdk/client-sts/tsconfig.json:26:4: warning: Duplicate key "stripInternal" in object literal
    26 │     "stripInternal": true,
       ╵     ~~~~~~~~~~~~~~~
```

### Testing
How was this change tested?

Not tested, change made through github web ui

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
