### PR TITLE
feat: add paginators for lib-dynamodb

### DIFF
--- a/lib/lib-dynamodb/src/index.ts
+++ b/lib/lib-dynamodb/src/index.ts
@@ -11,5 +11,8 @@ export * from "./commands/ScanCommand";
 export * from "./commands/TransactGetCommand";
 export * from "./commands/TransactWriteCommand";
 export * from "./commands/UpdateCommand";
+export * from "./pagination/QueryPaginator";
+export * from "./pagination/ScanPaginator";
+export * from "./pagination/Interfaces";
 export * from "./DynamoDBDocumentClient";
 export * from "./DynamoDBDocument";

--- a/lib/lib-dynamodb/src/pagination/Interfaces.ts
+++ b/lib/lib-dynamodb/src/pagination/Interfaces.ts
@@ -1,0 +1,8 @@
+import { PaginationConfiguration } from "@aws-sdk/types";
+
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+
+export interface DynamoDBDocumentPaginationConfiguration extends PaginationConfiguration {
+  client: DynamoDBDocument | DynamoDBDocumentClient;
+}

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -1,0 +1,54 @@
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+import { QueryCommand, QueryCommandInput, QueryCommandOutput } from "../commands/QueryCommand";
+import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+import { Paginator } from "@aws-sdk/types";
+
+/**
+ * @private
+ */
+const makePagedClientRequest = async (
+  client: DynamoDBDocumentClient,
+  input: QueryCommandInput,
+  ...args: any
+): Promise<QueryCommandOutput> => {
+  // @ts-ignore
+  return await client.send(new QueryCommand(input), ...args);
+};
+/**
+ * @private
+ */
+const makePagedRequest = async (
+  client: DynamoDBDocument,
+  input: QueryCommandInput,
+  ...args: any
+): Promise<QueryCommandOutput> => {
+  // @ts-ignore
+  return await client.query(input, ...args);
+};
+export async function* paginateQuery(
+  config: DynamoDBPaginationConfiguration,
+  input: QueryCommandInput,
+  ...additionalArguments: any
+): Paginator<QueryCommandOutput> {
+  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
+  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let hasNext = true;
+  let page: QueryCommandOutput;
+  while (hasNext) {
+    input.ExclusiveStartKey = token;
+    input["Limit"] = config.pageSize;
+    if (config.client instanceof DynamoDBDocument) {
+      page = await makePagedRequest(config.client, input, ...additionalArguments);
+    } else if (config.client instanceof DynamoDBDocumentClient) {
+      page = await makePagedClientRequest(config.client, input, ...additionalArguments);
+    } else {
+      throw new Error("Invalid client, expected DynamoDBDocument | DynamoDBDocumentClient");
+    }
+    yield page;
+    token = page.LastEvaluatedKey;
+    hasNext = !!token;
+  }
+  // @ts-ignore
+  return undefined;
+}

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -1,0 +1,54 @@
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+import { ScanCommand, ScanCommandInput, ScanCommandOutput } from "../commands/ScanCommand";
+import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+import { Paginator } from "@aws-sdk/types";
+
+/**
+ * @private
+ */
+const makePagedClientRequest = async (
+  client: DynamoDBDocumentClient,
+  input: ScanCommandInput,
+  ...args: any
+): Promise<ScanCommandOutput> => {
+  // @ts-ignore
+  return await client.send(new ScanCommand(input), ...args);
+};
+/**
+ * @private
+ */
+const makePagedRequest = async (
+  client: DynamoDBDocument,
+  input: ScanCommandInput,
+  ...args: any
+): Promise<ScanCommandOutput> => {
+  // @ts-ignore
+  return await client.scan(input, ...args);
+};
+export async function* paginateScan(
+  config: DynamoDBPaginationConfiguration,
+  input: ScanCommandInput,
+  ...additionalArguments: any
+): Paginator<ScanCommandOutput> {
+  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
+  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let hasNext = true;
+  let page: ScanCommandOutput;
+  while (hasNext) {
+    input.ExclusiveStartKey = token;
+    input["Limit"] = config.pageSize;
+    if (config.client instanceof DynamoDBDocument) {
+      page = await makePagedRequest(config.client, input, ...additionalArguments);
+    } else if (config.client instanceof DynamoDBDocumentClient) {
+      page = await makePagedClientRequest(config.client, input, ...additionalArguments);
+    } else {
+      throw new Error("Invalid client, expected DynamoDBDocument | DynamoDBDocumentClient");
+    }
+    yield page;
+    token = page.LastEvaluatedKey;
+    hasNext = !!token;
+  }
+  // @ts-ignore
+  return undefined;
+}


### PR DESCRIPTION
### Issue
#2546
#2159

### Description
- Add Query & Scan paginators to lib-dynamodb.
- Exports `paginateQuery`, `paginateScan` & `DynamoDBDocumentPaginationConfiguration`

### Testing
How was this change tested?
- Built and run on a separate repository.

### Additional context
- Doesn't look like we can reuse the paginators in the client-dynamodb library without a rewrite of them.

Steps taken for change:
- Copy pasted paginators from `client-dynamodb`. Kept only `QueryPaginator` and `ScanPaginator`.
- Replaced `DynamoDB` with `DynamoDBDocument`, `DynamoDBClient` with `DynamoDBDocumentClient`
- `QueryCommand` and `ScanCommand` exist in both `client-dynamodb` and `util-dynamodb` so that does not need to change.
- Rename DynamoDBPaginationConfiguration to DynamoDBDocumentPaginationConfiguration
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
