### PR TITLE
fix(md5-js): call fromUtf8 from correct environment

### DIFF
--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -29,13 +29,16 @@
   "dependencies": {
     "@aws-sdk/types": "3.22.0",
     "@aws-sdk/util-utf8-browser": "3.23.0",
+    "@aws-sdk/util-utf8-node": "3.23.0",
     "tslib": "^2.3.0"
   },
   "browser": {
-    "@aws-sdk/util-base64-node": "@aws-sdk/util-base64-browser"
+    "@aws-sdk/util-base64-node": "@aws-sdk/util-base64-browser",
+    "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"
   },
   "react-native": {
-    "@aws-sdk/util-base64-node": "@aws-sdk/util-base64-browser"
+    "@aws-sdk/util-base64-node": "@aws-sdk/util-base64-browser",
+    "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/md5-js/src/index.ts
+++ b/packages/md5-js/src/index.ts
@@ -1,5 +1,5 @@
 import { Hash, SourceData } from "@aws-sdk/types";
-import { fromUtf8 } from "@aws-sdk/util-utf8-browser";
+import { fromUtf8 } from "@aws-sdk/util-utf8-node";
 
 import { BLOCK_SIZE, DIGEST_LENGTH, INIT } from "./constants";
 


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2640

### Description
Calls fromUtf8 from correct environment in md5-js

### Testing
Added console.log as follows:

<details>
<summary>packages/util-utf8-browser/src/index.ts</summary>

```diff
 declare const TextDecoder: Function | undefined;
 declare const TextEncoder: Function | undefined;
 
-export const fromUtf8 = (input: string): Uint8Array =>
-  typeof TextEncoder === "function" ? textEncoderFromUtf8(input) : jsFromUtf8(input);
+export const fromUtf8 = (input: string): Uint8Array => {
+  console.log("util-utf8-browser");
+  return typeof TextEncoder === "function" ? textEncoderFromUtf8(input) : jsFromUtf8(input);
+};
 
 export const toUtf8 = (input: Uint8Array): string =>
   typeof TextDecoder === "function" ? textEncoderToUtf8(input) : jsToUtf8(input);
```

</details>

<details>
<summary>packages/util-utf8-node/src/index.ts</summary>

```diff
 import { fromArrayBuffer, fromString } from "@aws-sdk/util-buffer-from";
 
 export const fromUtf8 = (input: string): Uint8Array => {
+  console.log("util-utf8-node");
   const buf = fromString(input, "utf8");
   return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength / Uint8Array.BYTES_PER_ELEMENT);
 };
```

</details>

#### Test code
```js
// test.js
import { Md5 } from "../aws-sdk-js-v3/packages/md5-js/dist/cjs/index.js";

const hash = new Md5();
hash.update("test");
console.log(btoa(String.fromCharCode.apply(null, await hash.digest())));
```

#### Node.js

```console
$ node test.js
util-utf8-node
CY9rzUYh03PK3k6DJie09g==
```

#### Browser

Created bundle using webpack
```console
$ webpack --version
webpack 5.48.0
webpack-cli 4.7.2

$ webpack ./test.js
```

Copied code from `dist/main.js` and pasted it in browser.
Verified that the following was printed in console:
```
util-utf8-browser
CY9rzUYh03PK3k6DJie09g==
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
