### PR TITLE
feat(postinstall-node-version-check): util to show NodeDeprecationWarning

### DIFF
--- a/packages/postinstall-node-version-check/.gitignore
+++ b/packages/postinstall-node-version-check/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/postinstall-node-version-check/.npmignore
+++ b/packages/postinstall-node-version-check/.npmignore
@@ -1,0 +1,14 @@
+/coverage/
+/docs/
+tsconfig.test.json
+*.tsbuildinfo
+jest.config.js
+
+*.spec.js
+*.spec.ts
+*.spec.d.ts
+*.spec.js.map
+
+*.fixture.js
+*.fixture.d.ts
+*.fixture.js.map

--- a/packages/postinstall-node-version-check/CHANGELOG.md
+++ b/packages/postinstall-node-version-check/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/postinstall-node-version-check/LICENSE
+++ b/packages/postinstall-node-version-check/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/postinstall-node-version-check/README.md
+++ b/packages/postinstall-node-version-check/README.md
@@ -1,0 +1,10 @@
+# @aws-sdk/postinstall-node-version-check
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/postinstall-node-version-check/latest.svg)](https://www.npmjs.com/package/@aws-sdk/postinstall-node-version-check)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/postinstall-node-version-check.svg)](https://www.npmjs.com/package/@aws-sdk/postinstall-node-version-check)
+
+> An internal package
+
+## Usage
+
+You probably shouldn't, at least directly.

--- a/packages/postinstall-node-version-check/jest.config.js
+++ b/packages/postinstall-node-version-check/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/postinstall-node-version-check/package.json
+++ b/packages/postinstall-node-version-check/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@aws-sdk/postinstall-node-version-check",
+  "version": "3.20.0",
+  "scripts": {
+    "build": "tsc -p tsconfig.cjs.json",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "test": "jest"
+  },
+  "bin": {
+    "postinstall-node-version-check": "dist/cjs/index.js"
+  },
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/types/index.d.ts",
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "@types/jest": "^26.0.4",
+    "jest": "^26.1.0",
+    "typescript": "~4.3.2"
+  },
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist/types/*": [
+        "dist/types/ts3.4/*"
+      ]
+    }
+  },
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/postinstall-node-version-check",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/postinstall-node-version-check"
+  }
+}

--- a/packages/postinstall-node-version-check/package.json
+++ b/packages/postinstall-node-version-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-sdk/postinstall-node-version-check",
-  "version": "3.20.0",
+  "version": "3.0.0",
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",

--- a/packages/postinstall-node-version-check/package.json
+++ b/packages/postinstall-node-version-check/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aws-sdk/postinstall-node-version-check",
   "version": "3.0.0",
+  "description": "Emits warning on postinstall if the Node.js version being used is nearing end-of-support.",
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",

--- a/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.spec.ts
@@ -34,7 +34,7 @@ describe(emitWarningIfUnsupportedVersion.name, () => {
           `no longer support Node.js ${unsupportedVersion} as of January 1, 2022.\n` +
           `To continue receiving updates to AWS services, bug fixes, and security\n` +
           `updates please upgrade to Node.js 12.x or later.\n\n` +
-          `More information can be found at: {LINK TO BLOG}`,
+          `More information can be found at: https://a.co/1l6FLnu`,
         `NodeDeprecationWarning`
       );
     });

--- a/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.spec.ts
@@ -1,0 +1,58 @@
+import { emitWarningIfUnsupportedVersion } from "./emitWarningIfUnsupportedVersion";
+
+describe(emitWarningIfUnsupportedVersion.name, () => {
+  const emitWarning = process.emitWarning;
+  const supportedVersion = "12.0.0";
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.emitWarning = emitWarning;
+  });
+
+  describe(`emits warning for Node.js <${supportedVersion}`, () => {
+    const getPreviousMajorVersion = (major: number) => (major === 0 ? 0 : major - 1);
+
+    const getPreviousMinorVersion = ([major, minor]: [number, number]) =>
+      minor === 0 ? [getPreviousMajorVersion(major), 9] : [major, minor - 1];
+
+    const getPreviousPatchVersion = ([major, minor, patch]: [number, number, number]) =>
+      patch === 0 ? [...getPreviousMinorVersion([major, minor]), 9] : [major, minor, patch - 1];
+
+    const [major, minor, patch] = supportedVersion.split(".").map(Number);
+    it.each(
+      [
+        getPreviousPatchVersion([major, minor, patch]),
+        [...getPreviousMinorVersion([major, minor]), 0],
+        [getPreviousMajorVersion(major), 0, 0],
+      ].map((arr) => `v${arr.join(".")}`)
+    )(`%s`, async (unsupportedVersion) => {
+      process.emitWarning = jest.fn();
+      emitWarningIfUnsupportedVersion(unsupportedVersion);
+      expect(process.emitWarning).toHaveBeenCalledTimes(1);
+      expect(process.emitWarning).toHaveBeenCalledWith(
+        `The AWS SDK for JavaScript (v3) will\n` +
+          `no longer support Node.js ${unsupportedVersion} as of January 1, 2022.\n` +
+          `To continue receiving updates to AWS services, bug fixes, and security\n` +
+          `updates please upgrade to Node.js 12.x or later.\n\n` +
+          `More information can be found at: {LINK TO BLOG}`,
+        `NodeDeprecationWarning`
+      );
+    });
+  });
+
+  describe(`emits no warning for Node.js >=${supportedVersion}`, () => {
+    const [major, minor, patch] = supportedVersion.split(".").map(Number);
+    it.each(
+      [
+        [major, minor, patch],
+        [major, minor, patch + 1],
+        [major, minor + 1, 0],
+        [major + 1, 0, 0],
+      ].map((arr) => `v${arr.join(".")}`)
+    )(`%s`, async (unsupportedVersion) => {
+      process.emitWarning = jest.fn();
+      emitWarningIfUnsupportedVersion(unsupportedVersion);
+      expect(process.emitWarning).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
@@ -1,4 +1,7 @@
 export const emitWarningIfUnsupportedVersion = (version: string) => {
+  // process.emitWarning will not be defined if user is on node < 6.
+  // We don't support node < 6, but do not want postinstall script to fail.
+  // @ts-expect-error This condition will always return true since this function is always defined
   if (process.emitWarning && version && parseInt(version.substring(1, version.indexOf("."))) < 12) {
     process.emitWarning(
       `The AWS SDK for JavaScript (v3) will\n` +

--- a/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
@@ -5,7 +5,7 @@ export const emitWarningIfUnsupportedVersion = (version: string) => {
         `no longer support Node.js ${version} as of January 1, 2022.\n` +
         `To continue receiving updates to AWS services, bug fixes, and security\n` +
         `updates please upgrade to Node.js 12.x or later.\n\n` +
-        `More information can be found at: {LINK TO BLOG}`,
+        `More information can be found at: https://a.co/1l6FLnu`,
       `NodeDeprecationWarning`
     );
   }

--- a/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
@@ -1,8 +1,5 @@
 export const emitWarningIfUnsupportedVersion = (version: string) => {
-  // process.emitWarning will not be defined if user is on node < 6.
-  // We don't support node < 6, but do not want postinstall script to fail.
-  // @ts-expect-error This condition will always return true since this function is always defined
-  if (process.emitWarning && version && parseInt(version.substring(1, version.indexOf("."))) < 12) {
+  if (version && parseInt(version.substring(1, version.indexOf("."))) < 12) {
     process.emitWarning(
       `The AWS SDK for JavaScript (v3) will\n` +
         `no longer support Node.js ${version} as of January 1, 2022.\n` +

--- a/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/postinstall-node-version-check/src/emitWarningIfUnsupportedVersion.ts
@@ -1,0 +1,12 @@
+export const emitWarningIfUnsupportedVersion = (version: string) => {
+  if (process.emitWarning && version && parseInt(version.substring(1, version.indexOf("."))) < 12) {
+    process.emitWarning(
+      `The AWS SDK for JavaScript (v3) will\n` +
+        `no longer support Node.js ${version} as of January 1, 2022.\n` +
+        `To continue receiving updates to AWS services, bug fixes, and security\n` +
+        `updates please upgrade to Node.js 12.x or later.\n\n` +
+        `More information can be found at: {LINK TO BLOG}`,
+      `NodeDeprecationWarning`
+    );
+  }
+};

--- a/packages/postinstall-node-version-check/src/index.spec.ts
+++ b/packages/postinstall-node-version-check/src/index.spec.ts
@@ -1,0 +1,8 @@
+import { emitWarningIfUnsupportedVersion } from "./emitWarningIfUnsupportedVersion";
+jest.mock("./emitWarningIfUnsupportedVersion");
+
+it("index", () => {
+  require("./index");
+  expect(emitWarningIfUnsupportedVersion).toHaveBeenCalledTimes(1);
+  expect(emitWarningIfUnsupportedVersion).toHaveBeenCalledWith(process.version);
+});

--- a/packages/postinstall-node-version-check/src/index.ts
+++ b/packages/postinstall-node-version-check/src/index.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+import { emitWarningIfUnsupportedVersion } from "./emitWarningIfUnsupportedVersion";
+emitWarningIfUnsupportedVersion(process.version);

--- a/packages/postinstall-node-version-check/tsconfig.cjs.json
+++ b/packages/postinstall-node-version-check/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}


### PR DESCRIPTION
### Issue
Internal JS-2727

### Description
Creates a script which can be run on postinstall
The script displays the following message if Node.js version is <12.0.0

```console
(node:11997) NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
no longer support Node.js v10.24.1 as of January 1, 2022.
To continue receiving updates to AWS services, bug fixes, and security
updates please upgrade to Node.js 12.x or later.

More information can be found at: {LINK TO BLOG}
```

### Testing
* Unit testing
* Tested in [postinstall-node-version-check@0.2.4](https://www.npmjs.com/package/postinstall-node-version-check) with [test-postinstall-node-version-check@0.1.4](https://www.npmjs.com/package/test-postinstall-node-version-check)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
