### PR TITLE
chore(smithy-client): emitWarningIfUnsupportedVersion

### DIFF
--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
@@ -33,6 +33,8 @@ describe("emitWarningIfUnsupportedVersion", () => {
     )(`%s`, async (unsupportedVersion) => {
       process.emitWarning = jest.fn();
       emitWarningIfUnsupportedVersion(unsupportedVersion);
+
+      // Verify that the warning was emitted.
       expect(process.emitWarning).toHaveBeenCalledTimes(1);
       expect(process.emitWarning).toHaveBeenCalledWith(
         `The AWS SDK for JavaScript (v3) will\n` +
@@ -42,6 +44,10 @@ describe("emitWarningIfUnsupportedVersion", () => {
           `More information can be found at: https://a.co/1l6FLnu`,
         `NodeDeprecationWarning`
       );
+
+      // Verify that the warning emits only once.
+      emitWarningIfUnsupportedVersion(unsupportedVersion);
+      expect(process.emitWarning).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
@@ -1,0 +1,63 @@
+describe("emitWarningIfUnsupportedVersion", () => {
+  let emitWarningIfUnsupportedVersion;
+  const emitWarning = process.emitWarning;
+  const supportedVersion = "12.0.0";
+
+  beforeEach(() => {
+    const module = require("./emitWarningIfUnsupportedVersion");
+    emitWarningIfUnsupportedVersion = module.emitWarningIfUnsupportedVersion;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    process.emitWarning = emitWarning;
+  });
+
+  describe(`emits warning for Node.js <${supportedVersion}`, () => {
+    const getPreviousMajorVersion = (major: number) => (major === 0 ? 0 : major - 1);
+
+    const getPreviousMinorVersion = ([major, minor]: [number, number]) =>
+      minor === 0 ? [getPreviousMajorVersion(major), 9] : [major, minor - 1];
+
+    const getPreviousPatchVersion = ([major, minor, patch]: [number, number, number]) =>
+      patch === 0 ? [...getPreviousMinorVersion([major, minor]), 9] : [major, minor, patch - 1];
+
+    const [major, minor, patch] = supportedVersion.split(".").map(Number);
+    it.each(
+      [
+        getPreviousPatchVersion([major, minor, patch]),
+        [...getPreviousMinorVersion([major, minor]), 0],
+        [getPreviousMajorVersion(major), 0, 0],
+      ].map((arr) => `v${arr.join(".")}`)
+    )(`%s`, async (unsupportedVersion) => {
+      process.emitWarning = jest.fn();
+      emitWarningIfUnsupportedVersion(unsupportedVersion);
+      expect(process.emitWarning).toHaveBeenCalledTimes(1);
+      expect(process.emitWarning).toHaveBeenCalledWith(
+        `The AWS SDK for JavaScript (v3) will\n` +
+          `no longer support Node.js ${unsupportedVersion} as of January 1, 2022.\n` +
+          `To continue receiving updates to AWS services, bug fixes, and security\n` +
+          `updates please upgrade to Node.js 12.x or later.\n\n` +
+          `More information can be found at: https://a.co/1l6FLnu`,
+        `NodeDeprecationWarning`
+      );
+    });
+  });
+
+  describe(`emits no warning for Node.js >=${supportedVersion}`, () => {
+    const [major, minor, patch] = supportedVersion.split(".").map(Number);
+    it.each(
+      [
+        [major, minor, patch],
+        [major, minor, patch + 1],
+        [major, minor + 1, 0],
+        [major + 1, 0, 0],
+      ].map((arr) => `v${arr.join(".")}`)
+    )(`%s`, async (unsupportedVersion) => {
+      process.emitWarning = jest.fn();
+      emitWarningIfUnsupportedVersion(unsupportedVersion);
+      expect(process.emitWarning).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
@@ -1,0 +1,21 @@
+// Stores whether the warning was already emitted.
+let warningEmitted = false;
+
+/**
+ * Emits warning if the provided Node.js version string is pending deprecation.
+ *
+ * @param {string} version - The Node.js version string.
+ */
+export const emitWarningIfUnsupportedVersion = (version: string) => {
+  if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 12) {
+    warningEmitted = true;
+    process.emitWarning(
+      `The AWS SDK for JavaScript (v3) will\n` +
+        `no longer support Node.js ${version} as of January 1, 2022.\n` +
+        `To continue receiving updates to AWS services, bug fixes, and security\n` +
+        `updates please upgrade to Node.js 12.x or later.\n\n` +
+        `More information can be found at: https://a.co/1l6FLnu`,
+      `NodeDeprecationWarning`
+    );
+  }
+};

--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./client";
 export * from "./command";
+export * from "./emitWarningIfUnsupportedVersion";
 export * from "./extended-encode-uri-component";
 export * from "./get-array-if-single-item";
 export * from "./get-value-from-text-node";


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2594#issuecomment-883696975

### Description
Create emitWarningIfUnsupportedVersion in smithy-client.
This file would be called from runtimeConfig in clients.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
