### PR TITLE
feat(lib-storage): improve performance by reducing buffer copies

### DIFF
--- a/lib/lib-storage/src/bytelength.ts
+++ b/lib/lib-storage/src/bytelength.ts
@@ -1,8 +1,11 @@
 import { ClientDefaultValues } from "./runtimeConfig";
+import { Buffer } from "buffer";
 
 export const byteLength = (input: any) => {
   if (input === null || input === undefined) return 0;
-  if (typeof input === "string") input = Buffer.from(input);
+  if (typeof input === "string") {
+    return Buffer.byteLength(input);
+  }
   if (typeof input.byteLength === "number") {
     return input.byteLength;
   } else if (typeof input.length === "number") {

--- a/lib/lib-storage/src/chunker.ts
+++ b/lib/lib-storage/src/chunker.ts
@@ -8,12 +8,12 @@ import { getDataReadableStream } from "./chunks/getDataReadableStream";
 import { BodyDataTypes } from "./types";
 
 export const getChunk = (data: BodyDataTypes, partSize: number) => {
-  if (data instanceof Buffer) {
+  if (data instanceof Buffer || data instanceof Uint8Array) {
     return getChunkBuffer(data, partSize);
   } else if (data instanceof Readable) {
     return getChunkStream<Readable>(data, partSize, getDataReadable);
-  } else if (data instanceof String || typeof data === "string" || data instanceof Uint8Array) {
-    // chunk Strings, Uint8Array.
+  } else if (data instanceof String || typeof data === "string") {
+    // chunk Strings
     return getChunkBuffer(Buffer.from(data), partSize);
   }
   if (typeof (data as any).stream === "function") {

--- a/lib/lib-storage/src/chunks/getChunkBuffer.spec.ts
+++ b/lib/lib-storage/src/chunks/getChunkBuffer.spec.ts
@@ -2,65 +2,68 @@ import { byteLength } from "../bytelength";
 import { getChunkBuffer } from "./getChunkBuffer";
 
 describe.only(getChunkBuffer.name, () => {
-  const getBuffer = (size: number) => Buffer.from("#".repeat(size));
+  [
+    { type: "Buffer", getBuffer: (size: number) => Buffer.from("#".repeat(size)) },
+    { type: "Uint8Array", getBuffer: (size: number) => Uint8Array.from(Buffer.from("#".repeat(size))) },
+  ].forEach(({ getBuffer, type }) => {
+    describe(`${type} chunking`, () => {
+      it("should come back with small sub buffers", async () => {
+        const chunklength = 100;
+        const totalLength = 1000;
+        const buffer = getBuffer(totalLength);
+        const chunker = getChunkBuffer(buffer, chunklength);
 
-  describe("Buffer chunking", () => {
-    it("should come back with small sub buffers", async () => {
-      const chunklength = 100;
-      const totalLength = 1000;
-      const buffer = getBuffer(totalLength);
-      const chunker = getChunkBuffer(buffer, chunklength);
-
-      let chunkNum = 0;
-      const expectedNumberOfChunks = totalLength / chunklength;
-      for await (const chunk of chunker) {
-        chunkNum += 1;
-        expect(byteLength(chunk.data)).toEqual(chunklength);
-        expect(chunk.partNumber).toEqual(chunkNum);
-        if (chunkNum < expectedNumberOfChunks) {
-          expect(chunk.lastPart).toBe(undefined);
-        } else {
-          expect(chunk.lastPart).toBe(true);
+        let chunkNum = 0;
+        const expectedNumberOfChunks = totalLength / chunklength;
+        for await (const chunk of chunker) {
+          chunkNum += 1;
+          expect(byteLength(chunk.data)).toEqual(chunklength);
+          expect(chunk.partNumber).toEqual(chunkNum);
+          if (chunkNum < expectedNumberOfChunks) {
+            expect(chunk.lastPart).toBe(undefined);
+          } else {
+            expect(chunk.lastPart).toBe(true);
+          }
         }
-      }
 
-      expect(chunkNum).toEqual(expectedNumberOfChunks);
-    });
+        expect(chunkNum).toEqual(expectedNumberOfChunks);
+      });
 
-    it("should come back with the last chunk the remainder size", async () => {
-      const chunklength = 1000;
-      const totalLength = 2200;
-      const buffer = getBuffer(totalLength);
+      it("should come back with the last chunk the remainder size", async () => {
+        const chunklength = 1000;
+        const totalLength = 2200;
+        const buffer = getBuffer(totalLength);
 
-      const chunker = getChunkBuffer(buffer, chunklength);
-      const chunks = [];
-      for await (const chunk of chunker) {
-        chunks.push(chunk);
-      }
+        const chunker = getChunkBuffer(buffer, chunklength);
+        const chunks = [];
+        for await (const chunk of chunker) {
+          chunks.push(chunk);
+        }
 
-      expect(chunks.length).toEqual(3);
-      expect(byteLength(chunks[0].data)).toBe(chunklength);
-      expect(chunks[0].lastPart).toBe(undefined);
-      expect(byteLength(chunks[1].data)).toBe(chunklength);
-      expect(chunks[1].lastPart).toBe(undefined);
-      expect(byteLength(chunks[2].data)).toBe(totalLength % chunklength);
-      expect(chunks[2].lastPart).toBe(true);
-    });
+        expect(chunks.length).toEqual(3);
+        expect(byteLength(chunks[0].data)).toBe(chunklength);
+        expect(chunks[0].lastPart).toBe(undefined);
+        expect(byteLength(chunks[1].data)).toBe(chunklength);
+        expect(chunks[1].lastPart).toBe(undefined);
+        expect(byteLength(chunks[2].data)).toBe(totalLength % chunklength);
+        expect(chunks[2].lastPart).toBe(true);
+      });
 
-    it("should come back with one chunk if it is a small buffer", async () => {
-      const chunklength = 1000;
-      const totalLength = 200;
-      const buffer = getBuffer(totalLength);
+      it("should come back with one chunk if it is a small buffer", async () => {
+        const chunklength = 1000;
+        const totalLength = 200;
+        const buffer = getBuffer(totalLength);
 
-      const chunker = getChunkBuffer(buffer, chunklength);
-      const chunks = [];
-      for await (const chunk of chunker) {
-        chunks.push(chunk);
-      }
+        const chunker = getChunkBuffer(buffer, chunklength);
+        const chunks = [];
+        for await (const chunk of chunker) {
+          chunks.push(chunk);
+        }
 
-      expect(chunks.length).toEqual(1);
-      expect(byteLength(chunks[0].data)).toBe(totalLength % chunklength);
-      expect(chunks[0].lastPart).toBe(true);
+        expect(chunks.length).toEqual(1);
+        expect(byteLength(chunks[0].data)).toBe(totalLength % chunklength);
+        expect(chunks[0].lastPart).toBe(true);
+      });
     });
   });
 });

--- a/lib/lib-storage/src/chunks/getChunkBuffer.ts
+++ b/lib/lib-storage/src/chunks/getChunkBuffer.ts
@@ -1,6 +1,9 @@
 import { RawDataPart } from "../Upload";
 
-export async function* getChunkBuffer(data: Buffer, partSize: number): AsyncGenerator<RawDataPart, void, undefined> {
+export async function* getChunkBuffer(
+  data: Buffer | Uint8Array,
+  partSize: number
+): AsyncGenerator<RawDataPart, void, undefined> {
   let partNumber = 1;
   let startByte = 0;
   let endByte = partSize;
@@ -8,7 +11,7 @@ export async function* getChunkBuffer(data: Buffer, partSize: number): AsyncGene
   while (endByte < data.byteLength) {
     yield {
       partNumber,
-      data: data.slice(startByte, endByte),
+      data: data.subarray(startByte, endByte),
     };
     partNumber += 1;
     startByte = endByte;
@@ -17,7 +20,7 @@ export async function* getChunkBuffer(data: Buffer, partSize: number): AsyncGene
 
   yield {
     partNumber,
-    data: data.slice(startByte),
+    data: data.subarray(startByte),
     lastPart: true,
   };
 }

--- a/lib/lib-storage/src/chunks/getChunkStream.ts
+++ b/lib/lib-storage/src/chunks/getChunkStream.ts
@@ -3,21 +3,21 @@ import { Buffer } from "buffer";
 import { RawDataPart } from "../Upload";
 
 interface Buffers {
-  chunks: Buffer[];
+  chunks: (Buffer | Uint8Array)[];
   length: number;
 }
 
 export async function* getChunkStream<T>(
   data: T,
   partSize: number,
-  getNextData: (data: T) => AsyncGenerator<Buffer>
+  getNextData: (data: T) => AsyncGenerator<Buffer | Uint8Array>
 ): AsyncGenerator<RawDataPart, void, undefined> {
   let partNumber = 1;
   const currentBuffer: Buffers = { chunks: [], length: 0 };
 
   for await (const datum of getNextData(data)) {
     currentBuffer.chunks.push(datum);
-    currentBuffer.length += datum.length;
+    currentBuffer.length += datum.byteLength;
 
     while (currentBuffer.length >= partSize) {
       /**
@@ -28,18 +28,18 @@ export async function* getChunkStream<T>(
 
       yield {
         partNumber,
-        data: dataChunk.slice(0, partSize),
+        data: dataChunk.subarray(0, partSize),
       };
 
       // Reset the buffer.
-      currentBuffer.chunks = [dataChunk.slice(partSize)];
-      currentBuffer.length = currentBuffer.chunks[0].length;
+      currentBuffer.chunks = [dataChunk.subarray(partSize)];
+      currentBuffer.length = currentBuffer.chunks[0].byteLength;
       partNumber += 1;
     }
   }
   yield {
     partNumber,
-    data: Buffer.concat(currentBuffer.chunks),
+    data: currentBuffer.chunks.length !== 1 ? Buffer.concat(currentBuffer.chunks) : currentBuffer.chunks[0],
     lastPart: true,
   };
 }

--- a/lib/lib-storage/src/chunks/getDataReadable.ts
+++ b/lib/lib-storage/src/chunks/getDataReadable.ts
@@ -1,8 +1,13 @@
 import { Buffer } from "buffer";
 import { Readable } from "stream";
 
-export async function* getDataReadable(data: Readable): AsyncGenerator<Buffer> {
+export async function* getDataReadable(data: Readable): AsyncGenerator<Buffer | Uint8Array> {
   for await (const chunk of data) {
-    yield Buffer.from(chunk);
+    // check if is Buffer/Unit8Array
+    if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+      yield chunk;
+    } else {
+      yield Buffer.from(chunk);
+    }
   }
 }

--- a/lib/lib-storage/src/chunks/getDataReadableStream.ts
+++ b/lib/lib-storage/src/chunks/getDataReadableStream.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "buffer";
 
-export async function* getDataReadableStream(data: ReadableStream): AsyncGenerator<Buffer> {
+export async function* getDataReadableStream(data: ReadableStream): AsyncGenerator<Buffer | Uint8Array> {
   // Get a lock on the stream.
   const reader = data.getReader();
 
@@ -10,8 +10,12 @@ export async function* getDataReadableStream(data: ReadableStream): AsyncGenerat
       const { done, value } = await reader.read();
       // Exit if we're done.
       if (done) return;
-      // Else yield the chunk.
-      yield Buffer.from(value);
+      // check if is Buffer/Unit8Array
+      if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+        yield value;
+      } else {
+        yield Buffer.from(value);
+      }
     }
   } catch (e) {
     throw e;

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -22,7 +22,11 @@ function writeBody(
     // pipe automatically handles end
     body.pipe(httpRequest);
   } else if (body) {
-    httpRequest.end(Buffer.from(body));
+    if (Buffer.isBuffer(body) || typeof body === "string") {
+      httpRequest.end(body);
+    } else {
+      httpRequest.end(Buffer.from(body));
+    }
   } else {
     httpRequest.end();
   }

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -25,7 +25,12 @@ function writeBody(
     if (Buffer.isBuffer(body) || typeof body === "string") {
       httpRequest.end(body);
     } else {
-      httpRequest.end(Buffer.from(body));
+      // buffer.from copies TypedArrays but can reuse ArrayBuffers
+      if (body instanceof Uint8Array) {
+        httpRequest.end(Buffer.from(body.buffer, body.byteOffset, body.byteLength));
+      } else {
+        httpRequest.end(Buffer.from(body));
+      }
     }
   } else {
     httpRequest.end();

--- a/packages/util-body-length-node/src/index.ts
+++ b/packages/util-body-length-node/src/index.ts
@@ -5,7 +5,7 @@ export function calculateBodyLength(body: any): number | undefined {
     return 0;
   }
   if (typeof body === "string") {
-    return Buffer.from(body).length;
+    return Buffer.byteLength(body);
   } else if (typeof body.byteLength === "number") {
     // handles Uint8Array, ArrayBuffer, Buffer, and ArrayBufferView
     return body.byteLength;


### PR DESCRIPTION
Reduce memory usage by reducing buffer-copying and returning the original buffer instead.

### Description
This PR reduces the number of buffers copied and created from existing buffers. The most significant change was made to streams that return buffers and Uint8Arrays, but some minor improvements were made for `string` and `Uint8Array` bodies as well. The following changes were made:

- Yield without copying the given Buffer/Uint8Array in `getDataReadable.ts` and `getDataReadableStream.ts` (probably the most significant change).
- In `byteLength.ts`, use `Buffer.byteLength(string)` instead of `Buffer.from(string).byteLength` for computing the string byteLength, so that the string is not copied into a buffer just for its byteLength.
- Treat `Uint8Array` the same as a Buffer in `chunker.ts`
- Use `subarray` instead of `slice` in `getChunkBuffer.ts` so that `Uint8Array` and `Buffer` inputs behave the same. In Node `.slice` on Uint8Array copies the data, while `.subarray` just takes the subarray without copying. Slice and subarray for Buffers in Node are the same (both don't copy the data).
- `getChunkStream.ts` was changed in a similar way to `getChunkBuffer.ts`, and also added a change so that the last  buffer is not copied if there's only one buffer left (the last change is probably relatively minor).

### Testing
I ran the following file for different values:

```ts
import { getChunk } from './chunker';
import { Readable } from 'stream';
const buf = Buffer.from('#'.repeat(1024 * 1024 * 10));
const getIter = () => getChunk(Readable.from((async function* () {
    const chunkSize = 1024 * 1024;
    for (let i = 0; i < buf.byteLength; i += chunkSize) {
        yield buf.subarray(i, i + chunkSize);
    }
})()), 1024 * 1024 * 5)

async function iterateTimes(times: number) {
    console.time('timing')
    for (let i = 0; i < times; i++) {
        for await (const z of getIter()) { }
    }
    console.log(`times ${times}`);
    const used = process.memoryUsage() as any;
    for (let key in used) {
        console.log(`${key} ${Math.round(used[key] / 1024 / 1024 * 100) / 100} MB`);
    }
    console.timeEnd('timing')
}

iterateTimes(10);
```
<details>
<summary>results</summary>
Original code

>>>>>
times 1
rss 59.67 MB
heapTotal 15.68 MB
heapUsed 12.78 MB
external 30.91 MB
arrayBuffers 30.02 MB
timing: 17.289ms

times 2
rss 79.71 MB
heapTotal 15.68 MB
heapUsed 12.82 MB
external 50.91 MB
arrayBuffers 50.02 MB
timing: 26.743ms

times 10
rss 173.15 MB
heapTotal 7.18 MB
heapUsed 2.3 MB
external 90.91 MB
arrayBuffers 90.02 MB
timing: 90.863ms

>>>>>
New:
times 1
rss 49.52 MB
heapTotal 15.68 MB
heapUsed 12.78 MB
external 20.91 MB
arrayBuffers 20.02 MB
timing: 13.046ms

times 2
rss 59.64 MB
heapTotal 15.43 MB
heapUsed 12.8 MB
external 30.91 MB
arrayBuffers 30.02 MB
timing: 17.994ms

times 10
rss 129.96 MB
heapTotal 7.18 MB
heapUsed 2.32 MB
external 60.91 MB
arrayBuffers 60.02 MB
timing: 59.366ms
</details>

Note that I executed the above multiple times, to see that the results are essentially the same, but I didn't do a z-test or anything. If there's any benchmarking tools that I can use to have better results to show that the results are significant, I'd be happy to use them. From my testing, the new chunking was faster and also used less memory, when chunking a stream of a 10MB buffer with 1MB chunks. I also checked to see if there was some degraded performance for streams that return strings instead of buffers, but performance was essentially the same.

For byteLength, I executed a similar script that called `byteLength` 10 times with a 10MB and 1MB strings and also saw significant memory reduction.
<details>
 <summary>results</summary>
10MB strings:
>>>>>
original code

times 10
rss 129.17 MB
heapTotal 14.93 MB
heapUsed 12.1 MB
external 40.93 MB
arrayBuffers 40.01 MB
timing: 90.462ms
>>>>>
new code
times 10
rss 29.49 MB
heapTotal 15.43 MB
heapUsed 12.66 MB
external 0.93 MB
arrayBuffers 0.01 MB
timing: 26.115ms

1MB strings
>>>>>
original code
times 10
rss 30.39 MB
heapTotal 6.68 MB
heapUsed 3.66 MB
external 0.93 MB
arrayBuffers 0.01 MB
timing: 13.741ms
>>>>>>>
new code
times 10
rss 20.36 MB
heapTotal 6.68 MB
heapUsed 3.67 MB
external 0.93 MB
arrayBuffers 0.01 MB
timing: 7.668ms
</details>

I did not check `Uint8Array` buffers or streams (i.e. streams that return such chunks), but I expect similar performance number improvements as above. If it's necessary I'll also check as well.

### Additional context
~If the general direction of this PR is OK, I'd be happy to add some more (regression) tests for Uint8Array buffers and streams and some other edge-cases, as those currently don't exist so if I did mess something up with such inputs, there are no tests to show it.~ Also, if there's some benchmark tooling that I missed, I'd be happy to add benchmarks.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
