### PR TITLE
fix: set skew offset in catch block upon failure

### DIFF
--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -30,6 +30,13 @@ export function awsAuthMiddleware<Input extends object, Output extends object>(
           signingRegion: context["signing_region"],
           signingService: context["signing_service"],
         }),
+      }).catch((error) => {
+        if (error.Code === "RequestTimeTooSkewed" && error.ServerTime) {
+          const serverTime = Date.parse(error.ServerTime);
+          const newOffset = serverTime - Date.now();
+          options.systemClockOffset = newOffset;
+        }
+        throw error;
       });
 
       const { headers } = output.response as any;


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/2208

### Description
The time skew wasn't correct since the await block got rejected upon a request that has a skewed time. Hence we need to correct the time inside a catch block for it to succeed on the next try.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
