### PR TITLE
fix(polly-request-presigner): not to throw when presign concurrently

### DIFF
--- a/packages/polly-request-presigner/src/getSignedUrls.spec.ts
+++ b/packages/polly-request-presigner/src/getSignedUrls.spec.ts
@@ -93,4 +93,17 @@ describe("getSignedUrl", () => {
     expect(mockPresign).toBeCalled();
     expect(mockPresign.mock.calls[0][1]).toMatchObject(options);
   });
+
+  it("should not throw if it's called concurrently", async () => {
+    const mockPresigned = "a presigned url";
+    mockPresign.mockReturnValue(mockPresigned);
+    const client = new PollyClient(clientParams);
+    const command = new SynthesizeSpeechCommand({
+      Text: "hello world, this is alex",
+      OutputFormat: "mp3",
+      VoiceId: "Kimberly",
+    });
+    const commands = [command, command];
+    return expect(Promise.all(commands.map((command) => getSignedUrl(client, command)))).resolves.toBeInstanceOf(Array);
+  });
 });

--- a/packages/polly-request-presigner/src/getSignedUrls.ts
+++ b/packages/polly-request-presigner/src/getSignedUrls.ts
@@ -51,11 +51,20 @@ export const getSignedUrl = async (
     } as any;
   };
 
-  client.middlewareStack.addRelativeTo(presignInterceptMiddleware, {
-    name: "presignInterceptMiddleware",
-    relation: "before",
-    toMiddleware: "awsAuthMiddleware",
-  });
+  const middlewareName = "presignInterceptMiddleware";
+  try {
+    client.middlewareStack.addRelativeTo(presignInterceptMiddleware, {
+      name: middlewareName,
+      relation: "before",
+      toMiddleware: "awsAuthMiddleware",
+    });
+  } catch (e) {
+    if (e.message!.includes(`Duplicated middleware name '${middlewareName}'`)) {
+      // Swallow if the interceptor is already added. See https://github.com/aws/aws-sdk-js-v3/issues/2417
+    } else {
+      throw e;
+    }
+  }
 
   let presigned: HttpRequest;
   try {
@@ -63,7 +72,7 @@ export const getSignedUrl = async (
     //@ts-ignore the output is faked, so it's not actually OutputType
     presigned = output.presigned;
   } finally {
-    client.middlewareStack.remove("presignInterceptMiddleware");
+    client.middlewareStack.remove(middlewareName);
   }
 
   return formatUrl(presigned);


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-js-v3/issues/2417

Reference: https://github.com/aws/aws-sdk-js-v3/pull/1884

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
