### PR TITLE
fix(ci): link in development ssdk common lib

### DIFF
--- a/.github/workflows/server-protocol-tests.yml
+++ b/.github/workflows/server-protocol-tests.yml
@@ -27,7 +27,12 @@ jobs:
           git clone --depth 1 https://github.com/awslabs/smithy-typescript.git
           cd smithy-typescript
           ./gradlew clean build publishToMavenLocal
-          cd ..
+          cd smithy-typescript-ssdk-libs
+          yarn install
+          yarn build
+          cd server-common
+          yarn link
+          cd ../..
 
       - name: install dependencies
         run: |
@@ -40,6 +45,7 @@ jobs:
       # there are new dependencies as a result of generating server protocol tests
       - name: install dependencies again
         run: |
+          yarn link @aws-smithy/server-common
           yarn install
 
       - name: run protocol tests


### PR DESCRIPTION
### Issue

Fixes CI failures in server-protocol-tests.
Example https://github.com/aws/aws-sdk-js-v3/pull/2654/checks?check_run_id=3291926075

### Description

This links the ssdk common library before running the ssdk protocol tests.

### Testing

Ran the steps myself, and also the CI here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
