### PR TITLE
docs(lib-storage): fix typo, normalize comments

### DIFF
--- a/lib/lib-storage/README.md
+++ b/lib/lib-storage/README.md
@@ -17,7 +17,7 @@ Upload allows for easy and efficient uploading of buffers, blobs, or streams, us
       client: new S3({}) || new S3Client({}),
       tags: [...], // optional tags
       queueSize: 4, // optional concurrency configuration
-      partSize: 5MB, // optional size of each part
+      partSize: 5, // optional size of each part
       leavePartsOnError: false, // optional manually handle dropped parts
       params: target,
     });

--- a/lib/lib-storage/src/types.ts
+++ b/lib/lib-storage/src/types.ts
@@ -15,21 +15,20 @@ export type ServiceClients = S3Client;
 
 export interface Configuration {
   /**
+   * Default: 4
    * The size of the concurrent queue manager to upload parts in parallel. Set to 1 for synchronous uploading of parts. Note that the uploader will buffer at most queueSize * partSize bytes into memory at any given time.
-   * default: 4
    */
   queueSize: number;
 
   /**
-   * Default: 5 mb
-   * The size in bytes for each individual part to be uploaded. Adjust the part size to ensure the number of parts does not exceed maxTotalParts. See 5mb is the minimum allowed part size.
+   * Default: 5MB
+   * The size in bytes for each individual part to be uploaded. Adjust the part size to ensure the number of parts does not exceed maxTotalParts. 5MB is the minimum allowed part size.
    */
   partSize: number;
 
   /**
    * Default: false
-   * Whether to abort the multipart upload if an error occurs. Set to true if you want to handle failures manually. If set to false (default)
-   * the upload will drop parts that have failed.
+   * Whether to abort the multipart upload if an error occurs. Set to true if you want to handle failures manually. If set to false (default), the upload will drop parts that have failed.
    */
   leavePartsOnError: boolean;
 


### PR DESCRIPTION
### Issue
N/A

### Description
1. There is a typo in the demo code in the `lib-storage` module README: `partSize` accepts a number, however '5MB' (no quotes) is passed.
2. The comments in the `lib-storage` type declaration file have been normalized for consistency.

### Testing
N/A

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
