### PR TITLE
chore: re-enable ssdk content-length test

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -293,9 +293,6 @@ final class AwsProtocolUtils {
         if (testCase.getId().equals("QueryCustomizedError")) {
             return true;
         }
-        if (testCase.getId().equals("RestJsonStreamingTraitsRequireLengthWithBlob") && settings.generateServerSdk()) {
-            return true;
-        }
         //TODO: enable with Smithy 1.10
         if ((testCase.getId().equals("RestJsonAllQueryStringTypes")
                 || testCase.getId().equals("RestJsonQueryStringEscaping"))


### PR DESCRIPTION
### Issue
n/a

### Description
This re-enables an SSDK protocol test  since the feature is being fixed in https://github.com/awslabs/smithy-typescript/pull/386

CI won't pass until that is merged.

### Testing
Built the smithy-typescript change locally, and then ran the protocol tests.

### Additional context
n/a

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
