### PR TITLE
chore: bump code generators to 0.4.1

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.4.0"
+    version = "0.4.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("software.amazon.smithy:smithy-waiters:[1.9.0, 1.10.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.9.0, 1.10.0[")
     api("software.amazon.smithy:smithy-protocol-test-traits:[1.9.0, 1.10.0[")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.4.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.4.1")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
This bumps the version of the code generators. This should be merged after the next SDK release.

This depends on: https://github.com/awslabs/smithy-typescript/pull/385

(The java ci will fail due to the version bump, until the above is released)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
