### PR TITLE
fix(property-provider): stop memoizing rejected provider

### DIFF
--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -45,16 +45,16 @@ export const memoize: MemoizeOverload = <T>(
   isExpired?: (resolved: T) => boolean,
   requiresRefresh?: (resolved: T) => boolean
 ): Provider<T> => {
-  let result: any;
+  let resolved: any;
   let hasResult: boolean;
   if (isExpired === undefined) {
     // This is a static memoization; no need to incorporate refreshing
-    return () => {
+    return async () => {
       if (!hasResult) {
-        result = provider();
+        resolved = await provider();
         hasResult = true;
       }
-      return result;
+      return resolved;
     };
   }
 
@@ -62,20 +62,19 @@ export const memoize: MemoizeOverload = <T>(
 
   return async () => {
     if (!hasResult) {
-      result = provider();
+      resolved = await provider();
       hasResult = true;
     }
     if (isConstant) {
-      return result;
+      return resolved;
     }
 
-    const resolved = await result;
     if (requiresRefresh && !requiresRefresh(resolved)) {
       isConstant = true;
       return resolved;
     }
     if (isExpired(resolved)) {
-      return (result = provider());
+      return (resolved = await provider());
     }
     return resolved;
   };


### PR DESCRIPTION
### Description
Previously `memoize()` cached the provider promise no matter whether the promise is rejected. When the credential provider throws, the client will keep throwing the credential error even after the underlying credential provider resumes. 

With this change the `memoize()` only caches the successfully resolved credentials. If the credential provider errors out, it will retry the provider in next API call as no credential is available still.

### Testing
Unit test, integration test

### Additional context
JS-2740

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
