### PR TITLE
feat(node-http-handler): configure disableConcurrentStreams in NodeHttp2Handler

### DIFF
--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -290,7 +290,7 @@ describe(NodeHttp2Handler.name, () => {
     const requestTimeout = 200;
 
     describe("does not throw error when request not timed out", () => {
-      it("disableSessionCache: false (default)", async () => {
+      it("disableConcurrentStreams: false (default)", async () => {
         mockH2Server.removeAllListeners("request");
         mockH2Server.on("request", createResponseFunctionWithDelay(mockResponse, requestTimeout - 100));
 
@@ -298,17 +298,17 @@ describe(NodeHttp2Handler.name, () => {
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
       });
 
-      it("disableSessionCache: true", async () => {
+      it("disableConcurrentStreams: true", async () => {
         mockH2Server.removeAllListeners("request");
         mockH2Server.on("request", createResponseFunctionWithDelay(mockResponse, requestTimeout - 100));
 
-        nodeH2Handler = new NodeHttp2Handler({ requestTimeout, disableSessionCache: true });
+        nodeH2Handler = new NodeHttp2Handler({ requestTimeout, disableConcurrentStreams: true });
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
       });
     });
 
     describe("throws timeoutError on requestTimeout", () => {
-      it("disableSessionCache: false (default)", async () => {
+      it("disableConcurrentStreams: false (default)", async () => {
         mockH2Server.removeAllListeners("request");
         mockH2Server.on("request", createResponseFunctionWithDelay(mockResponse, requestTimeout + 100));
 
@@ -319,11 +319,11 @@ describe(NodeHttp2Handler.name, () => {
         });
       });
 
-      it("disableSessionCache: true", async () => {
+      it("disableConcurrentStreams: true", async () => {
         mockH2Server.removeAllListeners("request");
         mockH2Server.on("request", createResponseFunctionWithDelay(mockResponse, requestTimeout + 100));
 
-        nodeH2Handler = new NodeHttp2Handler({ requestTimeout, disableSessionCache: true });
+        nodeH2Handler = new NodeHttp2Handler({ requestTimeout, disableConcurrentStreams: true });
         await rejects(nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {}), {
           name: "TimeoutError",
           message: `Stream timed out because of no activity for ${requestTimeout} ms`,
@@ -336,7 +336,7 @@ describe(NodeHttp2Handler.name, () => {
     const sessionTimeout = 200;
 
     describe("destroys session on sessionTimeout", () => {
-      it("disableSessionCache: false (default)", async (done) => {
+      it("disableConcurrentStreams: false (default)", async (done) => {
         nodeH2Handler = new NodeHttp2Handler({ sessionTimeout });
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
@@ -354,8 +354,8 @@ describe(NodeHttp2Handler.name, () => {
         }, sessionTimeout + 100);
       });
 
-      it("disableSessionCache: true", async (done) => {
-        nodeH2Handler = new NodeHttp2Handler({ sessionTimeout, disableSessionCache: true });
+      it("disableConcurrentStreams: true", async (done) => {
+        nodeH2Handler = new NodeHttp2Handler({ sessionTimeout, disableConcurrentStreams: true });
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
         // @ts-ignore: access private property
@@ -369,10 +369,10 @@ describe(NodeHttp2Handler.name, () => {
     });
   });
 
-  describe("disableSessionCache", () => {
+  describe("disableConcurrentStreams", () => {
     beforeEach(() => {
       nodeH2Handler = new NodeHttp2Handler({
-        disableSessionCache: true,
+        disableConcurrentStreams: true,
       });
     });
 

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -48,11 +48,11 @@ describe(NodeHttp2Handler.name, () => {
 
     afterEach(() => {
       // @ts-ignore: access private property
-      const connectionPool = nodeH2Handler.connectionPool;
-      for (const [, session] of connectionPool) {
+      const sessionPool = nodeH2Handler.sessionPool;
+      for (const [, session] of sessionPool) {
         session.destroy();
       }
-      connectionPool.clear();
+      sessionPool.clear();
     });
 
     it("has metadata", () => {
@@ -219,22 +219,22 @@ describe(NodeHttp2Handler.name, () => {
     });
 
     describe("destroy", () => {
-      it("destroys session and clears connectionPool", async () => {
+      it("destroys session and clears sessionPool", async () => {
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
         // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connections[0];
+        const session: ClientHttp2Session = nodeH2Handler.sessions[0];
 
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionPool.size).toBe(1);
+        expect(nodeH2Handler.sessionPool.size).toBe(1);
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connections.length).toBe(1);
+        expect(nodeH2Handler.sessions.length).toBe(1);
         expect(session.destroyed).toBe(false);
         nodeH2Handler.destroy();
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionPool.size).toBe(0);
+        expect(nodeH2Handler.sessionPool.size).toBe(0);
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connections.length).toBe(0);
+        expect(nodeH2Handler.sessions.length).toBe(0);
         expect(session.destroyed).toBe(true);
       });
     });
@@ -242,7 +242,7 @@ describe(NodeHttp2Handler.name, () => {
     describe("abortSignal", () => {
       it("will not create session if request already aborted", async () => {
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionPool.size).toBe(0);
+        expect(nodeH2Handler.sessionPool.size).toBe(0);
         await expect(
           nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
             abortSignal: {
@@ -252,7 +252,7 @@ describe(NodeHttp2Handler.name, () => {
           })
         ).rejects.toHaveProperty("name", "AbortError");
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionPool.size).toBe(0);
+        expect(nodeH2Handler.sessionPool.size).toBe(0);
       });
 
       it("will not create request on session if request already aborted", async () => {
@@ -260,7 +260,7 @@ describe(NodeHttp2Handler.name, () => {
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
         // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connections[0];
+        const session: ClientHttp2Session = nodeH2Handler.sessions[0];
         const requestSpy = jest.spyOn(session, "request");
 
         await expect(
@@ -347,15 +347,15 @@ describe(NodeHttp2Handler.name, () => {
 
         const authority = `${protocol}//${hostname}:${port}`;
         // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connections[0];
+        const session: ClientHttp2Session = nodeH2Handler.sessions[0];
         expect(session.closed).toBe(false);
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionPool.get(authority)).toBeDefined();
+        expect(nodeH2Handler.sessionPool.get(authority)).toBeDefined();
         setTimeout(() => {
           expect(session.closed).toBe(true);
           expect(session.destroyed).toBe(false);
           // @ts-ignore: access private property
-          expect(nodeH2Handler.connectionPool.get(authority)).not.toBeDefined();
+          expect(nodeH2Handler.sessionPool.get(authority)).not.toBeDefined();
           done();
         }, sessionTimeout + 100);
       });
@@ -365,7 +365,7 @@ describe(NodeHttp2Handler.name, () => {
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
         // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connections[0];
+        const session: ClientHttp2Session = nodeH2Handler.sessions[0];
         expect(session.closed).toBe(false);
         setTimeout(() => {
           expect(session.closed).toBe(true);
@@ -439,14 +439,14 @@ describe(NodeHttp2Handler.name, () => {
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
         // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connections[0];
+        const session: ClientHttp2Session = nodeH2Handler.sessions[0];
 
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connections.length).toBe(1);
+        expect(nodeH2Handler.sessions.length).toBe(1);
         expect(session.destroyed).toBe(false);
         nodeH2Handler.destroy();
         // @ts-ignore: access private property
-        expect(nodeH2Handler.connections.length).toBe(0);
+        expect(nodeH2Handler.sessions.length).toBe(0);
         expect(session.destroyed).toBe(true);
       });
     });

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -28,290 +28,298 @@ describe(NodeHttp2Handler.name, () => {
   };
 
   beforeEach(() => {
-    nodeH2Handler = new NodeHttp2Handler();
     mockH2Server.on("request", createResponseFunction(mockResponse));
   });
 
   afterEach(() => {
     mockH2Server.removeAllListeners("request");
-    // @ts-ignore: access private property
-    const connectionPool = nodeH2Handler.connectionPool;
-    for (const [, session] of connectionPool) {
-      session.destroy();
-    }
-    connectionPool.clear();
   });
 
   afterAll(() => {
     mockH2Server.close();
   });
 
-  it("has metadata", () => {
-    expect(nodeH2Handler.metadata.handlerProtocol).toContain("h2");
-  });
-
-  describe("connectionPool", () => {
-    it("is empty on initialization", () => {
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(0);
+  describe("without options", () => {
+    beforeEach(() => {
+      nodeH2Handler = new NodeHttp2Handler();
     });
 
-    it("creates and stores session when request is made", async () => {
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-
+    afterEach(() => {
       // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(1);
-      expect(
+      const connectionPool = nodeH2Handler.connectionPool;
+      for (const [, session] of connectionPool) {
+        session.destroy();
+      }
+      connectionPool.clear();
+    });
+
+    it("has metadata", () => {
+      expect(nodeH2Handler.metadata.handlerProtocol).toContain("h2");
+    });
+
+    describe("connectionPool", () => {
+      it("is empty on initialization", () => {
         // @ts-ignore: access private property
-        nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`)
-      ).toBeDefined();
-    });
-
-    it("reuses existing session if request is made on same authority again", async () => {
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(1);
-
-      // @ts-ignore: access private property
-      const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`);
-      const requestSpy = jest.spyOn(session, "request");
-
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(1);
-      expect(requestSpy.mock.calls.length).toBe(1);
-    });
-
-    it("creates new session if request is made on new authority", async () => {
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(1);
-
-      const port2 = port + 1;
-      const mockH2Server2 = createMockHttp2Server().listen(port2);
-      mockH2Server2.on("request", createResponseFunction(mockResponse));
-
-      await nodeH2Handler.handle(new HttpRequest({ ...getMockReqOptions(), port: port2 }), {});
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(2);
-      expect(
-        // @ts-ignore: access private property
-        nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port2}`)
-      ).toBeDefined();
-
-      mockH2Server2.close();
-    });
-
-    it("closes and removes session on sessionTimeout", async (done) => {
-      const sessionTimeout = 500;
-      nodeH2Handler = new NodeHttp2Handler({ sessionTimeout });
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-
-      const authority = `${protocol}//${hostname}:${port}`;
-      // @ts-ignore: access private property
-      const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(authority);
-      expect(session.closed).toBe(false);
-      setTimeout(() => {
-        expect(session.closed).toBe(true);
-        // @ts-ignore: access private property
-        expect(nodeH2Handler.connectionPool.get(authority)).not.toBeDefined();
-        done();
-      }, sessionTimeout + 100);
-    });
-  });
-
-  describe("errors", () => {
-    const UNEXPECTEDLY_CLOSED_REGEX = /closed|destroy|cancel|did not get a response/i;
-    it("handles goaway frames", async () => {
-      const port3 = port + 2;
-      const mockH2Server3 = createMockHttp2Server().listen(port3);
-      let establishedConnections = 0;
-      let numRequests = 0;
-      let shouldSendGoAway = true;
-
-      mockH2Server3.on("stream", (request: Http2Stream) => {
-        // transmit goaway frame without shutting down the connection
-        // to simulate an unlikely error mode.
-        numRequests += 1;
-        if (shouldSendGoAway) {
-          request.session.goaway(constants.NGHTTP2_PROTOCOL_ERROR);
-        }
+        expect(nodeH2Handler.connectionPool.size).toBe(0);
       });
-      mockH2Server3.on("connection", () => {
-        establishedConnections += 1;
+
+      it("creates and stores session when request is made", async () => {
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(1);
+        expect(
+          // @ts-ignore: access private property
+          nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`)
+        ).toBeDefined();
       });
-      const req = new HttpRequest({ ...getMockReqOptions(), port: port3 });
-      expect(establishedConnections).toBe(0);
-      expect(numRequests).toBe(0);
-      await rejects(
-        nodeH2Handler.handle(req, {}),
-        UNEXPECTEDLY_CLOSED_REGEX,
-        "should be rejected promptly due to goaway frame"
-      );
-      expect(establishedConnections).toBe(1);
-      expect(numRequests).toBe(1);
-      await rejects(
-        nodeH2Handler.handle(req, {}),
-        UNEXPECTEDLY_CLOSED_REGEX,
-        "should be rejected promptly due to goaway frame"
-      );
-      expect(establishedConnections).toBe(2);
-      expect(numRequests).toBe(2);
-      await rejects(
-        nodeH2Handler.handle(req, {}),
-        UNEXPECTEDLY_CLOSED_REGEX,
-        "should be rejected promptly due to goaway frame"
-      );
-      expect(establishedConnections).toBe(3);
-      expect(numRequests).toBe(3);
 
-      // should be able to recover from goaway after reconnecting to a server
-      // that doesn't send goaway, and reuse the TCP connection (Http2Session)
-      shouldSendGoAway = false;
-      mockH2Server3.on("request", createResponseFunction(mockResponse));
-      await nodeH2Handler.handle(req, {});
-      const result = await nodeH2Handler.handle(req, {});
-      const resultReader = result.response.body;
+      it("reuses existing session if request is made on same authority again", async () => {
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(1);
 
-      // ...and validate that the mocked response is received
-      const responseBody = await new Promise((resolve) => {
-        const buffers = [];
-        resultReader.on("data", (chunk) => buffers.push(chunk));
-        resultReader.on("end", () => {
-          resolve(Buffer.concat(buffers).toString("utf8"));
+        // @ts-ignore: access private property
+        const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`);
+        const requestSpy = jest.spyOn(session, "request");
+
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(1);
+        expect(requestSpy.mock.calls.length).toBe(1);
+      });
+
+      it("creates new session if request is made on new authority", async () => {
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(1);
+
+        const port2 = port + 1;
+        const mockH2Server2 = createMockHttp2Server().listen(port2);
+        mockH2Server2.on("request", createResponseFunction(mockResponse));
+
+        await nodeH2Handler.handle(new HttpRequest({ ...getMockReqOptions(), port: port2 }), {});
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(2);
+        expect(
+          // @ts-ignore: access private property
+          nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port2}`)
+        ).toBeDefined();
+
+        mockH2Server2.close();
+      });
+
+      it("closes and removes session on sessionTimeout", async (done) => {
+        const sessionTimeout = 500;
+        nodeH2Handler = new NodeHttp2Handler({ sessionTimeout });
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+        const authority = `${protocol}//${hostname}:${port}`;
+        // @ts-ignore: access private property
+        const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(authority);
+        expect(session.closed).toBe(false);
+        setTimeout(() => {
+          expect(session.closed).toBe(true);
+          // @ts-ignore: access private property
+          expect(nodeH2Handler.connectionPool.get(authority)).not.toBeDefined();
+          done();
+        }, sessionTimeout + 100);
+      });
+    });
+
+    describe("errors", () => {
+      const UNEXPECTEDLY_CLOSED_REGEX = /closed|destroy|cancel|did not get a response/i;
+      it("handles goaway frames", async () => {
+        const port3 = port + 2;
+        const mockH2Server3 = createMockHttp2Server().listen(port3);
+        let establishedConnections = 0;
+        let numRequests = 0;
+        let shouldSendGoAway = true;
+
+        mockH2Server3.on("stream", (request: Http2Stream) => {
+          // transmit goaway frame without shutting down the connection
+          // to simulate an unlikely error mode.
+          numRequests += 1;
+          if (shouldSendGoAway) {
+            request.session.goaway(constants.NGHTTP2_PROTOCOL_ERROR);
+          }
         });
+        mockH2Server3.on("connection", () => {
+          establishedConnections += 1;
+        });
+        const req = new HttpRequest({ ...getMockReqOptions(), port: port3 });
+        expect(establishedConnections).toBe(0);
+        expect(numRequests).toBe(0);
+        await rejects(
+          nodeH2Handler.handle(req, {}),
+          UNEXPECTEDLY_CLOSED_REGEX,
+          "should be rejected promptly due to goaway frame"
+        );
+        expect(establishedConnections).toBe(1);
+        expect(numRequests).toBe(1);
+        await rejects(
+          nodeH2Handler.handle(req, {}),
+          UNEXPECTEDLY_CLOSED_REGEX,
+          "should be rejected promptly due to goaway frame"
+        );
+        expect(establishedConnections).toBe(2);
+        expect(numRequests).toBe(2);
+        await rejects(
+          nodeH2Handler.handle(req, {}),
+          UNEXPECTEDLY_CLOSED_REGEX,
+          "should be rejected promptly due to goaway frame"
+        );
+        expect(establishedConnections).toBe(3);
+        expect(numRequests).toBe(3);
+
+        // should be able to recover from goaway after reconnecting to a server
+        // that doesn't send goaway, and reuse the TCP connection (Http2Session)
+        shouldSendGoAway = false;
+        mockH2Server3.on("request", createResponseFunction(mockResponse));
+        await nodeH2Handler.handle(req, {});
+        const result = await nodeH2Handler.handle(req, {});
+        const resultReader = result.response.body;
+
+        // ...and validate that the mocked response is received
+        const responseBody = await new Promise((resolve) => {
+          const buffers = [];
+          resultReader.on("data", (chunk) => buffers.push(chunk));
+          resultReader.on("end", () => {
+            resolve(Buffer.concat(buffers).toString("utf8"));
+          });
+        });
+        expect(responseBody).toBe("test");
+        expect(establishedConnections).toBe(4);
+        expect(numRequests).toBe(5);
+        mockH2Server3.close();
       });
-      expect(responseBody).toBe("test");
-      expect(establishedConnections).toBe(4);
-      expect(numRequests).toBe(5);
-      mockH2Server3.close();
-    });
 
-    it("handles connections destroyed by servers", async () => {
-      const port3 = port + 2;
-      const mockH2Server3 = createMockHttp2Server().listen(port3);
-      let establishedConnections = 0;
-      let numRequests = 0;
+      it("handles connections destroyed by servers", async () => {
+        const port3 = port + 2;
+        const mockH2Server3 = createMockHttp2Server().listen(port3);
+        let establishedConnections = 0;
+        let numRequests = 0;
 
-      mockH2Server3.on("stream", (request: Http2Stream) => {
-        // transmit goaway frame and then shut down the connection.
-        numRequests += 1;
-        request.session.destroy();
+        mockH2Server3.on("stream", (request: Http2Stream) => {
+          // transmit goaway frame and then shut down the connection.
+          numRequests += 1;
+          request.session.destroy();
+        });
+        mockH2Server3.on("connection", () => {
+          establishedConnections += 1;
+        });
+        const req = new HttpRequest({ ...getMockReqOptions(), port: port3 });
+        expect(establishedConnections).toBe(0);
+        expect(numRequests).toBe(0);
+        await rejects(
+          nodeH2Handler.handle(req, {}),
+          UNEXPECTEDLY_CLOSED_REGEX,
+          "should be rejected promptly due to goaway frame or destroyed connection"
+        );
+        expect(establishedConnections).toBe(1);
+        expect(numRequests).toBe(1);
+        await rejects(
+          nodeH2Handler.handle(req, {}),
+          UNEXPECTEDLY_CLOSED_REGEX,
+          "should be rejected promptly due to goaway frame or destroyed connection"
+        );
+        expect(establishedConnections).toBe(2);
+        expect(numRequests).toBe(2);
+        await rejects(
+          nodeH2Handler.handle(req, {}),
+          UNEXPECTEDLY_CLOSED_REGEX,
+          "should be rejected promptly due to goaway frame or destroyed connection"
+        );
+        expect(establishedConnections).toBe(3);
+        expect(numRequests).toBe(3);
+        mockH2Server3.close();
       });
-      mockH2Server3.on("connection", () => {
-        establishedConnections += 1;
+    });
+
+    describe("destroy", () => {
+      it("destroys sessions and clears connectionPool", async () => {
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+        // @ts-ignore: access private property
+        const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`);
+
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(1);
+        expect(session.destroyed).toBe(false);
+        nodeH2Handler.destroy();
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(0);
+        expect(session.destroyed).toBe(true);
       });
-      const req = new HttpRequest({ ...getMockReqOptions(), port: port3 });
-      expect(establishedConnections).toBe(0);
-      expect(numRequests).toBe(0);
-      await rejects(
-        nodeH2Handler.handle(req, {}),
-        UNEXPECTEDLY_CLOSED_REGEX,
-        "should be rejected promptly due to goaway frame or destroyed connection"
-      );
-      expect(establishedConnections).toBe(1);
-      expect(numRequests).toBe(1);
-      await rejects(
-        nodeH2Handler.handle(req, {}),
-        UNEXPECTEDLY_CLOSED_REGEX,
-        "should be rejected promptly due to goaway frame or destroyed connection"
-      );
-      expect(establishedConnections).toBe(2);
-      expect(numRequests).toBe(2);
-      await rejects(
-        nodeH2Handler.handle(req, {}),
-        UNEXPECTEDLY_CLOSED_REGEX,
-        "should be rejected promptly due to goaway frame or destroyed connection"
-      );
-      expect(establishedConnections).toBe(3);
-      expect(numRequests).toBe(3);
-      mockH2Server3.close();
-    });
-  });
-
-  describe("destroy", () => {
-    it("destroys sessions and clears connectionPool", async () => {
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-
-      // @ts-ignore: access private property
-      const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`);
-
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(1);
-      expect(session.destroyed).toBe(false);
-      nodeH2Handler.destroy();
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(0);
-      expect(session.destroyed).toBe(true);
-    });
-  });
-
-  describe("abortSignal", () => {
-    it("will not create session if request already aborted", async () => {
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(0);
-      await expect(
-        nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
-          abortSignal: {
-            aborted: true,
-            onabort: null,
-          },
-        })
-      ).rejects.toHaveProperty("name", "AbortError");
-      // @ts-ignore: access private property
-      expect(nodeH2Handler.connectionPool.size).toBe(0);
     });
 
-    it("will not create request on session if request already aborted", async () => {
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-
-      // @ts-ignore: access private property
-      const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`);
-      const requestSpy = jest.spyOn(session, "request");
-
-      await expect(
-        nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
-          abortSignal: {
-            aborted: true,
-            onabort: null,
-          },
-        })
-      ).rejects.toHaveProperty("name", "AbortError");
-      expect(requestSpy.mock.calls.length).toBe(0);
-    });
-
-    /* Commenting out as the test is flaky https://github.com/aws/aws-sdk-js-v3/issues/487
-    it("will close request on session when aborted", async () => {
-      await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
-
-      // @ts-ignore: access private property
-      const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(
-        `${protocol}//${hostname}:${port}`
-      );
-      const requestSpy = jest.spyOn(session, "request");
-
-      const abortController = new AbortController();
-      // Delay response so that onabort is called earlier
-      setTimeout(() => {
-        abortController.abort();
-      }, 0);
-      mockH2Server.on(
-        "request",
-        async () =>
-          new Promise(resolve => {
-            setTimeout(() => {
-              resolve(createResponseFunction(mockResponse));
-            }, 1000);
+    describe("abortSignal", () => {
+      it("will not create session if request already aborted", async () => {
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(0);
+        await expect(
+          nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
+            abortSignal: {
+              aborted: true,
+              onabort: null,
+            },
           })
-      );
+        ).rejects.toHaveProperty("name", "AbortError");
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connectionPool.size).toBe(0);
+      });
 
-      await expect(
-        nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
-          abortSignal: abortController.signal
-        })
-      ).rejects.toHaveProperty("name", "AbortError");
-      expect(requestSpy.mock.calls.length).toBe(1);
+      it("will not create request on session if request already aborted", async () => {
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+        // @ts-ignore: access private property
+        const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`);
+        const requestSpy = jest.spyOn(session, "request");
+
+        await expect(
+          nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
+            abortSignal: {
+              aborted: true,
+              onabort: null,
+            },
+          })
+        ).rejects.toHaveProperty("name", "AbortError");
+        expect(requestSpy.mock.calls.length).toBe(0);
+      });
+
+      /* Commenting out as the test is flaky https://github.com/aws/aws-sdk-js-v3/issues/487
+      it("will close request on session when aborted", async () => {
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+  
+        // @ts-ignore: access private property
+        const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(
+          `${protocol}//${hostname}:${port}`
+        );
+        const requestSpy = jest.spyOn(session, "request");
+  
+        const abortController = new AbortController();
+        // Delay response so that onabort is called earlier
+        setTimeout(() => {
+          abortController.abort();
+        }, 0);
+        mockH2Server.on(
+          "request",
+          async () =>
+            new Promise(resolve => {
+              setTimeout(() => {
+                resolve(createResponseFunction(mockResponse));
+              }, 1000);
+            })
+        );
+  
+        await expect(
+          nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
+            abortSignal: abortController.signal
+          })
+        ).rejects.toHaveProperty("name", "AbortError");
+        expect(requestSpy.mock.calls.length).toBe(1);
+      });
+      */
     });
-    */
   });
 });

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -5,7 +5,7 @@ import { constants, Http2Stream } from "http2";
 import { NodeHttp2Handler } from "./node-http2-handler";
 import { createMockHttp2Server, createResponseFunction } from "./server.mock";
 
-describe("NodeHttp2Handler", () => {
+describe(NodeHttp2Handler.name, () => {
   let nodeH2Handler: NodeHttp2Handler;
 
   const protocol = "http:";

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -361,7 +361,8 @@ describe(NodeHttp2Handler.name, () => {
 
         // @ts-ignore: access private property
         const session: ClientHttp2Session = nodeH2Handler.sessionList[0];
-        expect(session.closed).toBe(false);
+        // When disableSessionCache:true, session is closed as soon as request gets response.
+        expect(session.closed).toBe(true);
         setTimeout(() => {
           expect(session.closed).toBe(true);
           expect(session.destroyed).toBe(false);

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -219,18 +219,22 @@ describe(NodeHttp2Handler.name, () => {
     });
 
     describe("destroy", () => {
-      it("destroys sessions and clears connectionPool", async () => {
+      it("destroys session and clears connectionPool", async () => {
         await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
 
         // @ts-ignore: access private property
-        const session: ClientHttp2Session = nodeH2Handler.connectionPool.get(`${protocol}//${hostname}:${port}`);
+        const session: ClientHttp2Session = nodeH2Handler.connections[0];
 
         // @ts-ignore: access private property
         expect(nodeH2Handler.connectionPool.size).toBe(1);
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connections.length).toBe(1);
         expect(session.destroyed).toBe(false);
         nodeH2Handler.destroy();
         // @ts-ignore: access private property
         expect(nodeH2Handler.connectionPool.size).toBe(0);
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connections.length).toBe(0);
         expect(session.destroyed).toBe(true);
       });
     });
@@ -427,6 +431,23 @@ describe(NodeHttp2Handler.name, () => {
         expect(connectSpy).toHaveBeenNthCalledWith(1, `${authorityPrefix}:${port}`);
         expect(connectSpy).toHaveBeenNthCalledWith(2, `${authorityPrefix}:${port2}`);
         mockH2Server2.close();
+      });
+    });
+
+    describe("destroy", () => {
+      it("destroys session and clears connections", async () => {
+        await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
+
+        // @ts-ignore: access private property
+        const session: ClientHttp2Session = nodeH2Handler.connections[0];
+
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connections.length).toBe(1);
+        expect(session.destroyed).toBe(false);
+        nodeH2Handler.destroy();
+        // @ts-ignore: access private property
+        expect(nodeH2Handler.connections.length).toBe(0);
+        expect(session.destroyed).toBe(true);
       });
     });
   });

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -343,12 +343,11 @@ describe(NodeHttp2Handler.name, () => {
         const authority = `${protocol}//${hostname}:${port}`;
         // @ts-ignore: access private property
         const session: ClientHttp2Session = nodeH2Handler.sessionList[0];
-        expect(session.closed).toBe(false);
+        expect(session.destroyed).toBe(false);
         // @ts-ignore: access private property
         expect(nodeH2Handler.sessionCache.get(authority)).toBeDefined();
         setTimeout(() => {
-          expect(session.closed).toBe(true);
-          expect(session.destroyed).toBe(false);
+          expect(session.destroyed).toBe(true);
           // @ts-ignore: access private property
           expect(nodeH2Handler.sessionCache.get(authority)).not.toBeDefined();
           done();
@@ -361,11 +360,9 @@ describe(NodeHttp2Handler.name, () => {
 
         // @ts-ignore: access private property
         const session: ClientHttp2Session = nodeH2Handler.sessionList[0];
-        // When disableSessionCache:true, session is closed as soon as request gets response.
-        expect(session.closed).toBe(true);
+        expect(session.destroyed).toBe(false);
         setTimeout(() => {
-          expect(session.closed).toBe(true);
-          expect(session.destroyed).toBe(false);
+          expect(session.destroyed).toBe(true);
           done();
         }, sessionTimeout + 100);
       });

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -50,7 +50,7 @@ export class NodeHttp2Handler implements HttpHandler {
   }
 
   destroy(): void {
-    this.connections.forEach(this.destroySession);
+    this.connections.forEach((session) => this.destroySession(session));
     this.connectionPool.clear();
   }
 
@@ -199,6 +199,7 @@ export class NodeHttp2Handler implements HttpHandler {
     if (!session.destroyed) {
       session.destroy();
     }
+    this.connections = this.connections.filter((s) => s !== session);
   }
 
   /**

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -22,17 +22,28 @@ export interface NodeHttp2HandlerOptions {
    * https://nodejs.org/docs/latest-v12.x/api/http2.html#http2_http2session_and_sockets
    */
   sessionTimeout?: number;
+
+  /**
+   * Disables sharing ClientHttp2Session instance between different HTTP/2 requests
+   * sent to the same URL. When set to true, it will create a new session instance for
+   * each request to a URL. **Default:** false.
+   * https://nodejs.org/api/http2.html#http2_class_clienthttp2session
+   */
+  disableSessionCache?: boolean;
 }
 
 export class NodeHttp2Handler implements HttpHandler {
   private readonly requestTimeout?: number;
   private readonly sessionTimeout?: number;
+  private readonly disableSessionCache?: boolean;
+
   private readonly connectionPool: Map<string, ClientHttp2Session>;
   public readonly metadata = { handlerProtocol: "h2" };
 
-  constructor({ requestTimeout, sessionTimeout }: NodeHttp2HandlerOptions = {}) {
+  constructor({ requestTimeout, sessionTimeout, disableSessionCache }: NodeHttp2HandlerOptions = {}) {
     this.requestTimeout = requestTimeout;
     this.sessionTimeout = sessionTimeout;
+    this.disableSessionCache = disableSessionCache;
     this.connectionPool = new Map<string, ClientHttp2Session>();
   }
 

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -97,6 +97,11 @@ export class NodeHttp2Handler implements HttpHandler {
         });
         fulfilled = true;
         resolve({ response: httpResponse });
+        if (this.disableSessionCache) {
+          // Gracefully closes the Http2Session, allowing any existing streams to complete
+          // on their own and preventing new Http2Stream instances from being created.
+          session.close();
+        }
       });
 
       const requestTimeout = this.requestTimeout;

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -208,7 +208,7 @@ export class NodeHttp2Handler implements HttpHandler {
    */
   private deleteSessionFromPool(authority: string, session: ClientHttp2Session): void {
     if (this.connectionPool.get(authority) !== session) {
-      // If the session is not in the pool, it has already been destroyed.
+      // If the session is not in the pool, it has already been deleted.
       return;
     }
     this.connectionPool.delete(authority);

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -158,7 +158,7 @@ export class NodeHttp2Handler implements HttpHandler {
     const sessionTimeout = this.sessionTimeout;
     if (sessionTimeout) {
       newSession.setTimeout(sessionTimeout, () => {
-        newSession.close();
+        this.destroySession(newSession);
       });
     }
 

--- a/packages/node-http-handler/src/server.mock.ts
+++ b/packages/node-http-handler/src/server.mock.ts
@@ -36,29 +36,28 @@ export const createResponseFunctionWithDelay =
     setTimeout(() => setResponseBody(response, httpResp.body), delay);
   };
 
-export function createContinueResponseFunction(httpResp: HttpResponse) {
-  return function (request: IncomingMessage, response: ServerResponse) {
+export const createContinueResponseFunction =
+  (httpResp: HttpResponse) => (request: IncomingMessage, response: ServerResponse) => {
     response.writeContinue();
     setTimeout(() => {
       createResponseFunction(httpResp)(request, response);
     }, 100);
   };
-}
 
-export function createMockHttpsServer(): HttpsServer {
+export const createMockHttpsServer = (): HttpsServer => {
   const server = createHttpsServer({
     key: readFileSync(join(fixturesDir, "test-server-key.pem")),
     cert: readFileSync(join(fixturesDir, "test-server-cert.pem")),
   });
   return server;
-}
+};
 
-export function createMockHttpServer(): HttpServer {
+export const createMockHttpServer = (): HttpServer => {
   const server = createHttpServer();
   return server;
-}
+};
 
-export function createMockHttp2Server(): Http2Server {
+export const createMockHttp2Server = (): Http2Server => {
   const server = createHttp2Server();
   return server;
-}
+};


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2550

### Description
Adds an option to disableConcurrentStreams in NodeHttp2Handler

Example:
```js
const client = new H2HandlerClient({
  requestHandler: new NodeHttp2Handler({
    disableConcurrentStreams: true
  }),
});
```

### Testing
CI is successful
Verified that TranscribeStreaming works in parallel in demo code https://github.com/trivikr/aws-parallel-transcribe-repro/pull/1

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
