### PR TITLE
feat(util-dynamodb): preserve keys in marshall types

### DIFF
--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -30,4 +30,4 @@ export interface marshallOptions {
 export const marshall = <T extends { [K in keyof T]: NativeAttributeValue }>(
   data: T,
   options?: marshallOptions
-): { [key: string]: AttributeValue } => convertToAttr(data, options).M as { [key: string]: AttributeValue };
+): { [key in keyof T]: AttributeValue } => convertToAttr(data, options).M as { [key in keyof T]: AttributeValue };

--- a/packages/util-dynamodb/src/unmarshall.ts
+++ b/packages/util-dynamodb/src/unmarshall.ts
@@ -20,8 +20,8 @@ export interface unmarshallOptions {
  * @param {any} data - The DynamoDB record
  * @param {unmarshallOptions} options - An optional configuration object for `unmarshall`
  */
-export const unmarshall = (
-  data: { [key: string]: AttributeValue },
+export const unmarshall = <T extends { [K in keyof T]: AttributeValue }>(
+  data: T,
   options?: unmarshallOptions
-): { [key: string]: NativeAttributeValue } =>
-  convertToNative({ M: data }, options) as { [key: string]: NativeAttributeValue };
+): { [K in keyof T]: NativeAttributeValue } =>
+  convertToNative({ M: data }, options) as { [K in keyof T]: NativeAttributeValue };


### PR DESCRIPTION
### Description
This updates the types of the `marshall` and `unmarshall` functions, by preserving the keys of the object provided in input, instead of coercing all the keys to `string`.
I believe this is more representative of what both functions actually do.

_Before_

`marshall`:

![Screen Shot 2021-07-09 at 9 07 19 AM](https://user-images.githubusercontent.com/6436053/125082495-48240080-e095-11eb-9ead-2eb214886fe2.png)

`unmarshall`:
![Screen Shot 2021-07-09 at 9 08 33 AM](https://user-images.githubusercontent.com/6436053/125082517-4d814b00-e095-11eb-86cb-080c29b2be1f.png)

_After_

`marshall`:
![Screen Shot 2021-07-09 at 9 10 29 AM](https://user-images.githubusercontent.com/6436053/125082730-91745000-e095-11eb-92cd-193e7bccd71a.png)

`unmarshall`:
![Screen Shot 2021-07-09 at 9 10 41 AM](https://user-images.githubusercontent.com/6436053/125082759-96d19a80-e095-11eb-8aa8-616846397110.png)


### Testing

Ran `test:all` and tested on personal project.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
