### PR TITLE
chore(codegen): bump to smithy 1.11.x

### DIFF
--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.10.0, 1.11.0[")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.11.0, 1.12.0[")
     compile(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -22,7 +22,7 @@ import kotlin.streams.toList
 
 buildscript {
     dependencies {
-        "classpath"("software.amazon.smithy:smithy-aws-traits:[1.5.1,2.0.0[")
+        "classpath"("software.amazon.smithy:smithy-aws-traits:[1.11.0,1.12.0[")
     }
 }
 

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -25,16 +25,16 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("software.amazon.smithy:smithy-model:[1.10.0, 1.11.0[")
+        classpath("software.amazon.smithy:smithy-model:[1.11.0, 1.12.0[")
     }
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-aws-cloudformation-traits:[1.10.0, 1.11.0[")
-    api("software.amazon.smithy:smithy-aws-traits:[1.10.0, 1.11.0[")
-    api("software.amazon.smithy:smithy-waiters:[1.10.0, 1.11.0[")
-    api("software.amazon.smithy:smithy-aws-iam-traits:[1.10.0, 1.11.0[")
-    api("software.amazon.smithy:smithy-protocol-test-traits:[1.10.0, 1.11.0[")
+    api("software.amazon.smithy:smithy-aws-cloudformation-traits:[1.11.0, 1.12.0[")
+    api("software.amazon.smithy:smithy-aws-traits:[1.11.0, 1.12.0[")
+    api("software.amazon.smithy:smithy-waiters:[1.11.0, 1.12.0[")
+    api("software.amazon.smithy:smithy-aws-iam-traits:[1.11.0, 1.12.0[")
+    api("software.amazon.smithy:smithy-protocol-test-traits:[1.11.0, 1.12.0[")
     api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.5.0")
 }
 


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2626

### Description
Bumps smithy to 1.11.x

### Testing
Packages were generated without any errors.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
