### PR TITLE
docs(client-cognito-identity-provider): Update `AllowedOAuthFlows` with allowed options

### DIFF
--- a/clients/client-cognito-identity-provider/models/models_0.ts
+++ b/clients/client-cognito-identity-provider/models/models_0.ts
@@ -6136,6 +6136,8 @@ export interface CreateUserPoolClientRequest {
    *         <p>Set to <code>client_credentials</code> to specify that the client should get the
    *             access token (and, optionally, ID token, based on scopes) from the token endpoint using
    *             a combination of client and client_secret.</p>
+   *         <p>Note that <code>client_credentials</code> flow can not be selected along with 
+   *             <code>code</code> flow or <code>implicit</code> flow.</p>
    */
   AllowedOAuthFlows?: (OAuthFlowType | string)[];
 

--- a/clients/client-cognito-identity-provider/models/models_0.ts
+++ b/clients/client-cognito-identity-provider/models/models_0.ts
@@ -6136,8 +6136,10 @@ export interface CreateUserPoolClientRequest {
    *         <p>Set to <code>client_credentials</code> to specify that the client should get the
    *             access token (and, optionally, ID token, based on scopes) from the token endpoint using
    *             a combination of client and client_secret.</p>
-   *         <p>Note that <code>client_credentials</code> flow can not be selected along with 
-   *             <code>code</code> flow or <code>implicit</code> flow.</p>
+   *         <note>
+   *             <p>Note that <code>client_credentials</code> flow can not be selected along with 
+   *                 <code>code</code> flow or <code>implicit</code> flow.</p>
+   *         </note>
    */
   AllowedOAuthFlows?: (OAuthFlowType | string)[];
 


### PR DESCRIPTION
Cognito does not allow combining `client_credentials` with either of `code` 
or `implicit`; updating documentation to note this.

### Issue
N/A

### Description
An error is produced if you attempt to do this; I have updated the
documentation to note this.

### Testing
N/A

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
