### PR TITLE
chore(clients): remove build step prior to test

### DIFF
--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -9,7 +9,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es"

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -9,7 +9,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es"

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -9,7 +9,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es"

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -8,7 +8,7 @@
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "test": "yarn build && jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",


### PR DESCRIPTION
### Issue
Noticed while working on https://github.com/aws/aws-sdk-js-v3/pull/2653
Change which introduced ts-jest https://github.com/aws/aws-sdk-js-v3/pull/2088

### Description
The build step is not required prior to running tests, as we now use ts-jest for testing which transpiles the test code before running it.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
