### PR TITLE
chore(codegen): fix link to Hash interface in SQS

### DIFF
--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -230,7 +230,7 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   regionInfoProvider?: RegionInfoProvider;
 
   /**
-   * A constructor for a class implementing the @aws-sdk/types.Hash interface
+   * A constructor for a class implementing the {@link __Hash} interface
    * that computes MD5 hashes.
    * @internal
    */

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSqsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSqsDependency.java
@@ -73,8 +73,9 @@ public class AddSqsDependency implements TypeScriptIntegration {
             return;
         }
 
+        writer.addImport("Hash", "__Hash", "@aws-sdk/types");
         writer.addImport("HashConstructor", "__HashConstructor", "@aws-sdk/types");
-        writer.writeDocs("A constructor for a class implementing the @aws-sdk/types.Hash interface \n"
+        writer.writeDocs("A constructor for a class implementing the {@link __Hash} interface \n"
                 + "that computes MD5 hashes.\n"
                 + "@internal");
         writer.write("md5?: __HashConstructor;\n");


### PR DESCRIPTION
### Issue
Similar to https://github.com/aws/aws-sdk-js-v3/pull/2573

### Description
Fixes link to Hash interface in the SQS documentation.

### Testing
<details>
<summary>Before: Link is not clickable.</summary>

![link-legacy](https://user-images.githubusercontent.com/16024985/127171006-9189b17e-09b6-4ae7-8952-a56fe657e91f.png)

</details>

<details>
<summary>After: Link points to Hash interface in @aws-sdk/types</summary>

![link-new](https://user-images.githubusercontent.com/16024985/127171033-ad245e56-02df-44bd-9829-c2880a0d9874.png)

![link-clicked](https://user-images.githubusercontent.com/16024985/127171055-12a43b2f-4b19-4947-8408-392983b310b1.png)

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
