### PR TITLE
chore: bump code generators to 0.5.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Smithy AWS Typescript Codegen Changelog
+
+## 0.5.0 (2021-07-23)
+
+### Features
+
+* Updated `smithy-typescript-codegen` dependency to `0.5.0`.

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.4.1"
+    version = "0.5.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("software.amazon.smithy:smithy-waiters:[1.9.0, 1.10.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.9.0, 1.10.0[")
     api("software.amazon.smithy:smithy-protocol-test-traits:[1.9.0, 1.10.0[")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.4.1")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.5.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
### Issue

n/a

### Description

bumps the code generator version to `0.5.0` and picks up the `0.5.0` update of `smithy-typescript-codegen`: https://github.com/awslabs/smithy-typescript/pull/390

### Testing

build and tested locally.

### Additional context

The java ci will fail until upstream is merged.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
