### PR TITLE
fix(node-http-handler): throw meaningful errors in H2 events

### DIFF
--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -125,10 +125,13 @@ export class NodeHttp2Handler implements HttpHandler {
       }
 
       // Set up handlers for errors
-      req.on("frameError", reject);
+      req.on("frameError", (type: number, code: number, id: number) => {
+        reject(new Error(`Frame type id ${type} in stream id ${id} has failed with code ${code}.`));
+      });
       req.on("error", reject);
-      req.on("goaway", reject);
-      req.on("aborted", reject);
+      req.on("aborted", () => {
+        reject(new Error(`HTTP/2 stream is abnormally aborted in mid-communication with result code ${req.rstCode}.`));
+      });
 
       // The HTTP/2 error code used when closing the stream can be retrieved using the
       // http2stream.rstCode property. If the code is any value other than NGHTTP2_NO_ERROR (0),


### PR DESCRIPTION
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2556

### Issue

Request's `goaway` event is not defined in the [Node.js spec](https://nodejs.org/api/http2.html#http2_class_http2stream), so remove it.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
