### PR TITLE
chore(protocol-test): update json 1.0 test

### DIFF
--- a/protocol_tests/aws-json-10/JSONRPC10Client.ts
+++ b/protocol_tests/aws-json-10/JSONRPC10Client.ts
@@ -15,7 +15,7 @@ import {
   SimpleScalarPropertiesCommandInput,
   SimpleScalarPropertiesCommandOutput,
 } from "./commands/SimpleScalarPropertiesCommand";
-import { ClientDefaultValues as __ClientDefaultValues } from "./runtimeConfig";
+import { getRuntimeConfig as __getRuntimeConfig } from "./runtimeConfig";
 import {
   EndpointsInputConfig,
   EndpointsResolvedConfig,
@@ -50,6 +50,7 @@ import {
   RegionInfoProvider,
   Decoder as __Decoder,
   Encoder as __Encoder,
+  Hash as __Hash,
   HashConstructor as __HashConstructor,
   HttpHandlerOptions as __HttpHandlerOptions,
   Logger as __Logger,
@@ -86,7 +87,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   requestHandler?: __HttpHandler;
 
   /**
-   * A constructor for a class implementing the @aws-sdk/types.Hash interface
+   * A constructor for a class implementing the {@link __Hash} interface
    * that computes the SHA-256 HMAC or checksum of a string or binary buffer.
    * @internal
    */
@@ -147,12 +148,6 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   disableHostPrefix?: boolean;
 
   /**
-   * Unique service identifier.
-   * @internal
-   */
-  serviceId?: string;
-
-  /**
    * Value for how many times a request will be made at most in case of retry.
    */
   maxAttempts?: number | __Provider<number>;
@@ -167,6 +162,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * Optional logger for logging debug/info/warn/error.
    */
   logger?: __Logger;
+
+  /**
+   * Unique service identifier.
+   * @internal
+   */
+  serviceId?: string;
 
   /**
    * Fetch related hostname, signing name or signing region with given region.
@@ -217,10 +218,7 @@ export class JSONRPC10Client extends __Client<
   readonly config: JSONRPC10ClientResolvedConfig;
 
   constructor(configuration: JSONRPC10ClientConfig) {
-    let _config_0 = {
-      ...__ClientDefaultValues,
-      ...configuration,
-    };
+    let _config_0 = __getRuntimeConfig(configuration);
     let _config_1 = resolveRegionConfig(_config_0);
     let _config_2 = resolveEndpointsConfig(_config_1);
     let _config_3 = resolveRetryConfig(_config_2);

--- a/protocol_tests/aws-json-10/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-json-10/runtimeConfig.browser.ts
@@ -7,27 +7,30 @@ import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
-import { ClientDefaults } from "./JSONRPC10Client";
-import { ClientSharedValues } from "./runtimeConfig.shared";
+import { JSONRPC10ClientConfig } from "./JSONRPC10Client";
+import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 
 /**
  * @internal
  */
-export const ClientDefaultValues: Required<ClientDefaults> = {
-  ...ClientSharedValues,
-  runtime: "browser",
-  base64Decoder: fromBase64,
-  base64Encoder: toBase64,
-  bodyLengthChecker: calculateBodyLength,
-  defaultUserAgentProvider: defaultUserAgent({
-    serviceId: ClientSharedValues.serviceId,
-    clientVersion: packageInfo.version,
-  }),
-  maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  requestHandler: new FetchHttpHandler(),
-  retryModeProvider: () => Promise.resolve(DEFAULT_RETRY_MODE),
-  sha256: Sha256,
-  streamCollector,
-  utf8Decoder: fromUtf8,
-  utf8Encoder: toUtf8,
+export const getRuntimeConfig = (config: JSONRPC10ClientConfig) => {
+  const clientSharedValues = getSharedRuntimeConfig(config);
+  return {
+    ...clientSharedValues,
+    ...config,
+    runtime: "browser",
+    base64Decoder: config.base64Decoder ?? fromBase64,
+    base64Encoder: config.base64Encoder ?? toBase64,
+    bodyLengthChecker: config.bodyLengthChecker ?? calculateBodyLength,
+    defaultUserAgentProvider:
+      config.defaultUserAgentProvider ??
+      defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    maxAttempts: config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    requestHandler: config.requestHandler ?? new FetchHttpHandler(),
+    retryModeProvider: config.retryModeProvider ?? (() => Promise.resolve(DEFAULT_RETRY_MODE)),
+    sha256: config.sha256 ?? Sha256,
+    streamCollector: config.streamCollector ?? streamCollector,
+    utf8Decoder: config.utf8Decoder ?? fromUtf8,
+    utf8Encoder: config.utf8Encoder ?? toUtf8,
+  };
 };

--- a/protocol_tests/aws-json-10/runtimeConfig.native.ts
+++ b/protocol_tests/aws-json-10/runtimeConfig.native.ts
@@ -1,12 +1,16 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
-import { ClientDefaults } from "./JSONRPC10Client";
-import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
+import { JSONRPC10ClientConfig } from "./JSONRPC10Client";
+import { getRuntimeConfig as getBrowserRuntimeConfig } from "./runtimeConfig.browser";
 
 /**
  * @internal
  */
-export const ClientDefaultValues: Required<ClientDefaults> = {
-  ...BrowserDefaults,
-  runtime: "react-native",
-  sha256: Sha256,
+export const getRuntimeConfig = (config: JSONRPC10ClientConfig) => {
+  const browserDefaults = getBrowserRuntimeConfig(config);
+  return {
+    ...browserDefaults,
+    ...config,
+    runtime: "react-native",
+    sha256: config.sha256 ?? Sha256,
+  };
 };

--- a/protocol_tests/aws-json-10/runtimeConfig.shared.ts
+++ b/protocol_tests/aws-json-10/runtimeConfig.shared.ts
@@ -1,15 +1,16 @@
 import { defaultRegionInfoProvider } from "./endpoints";
 import { Logger as __Logger } from "@aws-sdk/types";
 import { parseUrl } from "@aws-sdk/url-parser";
+import { JSONRPC10ClientConfig } from "./JSONRPC10Client";
 
 /**
  * @internal
  */
-export const ClientSharedValues = {
+export const getRuntimeConfig = (config: JSONRPC10ClientConfig) => ({
   apiVersion: "2020-07-14",
-  disableHostPrefix: false,
-  logger: {} as __Logger,
-  regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "JSON RPC 10",
-  urlParser: parseUrl,
-};
+  disableHostPrefix: config.disableHostPrefix ?? false,
+  logger: config.logger ?? ({} as __Logger),
+  regionInfoProvider: config.regionInfoProvider ?? defaultRegionInfoProvider,
+  serviceId: config.serviceId ?? "JSON RPC 10",
+  urlParser: config.urlParser ?? parseUrl,
+});

--- a/protocol_tests/aws-json-10/runtimeConfig.ts
+++ b/protocol_tests/aws-json-10/runtimeConfig.ts
@@ -8,27 +8,30 @@ import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
-import { ClientDefaults } from "./JSONRPC10Client";
-import { ClientSharedValues } from "./runtimeConfig.shared";
+import { JSONRPC10ClientConfig } from "./JSONRPC10Client";
+import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 
 /**
  * @internal
  */
-export const ClientDefaultValues: Required<ClientDefaults> = {
-  ...ClientSharedValues,
-  runtime: "node",
-  base64Decoder: fromBase64,
-  base64Encoder: toBase64,
-  bodyLengthChecker: calculateBodyLength,
-  defaultUserAgentProvider: defaultUserAgent({
-    serviceId: ClientSharedValues.serviceId,
-    clientVersion: packageInfo.version,
-  }),
-  maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
-  requestHandler: new NodeHttpHandler(),
-  retryModeProvider: loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
-  sha256: Hash.bind(null, "sha256"),
-  streamCollector,
-  utf8Decoder: fromUtf8,
-  utf8Encoder: toUtf8,
+export const getRuntimeConfig = (config: JSONRPC10ClientConfig) => {
+  const clientSharedValues = getSharedRuntimeConfig(config);
+  return {
+    ...clientSharedValues,
+    ...config,
+    runtime: "node",
+    base64Decoder: config.base64Decoder ?? fromBase64,
+    base64Encoder: config.base64Encoder ?? toBase64,
+    bodyLengthChecker: config.bodyLengthChecker ?? calculateBodyLength,
+    defaultUserAgentProvider:
+      config.defaultUserAgentProvider ??
+      defaultUserAgent({ serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version }),
+    maxAttempts: config.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+    requestHandler: config.requestHandler ?? new NodeHttpHandler(),
+    retryModeProvider: config.retryModeProvider ?? loadNodeConfig(NODE_RETRY_MODE_CONFIG_OPTIONS),
+    sha256: config.sha256 ?? Hash.bind(null, "sha256"),
+    streamCollector: config.streamCollector ?? streamCollector,
+    utf8Decoder: config.utf8Decoder ?? fromUtf8,
+    utf8Encoder: config.utf8Encoder ?? toUtf8,
+  };
 };

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -25,13 +25,14 @@ const getOverwritableDirectories = (subDirectories, packageName) => {
   ];
   return subDirectories.filter((subDirectory) => {
     const isBareBoneClient =
-      subDirectory.endsWith("Client.ts") && subDirectories.includes(subDirectory.replace("Client.ts", ".ts"));
-    const isAggregateClient = subDirectories.includes(subDirectory.replace(".ts", "Client.ts"));
+      subDirectory.endsWith("Client.ts") && subDirectories.indexOf(subDirectory.replace("Client.ts", ".ts")) >= 0;
+    const isAggregateClient =
+      subDirectory.endsWith(".ts") && subDirectories.indexOf(subDirectory.replace(".ts", "Client.ts")) >= 0;
     return (
       isBareBoneClient ||
       isAggregateClient ||
       overwritableDirectories.indexOf(subDirectory) >= 0 ||
-      additionalGeneratedFiles[packageName].includes(subDirectory)
+      additionalGeneratedFiles[packageName]?.indexOf(subDirectory) >= 0
     );
   });
 };

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -3,8 +3,11 @@ const { normalize, join } = require("path");
 const { copySync, removeSync } = require("fs-extra");
 const { readdirSync, lstatSync, readFileSync, existsSync, writeFileSync } = require("fs");
 
-const getOverwritablePredicate = (packageName) => (pathName) => {
-  const overwritablePathnames = [
+const getOverwritableDirectories = (subDirectories, packageName) => {
+  const additionalGeneratedFiles = {
+    "@aws-sdk/client-sts": ["defaultRoleAssumers.ts", "defaultStsRoleAssumers.ts", "defaultRoleAssumers.spec.ts"],
+  };
+  const overwritableDirectories = [
     "commands",
     "models",
     "protocols",
@@ -20,18 +23,17 @@ const getOverwritablePredicate = (packageName) => (pathName) => {
     "endpoints.ts",
     "README.md",
   ];
-  const additionalGeneratedFiles = {
-    "@aws-sdk/client-sts": ["defaultRoleAssumers.ts", "defaultStsRoleAssumers.ts", "defaultRoleAssumers.spec.ts"],
-  };
-  return (
-    pathName
-      .toLowerCase()
-      .startsWith(
-        packageName.toLowerCase().replace("@aws-sdk/client-", "").replace("@aws-sdk/aws-", "").replace(/-/g, "")
-      ) ||
-    overwritablePathnames.indexOf(pathName) >= 0 ||
-    additionalGeneratedFiles[packageName.toLowerCase()]?.indexOf(pathName) >= 0
-  );
+  return subDirectories.filter((subDirectory) => {
+    const isBareBoneClient =
+      subDirectory.endsWith("Client.ts") && subDirectories.includes(subDirectory.replace("Client.ts", ".ts"));
+    const isAggregateClient = subDirectories.includes(subDirectory.replace(".ts", "Client.ts"));
+    return (
+      isBareBoneClient ||
+      isAggregateClient ||
+      overwritableDirectories.indexOf(subDirectory) >= 0 ||
+      additionalGeneratedFiles[packageName].includes(subDirectory)
+    );
+  });
 };
 
 /**
@@ -109,7 +111,6 @@ const copyToClients = async (sourceDir, destinationDir) => {
 
     console.log(`copying ${packageName} from ${artifactPath} to ${destinationDir}`);
     const destPath = join(destinationDir, clientName);
-    const overwritablePredicate = getOverwritablePredicate(packageName);
 
     // Code to move files/folders prefixed with `doc-client-` to `lib/lib-dynamodb`
     if (clientName === "client-dynamodb") {
@@ -124,7 +125,9 @@ const copyToClients = async (sourceDir, destinationDir) => {
       }
     }
 
-    for (const packageSub of readdirSync(artifactPath)) {
+    const packageSubs = readdirSync(artifactPath);
+    const overWritableSubs = getOverwritableDirectories(packageSubs, packageName);
+    for (const packageSub of packageSubs) {
       const packageSubPath = join(artifactPath, packageSub);
       const destSubPath = join(destPath, packageSub);
 
@@ -141,7 +144,7 @@ const copyToClients = async (sourceDir, destinationDir) => {
           },
         };
         writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2).concat(`\n`));
-      } else if (overwritablePredicate(packageSub) || !existsSync(destSubPath)) {
+      } else if (overWritableSubs.includes(packageSub) || !existsSync(destSubPath)) {
         if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
         copySync(packageSubPath, destSubPath, {
           overwrite: true,
@@ -168,9 +171,10 @@ const copyServerTests = async (sourceDir, destinationDir) => {
 
     console.log(`copying ${packageName} from ${artifactPath} to ${destinationDir}`);
     const destPath = join(destinationDir, testName);
-    const overwritablePredicate = getOverwritablePredicate(packageName);
 
-    for (const packageSub of readdirSync(artifactPath)) {
+    const packageSubs = readdirSync(artifactPath);
+    const overWritableSubs = getOverwritableDirectories(packageSubs, packageName);
+    for (const packageSub of packageSubs) {
       const packageSubPath = join(artifactPath, packageSub);
       const destSubPath = join(destPath, packageSub);
 
@@ -187,7 +191,7 @@ const copyServerTests = async (sourceDir, destinationDir) => {
           },
         };
         writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2).concat(`\n`));
-      } else if (overwritablePredicate(packageSub) || !existsSync(destSubPath)) {
+      } else if (overWritableSubs.includes(packageSub) || !existsSync(destSubPath)) {
         if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
         copySync(packageSubPath, destSubPath, {
           overwrite: true,

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -48,7 +48,7 @@ const {
       await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
       await copyServerTests(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);
 
-      emptyDirSync(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+      // emptyDirSync(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
       emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
 
       rmdirSync(TEMP_CODE_GEN_INPUT_DIR);


### PR DESCRIPTION
### Issue
The [JSONRPC10Client.ts](https://github.com/aws/aws-sdk-js-v3/blob/5e3db0064c8916b51778a80e7c0c6ac307f69fd4/protocol_tests/aws-json-10/JSONRPC10Client.ts#L208) and JSONRPC10.ts cannot be updated with the generate-client script because they are in aws-json-10 folder, the script cannot infer the class name from the folder correctly(should have been `JSON10Client` instead). 

We need to update the script to not rely on the generated client folder name to infer the client class name.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
