### PR TITLE
test(e2e): fix test fail when no package changes

### DIFF
--- a/tests/e2e/index.js
+++ b/tests/e2e/index.js
@@ -6,6 +6,7 @@ const run = async () => {
     const integTestResourcesEnv = await getIntegTestResources();
     await runE2ETests(integTestResourcesEnv);
   } catch (e) {
+    console.error(e);
     process.exit(1);
   }
 };

--- a/tests/e2e/run-e2e-tests.js
+++ b/tests/e2e/run-e2e-tests.js
@@ -24,7 +24,9 @@ exports.runE2ETests = async (resourcesEnv) => {
   const changedPackages = changedPackagesRecord
     .toString()
     .split("\n")
+    .filter((record) => record.includes(":"))
     .map((record) => record.split(":").slice(0, 2));
+  console.log(changedPackages);
   const packagesToTest = changedPackages.filter((changedPackage) => hasE2Etest(changedPackage[0]));
   if (packagesToTest?.length === 0) {
     console.log("no changed package contains e2e test.");


### PR DESCRIPTION
### Description
Follow up to #2666
Previously the `changedPackages` contains empty array like `[[""]]` when no e2e-applicable package exists. This change removes it.

### Testing
Verified locally.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
