### PR TITLE
fix(middleware-sdk-transcribe-streaming): validate signer

### DIFF
--- a/packages/middleware-sdk-transcribe-streaming/src/configuration.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/configuration.ts
@@ -37,7 +37,4 @@ export const resolveWebSocketConfig = <T>(
         },
       };
 
-const validateSigner = (signer: any): signer is BaseSignatureV4 =>
-  // We cannot use instanceof here. Because we might import the wrong SignatureV4
-  // constructor here as multiple version of packages maybe installed here.
-  (signer.constructor.toString() as string).indexOf("SignatureV4") >= 0;
+const validateSigner = (signer: any): signer is BaseSignatureV4 => !!signer;


### PR DESCRIPTION
This fixes a bug in minified production code described here in #2002 by removing a faulty validator.