### PR TITLE
chore(clients): call postinstall-node-version-check

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -14,7 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -13,7 +13,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -49,7 +49,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -48,6 +48,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -13,7 +13,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -49,6 +49,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -13,7 +13,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -57,6 +57,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -14,7 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -45,7 +45,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -52,6 +52,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -15,7 +15,8 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "postbuild": "cp test/speech.wav dist/cjs/test",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddPostInstallNodeVersionCheckDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddPostInstallNodeVersionCheckDependency.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add dependency for running postinstall script which displays warnings for
+ * Node.js versions nearing end-of-support.
+ */
+@SmithyInternalApi
+public class AddPostInstallNodeVersionCheckDependency implements TypeScriptIntegration {
+
+    // TODO: Change to writeAdditionalDependencies or something similar.
+    @Override
+    public void writeAdditionalExports(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
+    ) {
+        writer.addDependency(AwsDependency.POSTINSTALL_NODE_VERSION_CHECK);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddPostInstallNodeVersionCheckDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddPostInstallNodeVersionCheckDependency.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -31,11 +32,12 @@ public class AddPostInstallNodeVersionCheckDependency implements TypeScriptInteg
 
     // TODO: Change to writeAdditionalDependencies or something similar.
     @Override
-    public void writeAdditionalExports(
+    public void onShapeWriterUse(
         TypeScriptSettings settings,
         Model model,
         SymbolProvider symbolProvider,
-        TypeScriptWriter writer
+        TypeScriptWriter writer,
+        Shape definedShape
     ) {
         writer.addDependency(AwsDependency.POSTINSTALL_NODE_VERSION_CHECK);
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -70,7 +70,8 @@ public enum AwsDependency implements SymbolDependencyContainer {
     MIDDLEWARE_USER_AGENT("dependencies", "@aws-sdk/middleware-user-agent"),
     AWS_SDK_UTIL_USER_AGENT_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/util-user-agent-browser"),
     AWS_SDK_UTIL_USER_AGENT_NODE(NORMAL_DEPENDENCY, "@aws-sdk/util-user-agent-node"),
-    MIDDLEWARE_ENDPOINT_DISCOVERY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-endpoint-discovery");
+    MIDDLEWARE_ENDPOINT_DISCOVERY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-endpoint-discovery"),
+    POSTINSTALL_NODE_VERSION_CHECK(NORMAL_DEPENDENCY, "@aws-sdk/postinstall-node-version-check");
 
     public final String packageName;
     public final String version;

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -19,3 +19,4 @@ software.amazon.smithy.aws.typescript.codegen.StripNewEnumNames
 software.amazon.smithy.aws.typescript.codegen.AddCrossRegionCopyingPlugin
 software.amazon.smithy.aws.typescript.codegen.AddDocumentClientPlugin
 software.amazon.smithy.aws.typescript.codegen.AddEndpointDiscoveryPlugin
+software.amazon.smithy.aws.typescript.codegen.AddPostInstallNodeVersionCheckDependency

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/querystring-builder": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/querystring-builder": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
-    "@aws-sdk/postinstall-node-version-check": "3.0.0",
+    "postinstall-node-version-check": "0.2.4",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/querystring-builder": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "postinstall": "postinstall-node-version-check"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/middleware-user-agent": "3.20.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/node-http-handler": "3.21.0",
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/querystring-builder": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -53,6 +53,10 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
         // Allow target package.json(toContent) has its own special script or
         // dev dependencies that won't be overwritten in codegen
         merged[name] = { ...toContent[name], ...merged[name] };
+        if (name === "scripts") {
+          // Overwrite scripts in codegen package.json with scripts in target package.json
+          merged[name] = { ...merged[name], postinstall: "postinstall-node-version-check" };
+        }
       }
       if (name === "dependencies" || name === "devDependencies") {
         // Sort dependencies as done by lerna

--- a/yarn.lock
+++ b/yarn.lock
@@ -9313,6 +9313,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postinstall-node-version-check@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/postinstall-node-version-check/-/postinstall-node-version-check-0.2.4.tgz#b7615793b6c3027d094a301911fa65784bf106ac"
+  integrity sha512-lF+FyL/SyGvMSEimBBovBO/bygMJegx2Ar3aRnX6cf+12PvOdZ6f8CVVJlAPudo3LtZvROkisqMr3mUsMQi4ow==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2592

### Description
Calls postinstall-node-version-check in clients

### Testing
Tested in package `@aws-sdk/client-s3`:

```console
$ fnm use 8
Using Node v8.17.0

$ yarn postinstall
yarn run v1.22.10
error @aws-sdk/client-s3@3.21.0: The engine "node" is incompatible with this module. Expected version ">=10.0.0". Got "8.17.0"
error Commands cannot run with an incompatible environment.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

$ fnm use 10
Using Node v10.24.1

$ yarn postinstall
yarn run v1.22.10
$ postinstall-node-version-check
Done in 0.11s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
