### PR TITLE
fix(codegen): fix detection of -s for generate-clients

### DIFF
--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -38,13 +38,12 @@ const {
   .alias("s", "server-artifacts")
   .boolean("s")
   .describe("s", "Generate server artifacts instead of client ones")
-  .default("s", false)
   .conflicts("s", ["m", "g", "n"])
   .help().argv;
 
 (async () => {
   try {
-    if (serverOnly) {
+    if (serverOnly === true) {
       await generateProtocolTests();
       await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
       await copyServerTests(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);


### PR DESCRIPTION
### Description
-s/--server-artifacts having a default value makes it see conflicts with
-m/-n/-g even if the caller did not specify them. Removing the default
fixes this.

### Testing
ran both `yarn generate-clients -g codegen/sdk-codegen/aws-models/dynamodb.2012-08-10.json` and `yarn generate-clients -s` locally.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
