### PR TITLE
Create waitForDNSFirewallRuleGroupNotShared.ts

### DIFF
--- a/clients/client-route53resolver/waiters/waitForDNSFirewallRuleGroupNotShared.ts
+++ b/clients/client-route53resolver/waiters/waitForDNSFirewallRuleGroupNotShared.ts
@@ -1,0 +1,51 @@
+import {
+  GetFirewallRuleGroupCommand,
+  GetFirewallRuleGroupCommandInput,
+  GetFirewallRuleGroupCommandOutput,
+  Route53ResolverClient,
+  ShareStatus,
+} from "@aws-sdk/client-route53resolver";
+import {
+  WaiterConfiguration,
+  WaiterResult,
+  WaiterState,
+  checkExceptions,
+  createWaiter,
+} from "@aws-sdk/util-waiter";
+
+const checkState = async (
+  client: Route53ResolverClient,
+  input: GetFirewallRuleGroupCommandInput
+): Promise<WaiterResult> => {
+  let reason;
+  try {
+    const result: GetFirewallRuleGroupCommandOutput = await client.send(
+      new GetFirewallRuleGroupCommand(input)
+    );
+    reason = result;
+    if (result.FirewallRuleGroup?.ShareStatus === ShareStatus.NotShared)
+      return { state: WaiterState.SUCCESS, reason };
+    else return { state: WaiterState.RETRY, reason };
+  } catch (exception) {
+    reason = exception;
+    return { state: WaiterState.FAILURE, reason };
+  }
+};
+
+/**
+ * @description waiter function to check DNS firewall share status set to NOT_SHARED
+ * @param {WaiterConfiguration<Route53ResolverClient>} params - Waiter configuration options.
+ * @param {GetFirewallRuleGroupCommandInput} input - The input to GetFirewallRuleGroup for polling.
+ */
+export const waitUntilDNSFirewallRuleGroupNotShared = async (
+  params: WaiterConfiguration<Route53ResolverClient>,
+  input: GetFirewallRuleGroupCommandInput
+): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 1, maxDelay: 10 };
+  const result = await createWaiter(
+    { ...serviceDefaults, ...params },
+    input,
+    checkState
+  );
+  return checkExceptions(result);
+};


### PR DESCRIPTION
waiter to wait for rule group shared status change to NOT_SHARED

### Description
Waiter to wait for DNS Firewall Rule Group share status transition to NOT_SHARED

### Testing
```
// waiting for rule group share status to change to NOT_SHARED
await waitUntilDNSFirewallRuleGroupNotShared(
  { client: route53Client, maxWaitTime: 300 }, // aggressive timeout, as there can be delay in deleting RAM resource share
  { FirewallRuleGroupId: ruleGrp.Id }
);

await route53Client.send(
  new DeleteFirewallRuleGroupCommand({
    FirewallRuleGroupId: ruleGrp.Id,
  })
);

```
waited for rule group share status to change before deletion, rule group cannot be deleted if it is shared

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
