### PR TITLE
Update code generation to Smithy 1.10

### DIFF
--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.9.1, 1.10.0[")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.10.0, 1.11.0[")
     compile(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -25,16 +25,16 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("software.amazon.smithy:smithy-model:[1.9.0, 1.10.0[")
+        classpath("software.amazon.smithy:smithy-model:[1.10.0, 1.11.0[")
     }
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-aws-cloudformation-traits:[1.9.0, 1.10.0[")
-    api("software.amazon.smithy:smithy-aws-traits:[1.9.0, 1.10.0[")
-    api("software.amazon.smithy:smithy-waiters:[1.9.0, 1.10.0[")
-    api("software.amazon.smithy:smithy-aws-iam-traits:[1.9.0, 1.10.0[")
-    api("software.amazon.smithy:smithy-protocol-test-traits:[1.9.0, 1.10.0[")
+    api("software.amazon.smithy:smithy-aws-cloudformation-traits:[1.10.0, 1.11.0[")
+    api("software.amazon.smithy:smithy-aws-traits:[1.10.0, 1.11.0[")
+    api("software.amazon.smithy:smithy-waiters:[1.10.0, 1.11.0[")
+    api("software.amazon.smithy:smithy-aws-iam-traits:[1.10.0, 1.11.0[")
+    api("software.amazon.smithy:smithy-protocol-test-traits:[1.10.0, 1.11.0[")
     api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.5.0")
 }
 

--- a/protocol_tests/aws-restjson/models/models_0.ts
+++ b/protocol_tests/aws-restjson/models/models_0.ts
@@ -33,7 +33,7 @@ export interface AllQueryStringTypesInput {
   queryTimestampList?: Date[];
   queryEnum?: FooEnum | string;
   queryEnumList?: (FooEnum | string)[];
-  queryParamsMapOfStrings?: { [key: string]: string };
+  queryParamsMapOfStringList?: { [key: string]: string[] };
 }
 
 export namespace AllQueryStringTypesInput {

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -168,7 +168,7 @@ export const serializeAws_restJson1AllQueryStringTypesCommand = async (
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/AllQueryStringTypesInput";
   const query: any = {
-    ...(input.queryParamsMapOfStrings !== undefined && input.queryParamsMapOfStrings),
+    ...(input.queryParamsMapOfStringList !== undefined && input.queryParamsMapOfStringList),
     ...(input.queryString !== undefined && { String: input.queryString }),
     ...(input.queryStringList !== undefined && { StringList: (input.queryStringList || []).map((_entry) => _entry) }),
     ...(input.queryStringSet !== undefined && {

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -304,10 +304,10 @@ it("RestJsonQueryStringMap:Request", async () => {
   });
 
   const command = new AllQueryStringTypesCommand({
-    queryParamsMapOfStrings: {
-      QueryParamsStringKeyA: "Foo",
+    queryParamsMapOfStringList: {
+      QueryParamsStringKeyA: ["Foo"],
 
-      QueryParamsStringKeyB: "Bar",
+      QueryParamsStringKeyB: ["Bar"],
     } as any,
   } as any);
   try {


### PR DESCRIPTION
### Description
Just an update to smithy-1.10.0 in code generation. It doesn't change anything outside of a protocol test, and makes it easier to test against new Smithy changes locally.

### Testing
Ran `yarn generate-clients` and `yarn test:protocols`. There were unrelated changes from client generation due to https://github.com/awslabs/smithy-typescript/pull/392 not being in smithy-typescript 0.5.0 in Maven, so I manually reverted the changes that would have rolled back the new generated code.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
