### PR TITLE
chore(clients): re-introduce CORS retry headers for supported services

### DIFF
--- a/clients/client-auditmanager/AuditManagerClient.ts
+++ b/clients/client-auditmanager/AuditManagerClient.ts
@@ -150,13 +150,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -496,7 +490,6 @@ export class AuditManagerClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   /**

--- a/clients/client-connect-contact-lens/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/ConnectContactLensClient.ts
@@ -19,13 +19,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -239,7 +233,6 @@ export class ConnectContactLensClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   /**

--- a/clients/client-customer-profiles/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/CustomerProfilesClient.ts
@@ -72,13 +72,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -355,7 +349,6 @@ export class CustomerProfilesClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   /**

--- a/clients/client-devops-guru/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/DevOpsGuruClient.ts
@@ -75,13 +75,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -346,7 +340,6 @@ export class DevOpsGuruClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   /**

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -23,13 +23,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -257,7 +251,6 @@ export class IoTDataPlaneClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   /**

--- a/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/ServiceCatalogAppRegistryClient.ts
@@ -65,13 +65,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -320,7 +314,6 @@ export class ServiceCatalogAppRegistryClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -32,16 +32,9 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
     private static final Set<String> SERVICE_IDS = SetUtils.of(
         "ConnectParticipant", // P43593766
-        "IoT Data Plane", // P40355845
         "IoT", // P39759657
         "Kinesis Video Signaling",
-        "AppFlow", // P44424582
-        "AppIntegrations", // P44426207
-        "AuditManager", // P44428767
-        "Connect Contact Lens", // P44429036
-        "Customer Profiles", // P44430824
-        "DevOps Guru", // P44429743
-        "Service Catalog AppRegistry" // P44430229
+        "AppIntegrations" // P44426207
     );
 
     @Override


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2041

### Description
Re-introduces CORS retry headers for supported services

### Testing
Verified in internal tickets that headers are supported for services in this PR.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
