### PR TITLE
chore(types): add `dist/` to typesVersions TS <4

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,8 +25,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "types/*": [
-        "types/ts3.4/*"
+      "dist/types/*": [
+        "dist/types/ts3.4/*"
       ]
     }
   },


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/2474

### Description
While @trivikr fixed the issue with `prepublishOnly` running on the wrong directory and we are now publishing the `dist/types/ts3.4` directory, we are still pointing to `types/ts3.4` and the types are not being picked up.

This change updates `typeVersions` to pick up the proper directories for TS <4.0.

### Testing
Made this change, `npm pack`, installed tarball in my TS 3.6 application, works at intended.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
