### PR TITLE
feat(credential-provider-sso): support sso credential when resolving shared credential file

### DIFF
--- a/packages/credential-provider-ini/README.md
+++ b/packages/credential-provider-ini/README.md
@@ -90,7 +90,7 @@ aws_access_key_id=foo
 aws_secret_access_key=bar
 
 [first]
-source_profile=first
+source_profile=second
 role_arn=arn:aws:iam::123456789012:role/example-role-arn
 ```
 
@@ -124,4 +124,47 @@ credential_source = EcsContainer
 [default]
 web_identity_token_file=/temp/token
 role_arn=arn:aws:iam::123456789012:role/example-role-arn
+```
+
+You can specify using the `first` profile which will assume a role
+`example-role` with the role `example-role-2` which derived from web
+identity token file.
+
+```ini
+[second]
+web_identity_token_file=/temp/token
+role_arn=arn:aws:iam::123456789012:role/example-role-2
+
+[first]
+source_profile=second
+role_arn=arn:aws:iam::123456789012:role/example-role
+```
+
+### profile with sso credentials
+
+Please refer the the [`sso credential provider package`](https://www.npmjs.com/package/@aws-sdk/credential-provider-sso)
+for how to configure the SSO credentials.
+
+```ini
+[default]
+sso_account_id = 012345678901
+sso_region = us-east-1
+sso_role_name = SampleRole
+sso_start_url = https://d-abc123.awsapps.com/start
+```
+
+You can specify using the `first` profile which will assume a role
+`example-role` with the role `example-role-2` which derived from SSO
+credentials.
+
+```ini
+[second]
+sso_account_id = 012345678901
+sso_region = us-east-1
+sso_role_name = example-role-2
+sso_start_url = https://d-abc123.awsapps.com/start
+
+[first]
+source_profile=second
+role_arn=arn:aws:iam::123456789012:role/example-role
 ```

--- a/packages/credential-provider-ini/README.md
+++ b/packages/credential-provider-ini/README.md
@@ -126,9 +126,8 @@ web_identity_token_file=/temp/token
 role_arn=arn:aws:iam::123456789012:role/example-role-arn
 ```
 
-You can specify using the `first` profile which will assume a role
-`example-role` with the role `example-role-2` which derived from web
-identity token file.
+You can specify another profile(`second`) whose credentials are used to assume
+the role by the `role_arn` setting in this profile(`first`).
 
 ```ini
 [second]
@@ -153,9 +152,8 @@ sso_role_name = SampleRole
 sso_start_url = https://d-abc123.awsapps.com/start
 ```
 
-You can specify using the `first` profile which will assume a role
-`example-role` with the role `example-role-2` which derived from SSO
-credentials.
+You can specify another profile(`second`) whose credentials derived from SSO
+are used to assume the role by the `role_arn` setting in this profile(`first`).
 
 ```ini
 [second]

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aws-sdk/credential-provider-env": "3.20.0",
     "@aws-sdk/credential-provider-imds": "3.20.0",
+    "@aws-sdk/credential-provider-sso": "3.21.0",
     "@aws-sdk/credential-provider-web-identity": "3.20.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/shared-ini-file-loader": "3.20.0",

--- a/packages/credential-provider-ini/src/index.spec.ts
+++ b/packages/credential-provider-ini/src/index.spec.ts
@@ -1,5 +1,6 @@
 import { fromEnv } from "@aws-sdk/credential-provider-env";
 import { fromContainerMetadata, fromInstanceMetadata } from "@aws-sdk/credential-provider-imds";
+import { fromSSO, isSsoProfile, validateSsoProfile } from "@aws-sdk/credential-provider-sso";
 import { fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
 import { ENV_CONFIG_PATH, ENV_CREDENTIALS_PATH } from "@aws-sdk/shared-ini-file-loader";
 import { Credentials } from "@aws-sdk/types";
@@ -60,6 +61,8 @@ jest.mock("@aws-sdk/credential-provider-web-identity");
 jest.mock("@aws-sdk/credential-provider-imds");
 
 jest.mock("@aws-sdk/credential-provider-env");
+
+jest.mock("@aws-sdk/credential-provider-sso");
 
 const DEFAULT_CREDS = {
   accessKeyId: "AKIAIOSFODNN7EXAMPLE",
@@ -985,6 +988,120 @@ role_arn = ${roleArn}`.trim()
         webIdentityTokenFile,
         roleArn,
         roleAssumerWithWebIdentity,
+      });
+    });
+  });
+
+  describe("assume role with SSO", () => {
+    const DEFAULT_PATH = join(homedir(), ".aws", "credentials");
+    it("should continue if profile is not configured with an SSO credential", async () => {
+      __addMatcher(
+        DEFAULT_PATH,
+        `[default]
+aws_access_key_id = ${DEFAULT_CREDS.accessKeyId}
+aws_secret_access_key = ${DEFAULT_CREDS.secretAccessKey}
+aws_session_token = ${DEFAULT_CREDS.sessionToken}
+      `.trim()
+      );
+      await fromIni()();
+      expect(fromSSO).not.toHaveBeenCalled();
+    });
+
+    it("should throw if profile is configured with incomplete SSO credential", async () => {
+      (isSsoProfile as unknown as jest.Mock).mockImplementationOnce(() => true);
+      const originalValidator = jest.requireActual("@aws-sdk/credential-provider-sso").validateSsoProfile;
+      (validateSsoProfile as unknown as jest.Mock).mockImplementationOnce(originalValidator);
+      __addMatcher(
+        DEFAULT_PATH,
+        `[default]
+sso_account_id = 1234567890
+sso_start_url = https://example.com/sso/
+      `.trim()
+      );
+      try {
+        await fromIni()();
+      } catch (e) {
+        console.error(e.message);
+        expect(e.message).toEqual(expect.stringContaining("Profile is configured with invalid SSO credentials"));
+      }
+    });
+
+    it("should resolve valid SSO credential", async () => {
+      (isSsoProfile as unknown as jest.Mock).mockImplementationOnce(() => true);
+      const originalValidator = jest.requireActual("@aws-sdk/credential-provider-sso").validateSsoProfile;
+      (validateSsoProfile as jest.Mock).mockImplementationOnce(originalValidator);
+      (fromSSO as jest.Mock).mockImplementationOnce(() => async () => DEFAULT_CREDS);
+      const accountId = "1234567890";
+      const startUrl = "https://example.com/sso/";
+      const region = "us-east-1";
+      const roleName = "role";
+      __addMatcher(
+        DEFAULT_PATH,
+        `[default]
+sso_account_id = ${accountId}
+sso_start_url = ${startUrl}
+sso_region = ${region}
+sso_role_name = ${roleName}
+      `.trim()
+      );
+      await fromIni()();
+      expect(fromSSO as unknown as jest.Mock).toBeCalledWith({
+        ssoAccountId: accountId,
+        ssoStartUrl: startUrl,
+        ssoRegion: region,
+        ssoRoleName: roleName,
+      });
+    });
+
+    it("should call fromTokenFile with assume role chaining", async () => {
+      (isSsoProfile as unknown as jest.Mock).mockImplementationOnce(
+        jest.requireActual("@aws-sdk/credential-provider-sso").isSsoProfile
+      );
+      (validateSsoProfile as unknown as jest.Mock).mockImplementationOnce(
+        jest.requireActual("@aws-sdk/credential-provider-sso").validateSsoProfile
+      );
+      (fromSSO as jest.Mock).mockImplementationOnce(() => async () => DEFAULT_CREDS);
+      const accountId = "1234567890";
+      const startUrl = "https://example.com/sso/";
+      const region = "us-east-1";
+      const roleName = "role";
+      const roleAssumerWithWebIdentity = jest.fn();
+
+      const fooRoleArn = "arn:aws:iam::123456789:role/foo";
+      const fooSessionName = "fooSession";
+      __addMatcher(
+        DEFAULT_PATH,
+        `
+[bar]
+sso_account_id = ${accountId}
+sso_start_url = ${startUrl}
+sso_region = ${region}
+sso_role_name = ${roleName}
+
+[foo]
+role_arn = ${fooRoleArn}
+role_session_name = ${fooSessionName}
+source_profile = bar`.trim()
+      );
+
+      const provider = fromIni({
+        profile: "foo",
+        roleAssumer(sourceCreds: Credentials, params: AssumeRoleParams): Promise<Credentials> {
+          expect(sourceCreds).toEqual(DEFAULT_CREDS);
+          expect(params.RoleArn).toEqual(fooRoleArn);
+          expect(params.RoleSessionName).toEqual(fooSessionName);
+          return Promise.resolve(FOO_CREDS);
+        },
+        roleAssumerWithWebIdentity,
+      });
+
+      expect(await provider()).toEqual(FOO_CREDS);
+      expect(fromSSO).toHaveBeenCalledTimes(1);
+      expect(fromSSO).toHaveBeenCalledWith({
+        ssoAccountId: accountId,
+        ssoStartUrl: startUrl,
+        ssoRegion: region,
+        ssoRoleName: roleName,
       });
     });
   });

--- a/packages/credential-provider-ini/src/index.spec.ts
+++ b/packages/credential-provider-ini/src/index.spec.ts
@@ -3,9 +3,10 @@ import { fromContainerMetadata, fromInstanceMetadata } from "@aws-sdk/credential
 import { fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
 import { ENV_CONFIG_PATH, ENV_CREDENTIALS_PATH } from "@aws-sdk/shared-ini-file-loader";
 import { Credentials } from "@aws-sdk/types";
+import { ENV_PROFILE } from "@aws-sdk/util-credentials";
 import { join, sep } from "path";
 
-import { AssumeRoleParams, ENV_PROFILE, fromIni } from "./";
+import { AssumeRoleParams, fromIni } from "./";
 
 jest.mock("fs", () => {
   interface FsModule {

--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -2,16 +2,10 @@ import { fromEnv } from "@aws-sdk/credential-provider-env";
 import { fromContainerMetadata, fromInstanceMetadata } from "@aws-sdk/credential-provider-imds";
 import { AssumeRoleWithWebIdentityParams, fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import {
-  loadSharedConfigFiles,
-  ParsedIniData,
-  Profile,
-  SharedConfigFiles,
-  SharedConfigInit,
-} from "@aws-sdk/shared-ini-file-loader";
+import { ParsedIniData, Profile } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
+import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/util-credentials";
 
-const DEFAULT_PROFILE = "default";
 export const ENV_PROFILE = "AWS_PROFILE";
 
 /**
@@ -45,21 +39,6 @@ export interface AssumeRoleParams {
    * The value provided by the MFA device.
    */
   TokenCode?: string;
-}
-
-export interface SourceProfileInit extends SharedConfigInit {
-  /**
-   * The configuration profile to use.
-   */
-  profile?: string;
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
 }
 
 export interface FromIniInit extends SourceProfileInit {
@@ -152,28 +131,6 @@ export const fromIni =
     const profiles = await parseKnownFiles(init);
     return resolveProfileData(getMasterProfileName(init), profiles, init);
   };
-
-/**
- * Load profiles from credentials and config INI files and normalize them into a
- * single profile list.
- *
- * @internal
- */
-export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
-  const { loadedConfig = loadSharedConfigFiles(init) } = init;
-
-  const parsedFiles = await loadedConfig;
-  return {
-    ...parsedFiles.configFile,
-    ...parsedFiles.credentialsFile,
-  };
-};
-
-/**
- * @internal
- */
-export const getMasterProfileName = (init: { profile?: string }): string =>
-  init.profile || process.env[ENV_PROFILE] || DEFAULT_PROFILE;
 
 const resolveProfileData = async (
   profileName: string,

--- a/packages/credential-provider-ini/src/index.ts
+++ b/packages/credential-provider-ini/src/index.ts
@@ -146,16 +146,6 @@ const resolveProfileData = async (
     return resolveStaticCredentials(data);
   }
 
-  if (isSsoProfile(data)) {
-    const { sso_start_url, sso_account_id, sso_region, sso_role_name } = validateSsoProfile(data);
-    return fromSSO({
-      ssoStartUrl: sso_start_url,
-      ssoAccountId: sso_account_id,
-      ssoRegion: sso_region,
-      ssoRoleName: sso_role_name,
-    })();
-  }
-
   // If this is the first profile visited, role assumption keys should be
   // given precedence over static credentials.
   if (isAssumeRoleWithSourceProfile(data) || isAssumeRoleWithProviderProfile(data)) {
@@ -216,6 +206,15 @@ const resolveProfileData = async (
   // web identity if web_identity_token_file and role_arn is available
   if (isWebIdentityProfile(data)) {
     return resolveWebIdentityCredentials(data, options);
+  }
+  if (isSsoProfile(data)) {
+    const { sso_start_url, sso_account_id, sso_region, sso_role_name } = validateSsoProfile(data);
+    return fromSSO({
+      ssoStartUrl: sso_start_url,
+      ssoAccountId: sso_account_id,
+      ssoRegion: sso_region,
+      ssoRoleName: sso_role_name,
+    })();
   }
 
   // If the profile cannot be parsed or contains neither static credentials

--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -27,8 +27,9 @@ jest.mock("@aws-sdk/credential-provider-ini", () => {
     fromIni: jest.fn().mockReturnValue(iniProvider),
   };
 });
-import { ENV_PROFILE, fromIni, FromIniInit } from "@aws-sdk/credential-provider-ini";
+import { fromIni, FromIniInit } from "@aws-sdk/credential-provider-ini";
 import { ENV_CONFIG_PATH, ENV_CREDENTIALS_PATH } from "@aws-sdk/shared-ini-file-loader";
+import { ENV_PROFILE } from "@aws-sdk/util-credentials";
 
 jest.mock("@aws-sdk/credential-provider-process", () => {
   const processProvider = jest.fn();

--- a/packages/credential-provider-node/src/index.ts
+++ b/packages/credential-provider-node/src/index.ts
@@ -6,13 +6,14 @@ import {
   fromInstanceMetadata,
   RemoteProviderInit,
 } from "@aws-sdk/credential-provider-imds";
-import { ENV_PROFILE, fromIni, FromIniInit } from "@aws-sdk/credential-provider-ini";
+import { fromIni, FromIniInit } from "@aws-sdk/credential-provider-ini";
 import { fromProcess, FromProcessInit } from "@aws-sdk/credential-provider-process";
 import { fromSSO, FromSSOInit } from "@aws-sdk/credential-provider-sso";
 import { fromTokenFile, FromTokenFileInit } from "@aws-sdk/credential-provider-web-identity";
 import { chain, CredentialsProviderError, memoize } from "@aws-sdk/property-provider";
 import { loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider } from "@aws-sdk/types";
+import { ENV_PROFILE } from "@aws-sdk/util-credentials";
 
 export const ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
 

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -21,10 +21,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/credential-provider-ini": "3.20.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/shared-ini-file-loader": "3.20.0",
     "@aws-sdk/types": "3.20.0",
+    "@aws-sdk/util-credentials": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-process/src/index.ts
+++ b/packages/credential-provider-process/src/index.ts
@@ -1,7 +1,7 @@
-import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/credential-provider-ini";
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { ParsedIniData } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
+import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/util-credentials";
 import { exec } from "child_process";
 
 /**

--- a/packages/credential-provider-sso/README.md
+++ b/packages/credential-provider-sso/README.md
@@ -6,20 +6,37 @@
 ## AWS Credential Provider for Node.js - AWS Single Sign-On (SSO)
 
 This module provides a function, `fromSSO`, that creates
-`CredentialProvider` functions that read from [AWS SDKs and Tools
-shared configuration and credentials
-files](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
-Profiles in the `credentials` file are given precedence over
-profiles in the `config` file. This provider loads the
+`CredentialProvider` functions that read from the
 _resolved_ access token from local disk then requests temporary AWS
 credentials. For guidance on the AWS Single Sign-On service, please
 refer to [AWS's Single Sign-On documentation](https://aws.amazon.com/single-sign-on/).
+
+You can create the `CredentialProvider` functions using the inline SSO
+parameters(`ssoStartUrl`, `ssoAccountId`, `ssoRegion`, `ssoRoleName`) or load
+them from [AWS SDKs and Tools shared configuration and credentials files](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html).
+Profiles in the `credentials` file are given precedence over
+profiles in the `config` file.
+
+This credential provider is intended for use with the AWS SDK for Node.js.
+
+This credential provider **ONLY** supports profiles using the SSO credential. If
+you have a profile that assumes a role which derived from the SSO credential,
+you should use the `@aws-sdk/credential-provider-ini`, or
+`@aws-sdk/credential-provider-node` package.
 
 ## Supported configuration
 
 You may customize how credentials are resolved by providing an options hash to
 the `fromSSO` factory function. The following options are supported:
 
+- `ssoStartUrl`: The URL to the AWS SSO service. Required if any of the `sso*`
+  options(except for `ssoClient`) is provided.
+- `ssoAccountId`: The ID of the AWS account to use for temporary credentials.
+  Required if any of the `sso*` options(except for `ssoClient`) is provided.
+- `ssoRegion`: The AWS region to use for temporary credentials. Required if any
+  of the `sso*` options(except for `ssoClient`) is provided.
+- `ssoRoleName`: The name of the AWS role to assume. Required if any of the
+  `sso*` options(except for `ssoClient`) is provided.
 - `profile` - The configuration profile to use. If not specified, the provider
   will use the value in the `AWS_PROFILE` environment variable or `default` by
   default.

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -22,10 +22,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-sso": "3.21.0",
-    "@aws-sdk/credential-provider-ini": "3.20.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/shared-ini-file-loader": "3.20.0",
     "@aws-sdk/types": "3.20.0",
+    "@aws-sdk/util-credentials": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-sso/src/index.spec.ts
+++ b/packages/credential-provider-sso/src/index.spec.ts
@@ -2,10 +2,10 @@ jest.useFakeTimers("modern");
 const now = 1613699814645;
 jest.setSystemTime(now);
 
-const mockParseKnowFiles = jest.fn();
+const mockParseKnownFiles = jest.fn();
 const mockGetMasterProfileName = jest.fn();
 jest.mock("@aws-sdk/credential-provider-ini", () => ({
-  parseKnownFiles: mockParseKnowFiles,
+  parseKnownFiles: mockParseKnownFiles,
   getMasterProfileName: mockGetMasterProfileName,
 }));
 
@@ -36,170 +36,232 @@ const toRFC3339String = (date: number): string => {
   return timestamp.replace(/\.[\d]+Z$/, "Z");
 };
 
-describe("fromSSO", () => {
-  const ssoConfig = {
-    sso_start_url: "https:some-url/start",
-    sso_account_id: "1234567890",
-    sso_region: "us-foo-1",
-    sso_role_name: "some-role",
-  };
+describe("fromSSO()", () => {
+  const ssoStartUrl = "https:some-url/start";
+  const ssoAccountId = "1234567890";
+  const ssoRegion = "us-foo-1";
+  const ssoRoleName = "some-role";
   const token = {
-    startUrl: ssoConfig.sso_start_url,
-    region: ssoConfig.sso_region,
+    startUrl: ssoStartUrl,
+    region: ssoRegion,
     accessToken: "base64 encoded string",
     expiresAt: toRFC3339String(now + 60 * 60 * 1000),
   };
+
   beforeEach(() => {
-    mockParseKnowFiles.mockClear();
+    mockParseKnownFiles.mockClear();
     mockGetMasterProfileName.mockClear();
     mockReadFileSync.mockClear();
     mockSSOSend.mockClear();
   });
 
-  it("should fetch credentials from resolved token file", async () => {
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
-    mockGetMasterProfileName.mockReturnValue("default");
-    mockReadFileSync.mockReturnValue(JSON.stringify(token));
-    const { roleCredentials } = mockRoleCredentials;
-    expect(await fromSSO()()).toEqual({ ...roleCredentials, expiration: new Date(roleCredentials.expiration) });
-    expect(mockReadFileSync.mock.calls[0][0]).toEqual(
-      expect.stringMatching(/fcab95d6966151d97d9ee7776a90d895b5e5fbe6.json$/)
-    );
-    expect(mockReadFileSync.mock.calls[0][1]).toMatchObject({ encoding: "utf-8" });
-    expect(mockGetRoleCredentialsCommand).toHaveBeenCalledWith({
-      accountId: ssoConfig.sso_account_id,
-      roleName: ssoConfig.sso_role_name,
-      accessToken: token.accessToken,
+  describe("load from shared config file", () => {
+    const ssoConfig = {
+      sso_start_url: ssoStartUrl,
+      sso_account_id: ssoAccountId,
+      sso_region: ssoRegion,
+      sso_role_name: ssoRoleName,
+    };
+
+    it("should fetch credentials from resolved token file", async () => {
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
+      mockGetMasterProfileName.mockReturnValue("default");
+      mockReadFileSync.mockReturnValue(JSON.stringify(token));
+      const { roleCredentials } = mockRoleCredentials;
+      expect(await fromSSO()()).toEqual({ ...roleCredentials, expiration: new Date(roleCredentials.expiration) });
+      expect(mockReadFileSync.mock.calls[0][0]).toEqual(
+        expect.stringMatching(/fcab95d6966151d97d9ee7776a90d895b5e5fbe6.json$/)
+      );
+      expect(mockReadFileSync.mock.calls[0][1]).toMatchObject({ encoding: "utf-8" });
+      expect(mockGetRoleCredentialsCommand).toHaveBeenCalledWith({
+        accountId: ssoConfig.sso_account_id,
+        roleName: ssoConfig.sso_role_name,
+        accessToken: token.accessToken,
+      });
     });
-  });
 
-  it("should allow supplying custom client", async () => {
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
-    mockGetMasterProfileName.mockReturnValue("default");
-    mockReadFileSync.mockReturnValue(JSON.stringify(token));
-    const newSSOClient = { send: jest.fn().mockReturnValue(Promise.resolve(mockRoleCredentials)) };
-    //@ts-expect-error
-    await fromSSO({ ssoClient: newSSOClient })();
-    expect(newSSOClient.send).toHaveBeenCalled();
-    expect(mockSSOSend).not.toHaveBeenCalled();
-  });
-
-  it("should throw if profile doesn't exist in the config files", () => {
-    const profile = "exist";
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ non_exist: { foo: "bar" } }));
-    mockGetMasterProfileName.mockReturnValue(profile);
-    return expect(async () => {
-      await fromSSO()();
-    }).rejects.toMatchObject({
-      message: `Profile ${profile} could not be found in shared credentials file.`,
-      tryNextLink: true,
+    it("should allow supplying custom client", async () => {
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
+      mockGetMasterProfileName.mockReturnValue("default");
+      mockReadFileSync.mockReturnValue(JSON.stringify(token));
+      const newSSOClient = { send: jest.fn().mockReturnValue(Promise.resolve(mockRoleCredentials)) };
+      //@ts-expect-error
+      await fromSSO({ ssoClient: newSSOClient })();
+      expect(newSSOClient.send).toHaveBeenCalled();
+      expect(mockSSOSend).not.toHaveBeenCalled();
     });
-  });
 
-  it("should throw if profile is not configured with SSO credential", () => {
-    const profile = "exist";
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ [profile]: { foo: "bar" } }));
-    mockGetMasterProfileName.mockReturnValue(profile);
-    return expect(async () => {
-      await fromSSO()();
-    }).rejects.toMatchObject({
-      message: `Profile ${profile} is not configured with SSO credentials.`,
-      tryNextLink: true,
+    it("should throw if profile doesn't exist in the config files", () => {
+      const profile = "exist";
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ non_exist: { foo: "bar" } }));
+      mockGetMasterProfileName.mockReturnValue(profile);
+      return expect(async () => {
+        await fromSSO()();
+      }).rejects.toMatchObject({
+        name: "CredentialsProviderError",
+        message: expect.stringContaining("Profile exist is not configured with SSO credentials"),
+        tryNextLink: true,
+      });
     });
-  });
 
-  for (let i = 0; i < Object.keys(ssoConfig).length; i++) {
-    const keyToRemove = Object.keys(ssoConfig)[i];
-    it(`should throw if sso configuration is missing ${keyToRemove}`, async () => {
+    it("should throw if profile is not configured with SSO credential", () => {
+      const profile = "exist";
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ [profile]: { foo: "bar" } }));
+      mockGetMasterProfileName.mockReturnValue(profile);
+      return expect(async () => {
+        await fromSSO()();
+      }).rejects.toMatchObject({
+        message: `Profile ${profile} is not configured with SSO credentials.`,
+        tryNextLink: true,
+      });
+    });
+
+    it.each(Object.keys(ssoConfig))("should throw if sso configuration is missing %s", async (keyToRemove) => {
       expect.assertions(2);
       const config = { ...ssoConfig };
       //@ts-ignore
       delete config[keyToRemove];
-      mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: config }));
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: config }));
       mockGetMasterProfileName.mockReturnValue("default");
       try {
         await fromSSO()();
       } catch (e) {
-        expect(e.message).toContain("Profile default does not have valid SSO credentials.");
+        expect(e.message).toContain("Profile is configured with invalid SSO credentials.");
         expect(e.tryNextLink).toBeFalsy();
       }
     });
-  }
 
-  it("should throw if token cache file is not found", async () => {
-    expect.assertions(2);
-    mockReadFileSync.mockImplementation(() => {
-      throw new Error("File not found.");
+    it("should throw if token cache file is not found", async () => {
+      expect.assertions(2);
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error("File not found.");
+      });
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
+      mockGetMasterProfileName.mockReturnValue("default");
+      try {
+        await fromSSO()();
+      } catch (e) {
+        expect(e.message).toContain(
+          "The SSO session associated with this profile has expired or is otherwise invalid."
+        );
+        expect(e.tryNextLink).toBeFalsy();
+      }
     });
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
-    mockGetMasterProfileName.mockReturnValue("default");
-    try {
-      await fromSSO()();
-    } catch (e) {
-      expect(e.message).toContain("The SSO session associated with this profile has expired or is otherwise invalid.");
-      expect(e.tryNextLink).toBeFalsy();
-    }
-  });
 
-  it("should throw if token cache file is invalid", async () => {
-    expect.assertions(2);
-    mockReadFileSync.mockReturnValue("invalid JSON content");
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
-    mockGetMasterProfileName.mockReturnValue("default");
-    try {
-      await fromSSO()();
-    } catch (e) {
-      expect(e.message).toContain("The SSO session associated with this profile has expired or is otherwise invalid.");
-      expect(e.tryNextLink).toBeFalsy();
-    }
-  });
-
-  it("should throw if token cache is expired", async () => {
-    expect.assertions(2);
-    mockReadFileSync.mockReturnValue({ ...token, expiration: toRFC3339String(now + EXPIRE_WINDOW_MS - 2) });
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
-    mockGetMasterProfileName.mockReturnValue("default");
-    try {
-      await fromSSO()();
-    } catch (e) {
-      expect(e.message).toContain("The SSO session associated with this profile has expired or is otherwise invalid.");
-      expect(e.tryNextLink).toBeFalsy();
-    }
-  });
-
-  it("should throw if SSO client throws", async () => {
-    expect.assertions(3);
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
-    mockGetMasterProfileName.mockReturnValue("default");
-    mockReadFileSync.mockReturnValue(JSON.stringify(token));
-    const clientError = new Error("No account is found for the user");
-    //@ts-ignore
-    clientError.$fault = "client";
-    mockSSOSend.mockImplementation(async () => {
-      throw clientError;
+    it("should throw if token cache file is invalid", async () => {
+      expect.assertions(2);
+      mockReadFileSync.mockReturnValue("invalid JSON content");
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
+      mockGetMasterProfileName.mockReturnValue("default");
+      try {
+        await fromSSO()();
+      } catch (e) {
+        expect(e.message).toContain(
+          "The SSO session associated with this profile has expired or is otherwise invalid."
+        );
+        expect(e.tryNextLink).toBeFalsy();
+      }
     });
-    try {
-      await fromSSO()();
-    } catch (e) {
-      expect(e.message).toContain(clientError.message);
-      expect(e.tryNextLink).toBeFalsy();
-      expect(e.$fault).toBe("client");
-    }
+
+    it("should throw if token cache is expired", async () => {
+      expect.assertions(2);
+      mockReadFileSync.mockReturnValue({ ...token, expiration: toRFC3339String(now + EXPIRE_WINDOW_MS - 2) });
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
+      mockGetMasterProfileName.mockReturnValue("default");
+      try {
+        await fromSSO()();
+      } catch (e) {
+        expect(e.message).toContain(
+          "The SSO session associated with this profile has expired or is otherwise invalid."
+        );
+        expect(e.tryNextLink).toBeFalsy();
+      }
+    });
+
+    it("should throw if SSO client throws", async () => {
+      expect.assertions(3);
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
+      mockGetMasterProfileName.mockReturnValue("default");
+      mockReadFileSync.mockReturnValue(JSON.stringify(token));
+      const clientError = new Error("No account is found for the user");
+      //@ts-ignore
+      clientError.$fault = "client";
+      mockSSOSend.mockImplementation(async () => {
+        throw clientError;
+      });
+      try {
+        await fromSSO()();
+      } catch (e) {
+        expect(e.message).toContain(clientError.message);
+        expect(e.tryNextLink).toBeFalsy();
+        expect(e.$fault).toBe("client");
+      }
+    });
+
+    it("should throw if credentials from SSO client is invalid", async () => {
+      expect.assertions(2);
+      mockReadFileSync.mockReturnValue(JSON.stringify(token));
+      mockParseKnownFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
+      mockGetMasterProfileName.mockReturnValue("default");
+      mockSSOSend.mockResolvedValue({
+        roleCredentials: { ...mockRoleCredentials.roleCredentials, accessKeyId: undefined },
+      });
+      try {
+        await fromSSO()();
+      } catch (e) {
+        expect(e.message).toContain("SSO returns an invalid temporary credential.");
+        expect(e.tryNextLink).toBeFalsy();
+      } finally {
+        mockSSOSend.mockResolvedValue(mockRoleCredentials);
+      }
+    });
   });
 
-  it("should throw if credentials from SSO client is invalid", async () => {
-    expect.assertions(2);
-    mockReadFileSync.mockReturnValue(JSON.stringify(token));
-    mockParseKnowFiles.mockReturnValue(Promise.resolve({ default: ssoConfig }));
-    mockGetMasterProfileName.mockReturnValue("default");
-    mockSSOSend.mockResolvedValue({
-      roleCredentials: { ...mockRoleCredentials.roleCredentials, accessKeyId: undefined },
+  describe("load with sso parameters", () => {
+    it("should fetch credentials from resolved token file without reading shared config file", async () => {
+      mockParseKnownFiles.mockRejectedValue("Should not call parseKnownFiles()");
+      mockGetMasterProfileName.mockRejectedValue("Should not call getMasterProfileName()");
+      mockReadFileSync.mockReturnValue(JSON.stringify(token));
+      const { roleCredentials } = mockRoleCredentials;
+      expect(
+        await fromSSO({
+          ssoStartUrl,
+          ssoAccountId,
+          ssoRegion,
+          ssoRoleName,
+        })()
+      ).toEqual({ ...roleCredentials, expiration: new Date(roleCredentials.expiration) });
+      expect(mockReadFileSync.mock.calls[0][0]).toEqual(
+        expect.stringMatching(/fcab95d6966151d97d9ee7776a90d895b5e5fbe6.json$/)
+      );
+      expect(mockReadFileSync.mock.calls[0][1]).toMatchObject({ encoding: "utf-8" });
+      expect(mockGetRoleCredentialsCommand).toHaveBeenCalledWith({
+        accountId: ssoAccountId,
+        roleName: ssoRoleName,
+        accessToken: token.accessToken,
+      });
     });
-    try {
-      await fromSSO()();
-    } catch (e) {
-      expect(e.message).toContain("SSO returns an invalid temporary credential.");
-      expect(e.tryNextLink).toBeFalsy();
-    }
+
+    it.each(["ssoStartUrl", "ssoAccountId", "ssoRegion", "ssoRoleName"])(
+      "should throw for incomplete sso parameters(missing %s)",
+      (undefinedKey) => {
+        mockParseKnownFiles.mockRejectedValue("Should not call parseKnownFiles()");
+        mockGetMasterProfileName.mockRejectedValue("Should not call getMasterProfileName()");
+        mockReadFileSync.mockReturnValue(JSON.stringify(token));
+        return expect(
+          async () =>
+            await fromSSO({
+              ssoStartUrl,
+              ssoAccountId,
+              ssoRegion,
+              ssoRoleName,
+              ...{ [undefinedKey]: undefined },
+            } as any)()
+        ).rejects.toMatchObject({
+          name: "CredentialsProviderError",
+          message: expect.stringMatching("Incomplete configuration"),
+        });
+      }
+    );
   });
 });

--- a/packages/credential-provider-sso/src/index.spec.ts
+++ b/packages/credential-provider-sso/src/index.spec.ts
@@ -4,7 +4,7 @@ jest.setSystemTime(now);
 
 const mockParseKnownFiles = jest.fn();
 const mockGetMasterProfileName = jest.fn();
-jest.mock("@aws-sdk/credential-provider-ini", () => ({
+jest.mock("@aws-sdk/util-credentials", () => ({
   parseKnownFiles: mockParseKnownFiles,
   getMasterProfileName: mockGetMasterProfileName,
 }));

--- a/packages/credential-provider-sso/src/index.ts
+++ b/packages/credential-provider-sso/src/index.ts
@@ -30,9 +30,24 @@ interface SSOToken {
 }
 
 export interface SsoCredentialsParameters {
+  /**
+   * The URL to the AWS SSO service.
+   */
   ssoStartUrl: string;
+
+  /**
+   * The ID of the AWS account to use for temporary credentials.
+   */
   ssoAccountId: string;
+
+  /**
+   * The AWS region to use for temporary credentials.
+   */
   ssoRegion: string;
+
+  /**
+   * The name of the AWS role to assume.
+   */
   ssoRoleName: string;
 }
 export interface FromSSOInit extends SourceProfileInit {

--- a/packages/credential-provider-sso/src/index.ts
+++ b/packages/credential-provider-sso/src/index.ts
@@ -1,8 +1,8 @@
 import { GetRoleCredentialsCommand, GetRoleCredentialsCommandOutput, SSOClient } from "@aws-sdk/client-sso";
-import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/credential-provider-ini";
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import { getHomeDir, ParsedIniData } from "@aws-sdk/shared-ini-file-loader";
+import { getHomeDir, Profile } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
+import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/util-credentials";
 import { createHash } from "crypto";
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -29,6 +29,12 @@ interface SSOToken {
   startUrl?: string;
 }
 
+export interface SsoCredentialsParameters {
+  ssoStartUrl: string;
+  ssoAccountId: string;
+  ssoRegion: string;
+  ssoRoleName: string;
+}
 export interface FromSSOInit extends SourceProfileInit {
   ssoClient?: SSOClient;
 }
@@ -38,34 +44,44 @@ export interface FromSSOInit extends SourceProfileInit {
  * in ini files.
  */
 export const fromSSO =
-  (init: FromSSOInit = {}): CredentialProvider =>
+  (init: FromSSOInit & Partial<SsoCredentialsParameters> = {} as any): CredentialProvider =>
   async () => {
-    const profiles = await parseKnownFiles(init);
-    return resolveSSOCredentials(getMasterProfileName(init), profiles, init);
+    const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoClient } = init;
+    if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName) {
+      // Load the SSO config from shared AWS config file.
+      const profiles = await parseKnownFiles(init);
+      const profileName = getMasterProfileName(init);
+      const profile = profiles[profileName];
+      if (!isSsoProfile(profile)) {
+        throw new CredentialsProviderError(`Profile ${profileName} is not configured with SSO credentials.`);
+      }
+      const { sso_start_url, sso_account_id, sso_region, sso_role_name } = validateSsoProfile(profile);
+      return resolveSSOCredentials({
+        ssoStartUrl: sso_start_url,
+        ssoAccountId: sso_account_id,
+        ssoRegion: sso_region,
+        ssoRoleName: sso_role_name,
+        ssoClient: ssoClient,
+      });
+    } else if (!ssoStartUrl || !ssoAccountId || !ssoRegion || !ssoRoleName) {
+      throw new CredentialsProviderError(
+        'Incomplete configuration. The fromSSO() argument hash must include "ssoStartUrl",' +
+          ' "ssoAccountId", "ssoRegion", "ssoRoleName"'
+      );
+    } else {
+      return resolveSSOCredentials({ ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoClient });
+    }
   };
 
-const resolveSSOCredentials = async (
-  profileName: string,
-  profiles: ParsedIniData,
-  options: FromSSOInit
-): Promise<Credentials> => {
-  const profile = profiles[profileName];
-  if (!profile) {
-    throw new CredentialsProviderError(`Profile ${profileName} could not be found in shared credentials file.`);
-  }
-  const { sso_start_url: startUrl, sso_account_id: accountId, sso_region: region, sso_role_name: roleName } = profile;
-  if (!startUrl && !accountId && !region && !roleName) {
-    throw new CredentialsProviderError(`Profile ${profileName} is not configured with SSO credentials.`);
-  }
-  if (!startUrl || !accountId || !region || !roleName) {
-    throw new CredentialsProviderError(
-      `Profile ${profileName} does not have valid SSO credentials. Required parameters "sso_account_id", "sso_region", ` +
-        `"sso_role_name", "sso_start_url". Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
-      SHOULD_FAIL_CREDENTIAL_CHAIN
-    );
-  }
+const resolveSSOCredentials = async ({
+  ssoStartUrl,
+  ssoAccountId,
+  ssoRegion,
+  ssoRoleName,
+  ssoClient,
+}: FromSSOInit & SsoCredentialsParameters): Promise<Credentials> => {
   const hasher = createHash("sha1");
-  const cacheName = hasher.update(startUrl).digest("hex");
+  const cacheName = hasher.update(ssoStartUrl).digest("hex");
   const tokenFile = join(getHomeDir(), ".aws", "sso", "cache", `${cacheName}.json`);
   let token: SSOToken;
   try {
@@ -81,13 +97,13 @@ const resolveSSOCredentials = async (
     );
   }
   const { accessToken } = token;
-  const sso = options.ssoClient || new SSOClient({ region });
+  const sso = ssoClient || new SSOClient({ region: ssoRegion });
   let ssoResp: GetRoleCredentialsCommandOutput;
   try {
     ssoResp = await sso.send(
       new GetRoleCredentialsCommand({
-        accountId,
-        roleName,
+        accountId: ssoAccountId,
+        roleName: ssoRoleName,
         accessToken,
       })
     );
@@ -100,3 +116,40 @@ const resolveSSOCredentials = async (
   }
   return { accessKeyId, secretAccessKey, sessionToken, expiration: new Date(expiration) };
 };
+
+/**
+ * @internal
+ */
+export interface SsoProfile extends Profile {
+  sso_start_url: string;
+  sso_account_id: string;
+  sso_region: string;
+  sso_role_name: string;
+}
+
+/**
+ * @internal
+ */
+export const validateSsoProfile = (profile: Partial<SsoProfile>): SsoProfile => {
+  const { sso_start_url, sso_account_id, sso_region, sso_role_name } = profile;
+  if (!sso_start_url || !sso_account_id || !sso_region || !sso_role_name) {
+    throw new CredentialsProviderError(
+      `Profile is configured with invalid SSO credentials. Required parameters "sso_account_id", "sso_region", ` +
+        `"sso_role_name", "sso_start_url". Got ${Object.keys(profile).join(
+          ", "
+        )}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
+      SHOULD_FAIL_CREDENTIAL_CHAIN
+    );
+  }
+  return profile as SsoProfile;
+};
+
+/**
+ * @internal
+ */
+export const isSsoProfile = (arg: Profile): arg is Partial<SsoProfile> =>
+  arg &&
+  (typeof arg.sso_start_url === "string" ||
+    typeof arg.sso_account_id === "string" ||
+    typeof arg.sso_region === "string" ||
+    typeof arg.sso_role_name === "string");

--- a/packages/util-credentials/LICENSE
+++ b/packages/util-credentials/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/util-credentials/LICENSE
+++ b/packages/util-credentials/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/util-credentials/README.md
+++ b/packages/util-credentials/README.md
@@ -1,0 +1,12 @@
+# @aws-sdk/util-credentials
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-sso/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-sso)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-sso.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-sso)
+
+> An internal package
+
+This package provides shared utilities for all credential providers.
+
+## Usage
+
+You probably shouldn't, at least directly.

--- a/packages/util-credentials/README.md
+++ b/packages/util-credentials/README.md
@@ -1,7 +1,7 @@
 # @aws-sdk/util-credentials
 
-[![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-sso/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-sso)
-[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-sso.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-sso)
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-credentials/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-credentials)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-credentials.svg)](https://www.npmjs.com/package/@aws-sdk/util-credentials)
 
 > An internal package
 

--- a/packages/util-credentials/jest.config.js
+++ b/packages/util-credentials/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -22,7 +22,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/shared-ini-file-loader": "3.20.0",
-    "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@aws-sdk/credential-provider-ini",
-  "version": "3.20.0",
-  "description": "AWS credential provider that sources credentials from ~/.aws/credentials and ~/.aws/config",
+  "name": "@aws-sdk/util-credentials",
+  "version": "3.0.0",
+  "description": "Shared utilities for all credential providers.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
@@ -21,13 +21,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/credential-provider-env": "3.20.0",
-    "@aws-sdk/credential-provider-imds": "3.20.0",
-    "@aws-sdk/credential-provider-web-identity": "3.20.0",
-    "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/shared-ini-file-loader": "3.20.0",
     "@aws-sdk/types": "3.20.0",
-    "@aws-sdk/util-credentials": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
@@ -47,10 +42,10 @@
       ]
     }
   },
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-provider-ini",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-credentials",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
-    "directory": "packages/credential-provider-ini"
+    "directory": "packages/util-credentials"
   }
 }

--- a/packages/util-credentials/src/index.ts
+++ b/packages/util-credentials/src/index.ts
@@ -1,0 +1,46 @@
+import {
+  loadSharedConfigFiles,
+  ParsedIniData,
+  SharedConfigFiles,
+  SharedConfigInit,
+} from "@aws-sdk/shared-ini-file-loader";
+
+export const ENV_PROFILE = "AWS_PROFILE";
+export const DEFAULT_PROFILE = "default";
+
+export interface SourceProfileInit extends SharedConfigInit {
+  /**
+   * The configuration profile to use.
+   */
+  profile?: string;
+
+  /**
+   * A promise that will be resolved with loaded and parsed credentials files.
+   * Used to avoid loading shared config files multiple times.
+   *
+   * @internal
+   */
+  loadedConfig?: Promise<SharedConfigFiles>;
+}
+
+/**
+ * Load profiles from credentials and config INI files and normalize them into a
+ * single profile list.
+ *
+ * @internal
+ */
+export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
+  const { loadedConfig = loadSharedConfigFiles(init) } = init;
+
+  const parsedFiles = await loadedConfig;
+  return {
+    ...parsedFiles.configFile,
+    ...parsedFiles.credentialsFile,
+  };
+};
+
+/**
+ * @internal
+ */
+export const getMasterProfileName = (init: { profile?: string }): string =>
+  init.profile || process.env[ENV_PROFILE] || DEFAULT_PROFILE;

--- a/packages/util-credentials/tsconfig.cjs.json
+++ b/packages/util-credentials/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/util-credentials/tsconfig.es.json
+++ b/packages/util-credentials/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}


### PR DESCRIPTION
Resolves #2504

### Description
* Add SSO credential support to INI credential provider. As a result, the SDK can follow the assume role chain specified in the shared `~/.aws/credentials` file, and assume the role derived from the SSO credential.
* The SSO credential provider supports specifying SSO parameters(e.g. start URL, account id, assume role name, region) in-line from the constructor parameters. If none of them is supplied, the provider will fall back to resolve the specified profile in the shared `~/.aws/credentials` file. **NOTE**: The SSO credential provider itself doesn't support assume role chain. It will fail if specified profile doesn't use a SSO credential
* Create an internal package `@aws-sdk/util-credentials` to host all the shared credential utilities. This is to optimize the dependency topology.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
