### PR TITLE
fix(client-transcribe-streaming): disable concurrent streams in handler

### DIFF
--- a/clients/client-transcribe-streaming/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.ts
@@ -34,7 +34,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   eventStreamSerdeProvider,
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-  requestHandler: new NodeHttp2Handler(),
+  requestHandler: new NodeHttp2Handler({ disableConcurrentStreams: true }),
   retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
   sha256: Hash.bind(null, "sha256"),
   streamCollector,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
@@ -76,6 +77,14 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
                 });
 
         switch (target) {
+            case NODE:
+                return MapUtils.of(
+                    "requestHandler", writer -> {
+                        writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
+                        writer.addImport("NodeHttp2Handler", "NodeHttp2Handler",
+                            TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
+                         writer.write("requestHandler: new NodeHttp2Handler({ disableConcurrentStreams: true }),");
+                    });
             case REACT_NATIVE:
             case BROWSER:
                 return transcribeStreamingHandlerConfig;


### PR DESCRIPTION
Resolves: #2555

### Description
Sets Transcribe Streaming client H/2 handler to create new session for every new request. Previously it doesn't work for concurrent stream on 1 session, possibly due to server-side limitation.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
