### PR TITLE
fix(packages): use HashConstructor instead of { new: Hash }

### DIFF
--- a/packages/middleware-apply-body-checksum/src/md5Configuration.ts
+++ b/packages/middleware-apply-body-checksum/src/md5Configuration.ts
@@ -1,8 +1,8 @@
-import { Encoder, Hash, StreamHasher } from "@aws-sdk/types";
+import { Encoder, HashConstructor, StreamHasher } from "@aws-sdk/types";
 
 export interface Md5BodyChecksumInputConfig {}
 interface PreviouslyResolved {
-  md5: { new (): Hash };
+  md5: HashConstructor;
   base64Encoder: Encoder;
   streamHasher: StreamHasher<any>;
 }
@@ -12,7 +12,7 @@ export interface Md5BodyChecksumResolvedConfig {
    * A constructor for a class implementing the @aws-sdk/types.Hash interface that computes MD5 hashes.
    * @internal
    */
-  md5: { new (): Hash };
+  md5: HashConstructor;
   /**
    * The function that will be used to convert binary data to a base64-encoded string.
    * @internal

--- a/packages/middleware-sdk-sqs/src/configurations.ts
+++ b/packages/middleware-sdk-sqs/src/configurations.ts
@@ -1,5 +1,5 @@
-import { Hash } from "@aws-sdk/types";
+import { HashConstructor } from "@aws-sdk/types";
 
 export interface PreviouslyResolved {
-  md5: { new (): Hash };
+  md5: HashConstructor;
 }

--- a/packages/middleware-ssec/src/index.ts
+++ b/packages/middleware-ssec/src/index.ts
@@ -1,7 +1,7 @@
 import {
   Decoder,
   Encoder,
-  Hash,
+  HashConstructor,
   InitializeHandler,
   InitializeHandlerArguments,
   InitializeHandlerOptions,
@@ -13,7 +13,7 @@ import {
 } from "@aws-sdk/types";
 interface PreviouslyResolved {
   base64Encoder: Encoder;
-  md5: { new (): Hash };
+  md5: HashConstructor;
   utf8Decoder: Decoder;
 }
 

--- a/packages/types/src/crypto.ts
+++ b/packages/types/src/crypto.ts
@@ -38,7 +38,7 @@ export interface HashConstructor {
  * implementation of this interface.
  */
 export interface StreamHasher<StreamType = any> {
-  (hashCtor: { new (): Hash }, stream: StreamType): Promise<Uint8Array>;
+  (hashCtor: HashConstructor, stream: StreamType): Promise<Uint8Array>;
 }
 
 /**


### PR DESCRIPTION
### Issue
N/A

### Description
Uses existing HashConstructor interface instead of `{ new (): Hash }`

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
