### PR TITLE
fix(credential-provider-node): add missing dependency

### DIFF
--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -33,6 +33,7 @@
     "@aws-sdk/property-provider": "3.23.0",
     "@aws-sdk/shared-ini-file-loader": "3.23.0",
     "@aws-sdk/types": "3.22.0",
+    "@aws-sdk/util-credentials": "3.23.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This being missing broke something for me. I can give some more context if needed. The package is imported in https://github.com/aws/aws-sdk-js-v3/blob/main/packages/credential-provider-node/src/index.ts#L16 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
