### PR TITLE
docs(util-dynamodb): add info about Document client

### DIFF
--- a/packages/util-dynamodb/README.md
+++ b/packages/util-dynamodb/README.md
@@ -5,6 +5,10 @@
 
 This package provides utilities to be used with `@aws-sdk/client-dynamodb`
 
+If you are looking for DynamoDB Document client, please check
+[@aws-sdk/lib-dynamodb](https://www.npmjs.com/package/@aws-sdk/lib-dynamodb)
+which automatically performs the necessary marshalling and unmarshalling.
+
 ## Convert JavaScript object into DynamoDB Record
 
 ```js


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/2652

### Description
Adds information about DyamoDB DocumentClient in README of `@aws-sdk/util-dynamodb`

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
