### PR TITLE
fix(smithy-client): export type explicitly

### DIFF
--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -9,4 +9,4 @@ export * from "./ser-utils";
 export * from "./date-utils";
 export * from "./split-every";
 export * from "./constants";
-export { DocumentType, SdkError, SmithyException } from "@aws-sdk/types";
+export type { DocumentType, SdkError, SmithyException } from "@aws-sdk/types";


### PR DESCRIPTION
### Issue
fixes #2597

### Description
Explicitly re-export types using `export type ...`

### Testing
Successfully built it locally with both `yarn build:all` and deno.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
