### PR TITLE
chore(codegen): enable protocol tests which depend on smithy 1.10.x

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -293,12 +293,6 @@ final class AwsProtocolUtils {
         if (testCase.getId().equals("QueryCustomizedError")) {
             return true;
         }
-        //TODO: enable with Smithy 1.10
-        if ((testCase.getId().equals("RestJsonAllQueryStringTypes")
-                || testCase.getId().equals("RestJsonQueryStringEscaping"))
-                && settings.generateServerSdk()) {
-            return true;
-        }
         // TODO: follow-up with smithy on whether whitespace strings should be trimmed.
         if (testCase.getId().equals("SimpleScalarPropertiesPureWhiteSpace")) {
             return true;


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2558

### Description
Enable protocol tests which depend on smithy 1.10.x
Update to smithy 1.10 was done in https://github.com/aws/aws-sdk-js-v3/pull/2626

### Testing
Will be done by @adamthom-amzn as it impacts server SDK.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
