### PR TITLE
feat(smithy-client): add parse utils for sized numbers

### DIFF
--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -49,6 +49,57 @@ export const expectNumber = (value: any): number | undefined => {
   throw new TypeError(`Expected number, got ${typeof value}`);
 };
 
+const MAX_FLOAT = Math.ceil(2 ** 127 * (2 - 2 ** -23));
+
+/**
+ * Asserts a value is a 32-bit float and returns it.
+ *
+ * @param value A value that is expected to be a 32-bit float.
+ * @returns The value if it's a float, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
+ */
+export const expectFloat32 = (value: any): number | undefined => {
+  const expected = expectNumber(value);
+  if (expected !== undefined && !Number.isNaN(expected) && expected !== Infinity && expected !== -Infinity) {
+    // IEEE-754 is an imperfect representation for floats. Consider the simple
+    // value `0.1`. The representation in a 32-bit float would look like:
+    //
+    // 0 01111011 10011001100110011001101
+    // Actual value: 0.100000001490116119384765625
+    //
+    // Note the repeating pattern of `1001` in the fraction part. The 64-bit
+    // representation is similar:
+    //
+    // 0 01111111011 1001100110011001100110011001100110011001100110011010
+    // Actual value: 0.100000000000000005551115123126
+    //
+    // So even for what we consider simple numbers, the representation differs
+    // between the two formats. And it's non-obvious how one might look at the
+    // 64-bit value (which is how JS represents numbers) and determine if it
+    // can be represented reasonably in the 32-bit form. Primarily because you
+    // can't know whether the intent was to represent `0.1` or the actual
+    // value in memory. But even if you have both the decimal value and the
+    // double value, that still doesn't communicate the intended precision.
+    //
+    // So rather than attempting to divine the intent of the caller, we instead
+    // do some simple bounds checking to make sure the value is passingly
+    // representable in a 32-bit float. It's not perfect, but it's good enough.
+    // Perfect, even if possible to achieve, would likely be too costly to
+    // be worth it.
+    //
+    // The maximum value of a 32-bit float. Since the 64-bit representation
+    // could be more or less, we just round it up to the nearest whole number.
+    // This further reduces our ability to be certain of the value, but it's
+    // an acceptable tradeoff.
+    //
+    // Compare against the absolute value to simplify things.
+    if (Math.abs(expected) > MAX_FLOAT) {
+      throw new TypeError(`Expected 32-bit float, got ${value}`);
+    }
+  }
+  return expected;
+};
+
 /**
  * Asserts a value is an integer and returns it.
  *
@@ -56,7 +107,7 @@ export const expectNumber = (value: any): number | undefined => {
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export const expectInt = (value: any): number | undefined => {
+export const expectLong = (value: any): number | undefined => {
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -64,6 +115,46 @@ export const expectInt = (value: any): number | undefined => {
     return value;
   }
   throw new TypeError(`Expected integer, got ${typeof value}`);
+};
+
+/**
+ * @deprecated Use expectLong
+ */
+export const expectInt = expectLong;
+
+/**
+ * Asserts a value is a 32-bit integer and returns it.
+ *
+ * @param value A value that is expected to be an integer.
+ * @returns The value if it's an integer, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
+ */
+export const expectInt32 = (value: any): number | undefined => expectSizedInt(value, Int32Array);
+
+/**
+ * Asserts a value is a 16-bit integer and returns it.
+ *
+ * @param value A value that is expected to be an integer.
+ * @returns The value if it's an integer, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
+ */
+export const expectShort = (value: any): number | undefined => expectSizedInt(value, Int16Array);
+
+/**
+ * Asserts a value is an 8-bit integer and returns it.
+ *
+ * @param value A value that is expected to be an integer.
+ * @returns The value if it's an integer, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
+ */
+export const expectByte = (value: any): number | undefined => expectSizedInt(value, Int8Array);
+
+const expectSizedInt = (value: any, intArray: any): number | undefined => {
+  const expected = expectLong(value);
+  if (expected !== undefined && intArray.of(expected)[0] !== expected) {
+    throw new TypeError(`Expected ${intArray.name.match(/\d+/)[0]}-bit integer, got ${value}`);
+  }
+  return expected;
 };
 
 /**
@@ -119,6 +210,35 @@ export const expectString = (value: any): string | undefined => {
 };
 
 /**
+ * Parses a value into a double. If the value is null or undefined, undefined
+ * will be returned. If the value is a string, it will be parsed by the standard
+ * parseFloat with one exception: NaN may only be explicitly set as the string
+ * "NaN", any implicit Nan values will result in an error being thrown. If any
+ * other type is provided, an exception will be thrown.
+ *
+ * @param value A number or string representation of a double.
+ * @returns The value as a number, or undefined if it's null/undefined.
+ */
+export const strictParseDouble = (value: string | number): number | undefined => {
+  if (value === "NaN") {
+    return NaN;
+  }
+  if (typeof value == "string") {
+    const parsed: number = parseFloat(value);
+    if (Number.isNaN(parsed)) {
+      throw new TypeError(`Expected real number, got implicit NaN`);
+    }
+    return expectNumber(parsed);
+  }
+  return expectNumber(value);
+};
+
+/**
+ * @deprecated Use strictParseDouble
+ */
+export const strictParseFloat = strictParseDouble;
+
+/**
  * Parses a value into a float. If the value is null or undefined, undefined
  * will be returned. If the value is a string, it will be parsed by the standard
  * parseFloat with one exception: NaN may only be explicitly set as the string
@@ -128,19 +248,18 @@ export const expectString = (value: any): string | undefined => {
  * @param value A number or string representation of a float.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
-export const strictParseFloat = (value: string | number): number | undefined => {
+export const strictParseFloat32 = (value: string | number): number | undefined => {
   if (value === "NaN") {
     return NaN;
   }
   if (typeof value == "string") {
-    // TODO: handle underflow / overflow explicitly
     const parsed: number = parseFloat(value);
     if (Number.isNaN(parsed)) {
       throw new TypeError(`Expected real number, got implicit NaN`);
     }
-    return expectNumber(parsed);
+    return expectFloat32(parsed);
   }
-  return expectNumber(value);
+  return expectFloat32(value);
 };
 
 /**
@@ -153,27 +272,52 @@ export const strictParseFloat = (value: string | number): number | undefined => 
  * @param value A number or string representation of a non-numeric float.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
-export const limitedParseFloat = (value: string | number): number | undefined => {
+export const limitedParseDouble = (value: string | number): number | undefined => {
   if (typeof value == "string") {
-    switch (value) {
-      case "NaN":
-        return NaN;
-      case "Infinity":
-        return Infinity;
-      case "-Infinity":
-        return -Infinity;
-      default:
-        throw new Error(`Unable to parse float value: ${value}`);
-    }
+    return parseFloatString(value);
   }
-
   return expectNumber(value);
 };
 
 /**
- * @deprecated Use limitedParseFloat or strictParseFloat
+ * @deprecated Use limitedParseDouble
  */
-export const handleFloat = limitedParseFloat;
+export const handleFloat = limitedParseDouble;
+
+/**
+ * @deprecated Use limitedParseDouble
+ */
+export const limitedParseFloat = limitedParseDouble;
+
+/**
+ * Asserts a value is a 32-bit float and returns it. If the value is a string
+ * representation of a non-numeric number type (NaN, Infinity, -Infinity),
+ * the value will be parsed. Any other string value will result in an exception
+ * being thrown. Null or undefined will be returned as undefined. Any other
+ * type will result in an exception being thrown.
+ *
+ * @param value A number or string representation of a non-numeric float.
+ * @returns The value as a number, or undefined if it's null/undefined.
+ */
+export const limitedParseFloat32 = (value: string | number): number | undefined => {
+  if (typeof value == "string") {
+    return parseFloatString(value);
+  }
+  return expectFloat32(value);
+};
+
+const parseFloatString = (value: string): number => {
+  switch (value) {
+    case "NaN":
+      return NaN;
+    case "Infinity":
+      return Infinity;
+    case "-Infinity":
+      return -Infinity;
+    default:
+      throw new Error(`Unable to parse float value: ${value}`);
+  }
+};
 
 /**
  * Parses a value into an integer. If the value is null or undefined, undefined
@@ -185,12 +329,73 @@ export const handleFloat = limitedParseFloat;
  * @param value A number or string representation of an integer.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
-export const strictParseInt = (value: string | number): number | undefined => {
+export const strictParseLong = (value: string | number): number | undefined => {
   if (typeof value === "string") {
     // parseInt can't be used here, because it will silently discard any
     // existing decimals. We want to instead throw an error if there are any.
-    // TODO: handle underflow / overflow explicitly
-    return expectInt(parseFloat(value));
+    return expectLong(parseFloat(value));
   }
-  return expectInt(value);
+  return expectLong(value);
+};
+
+/**
+ * @deprecated Use strictParseLong
+ */
+export const strictParseInt = strictParseLong;
+
+/**
+ * Parses a value into a 32-bit integer. If the value is null or undefined, undefined
+ * will be returned. If the value is a string, it will be parsed by parseFloat
+ * and the result will be asserted to be an integer. If the parsed value is not
+ * an integer, or the raw value is any type other than a string or number, an
+ * exception will be thrown.
+ *
+ * @param value A number or string representation of a 32-bit integer.
+ * @returns The value as a number, or undefined if it's null/undefined.
+ */
+export const strictParseInt32 = (value: string | number): number | undefined => {
+  if (typeof value === "string") {
+    // parseInt can't be used here, because it will silently discard any
+    // existing decimals. We want to instead throw an error if there are any.
+    return expectInt32(parseFloat(value));
+  }
+  return expectInt32(value);
+};
+
+/**
+ * Parses a value into a 16-bit integer. If the value is null or undefined, undefined
+ * will be returned. If the value is a string, it will be parsed by parseFloat
+ * and the result will be asserted to be an integer. If the parsed value is not
+ * an integer, or the raw value is any type other than a string or number, an
+ * exception will be thrown.
+ *
+ * @param value A number or string representation of a 16-bit integer.
+ * @returns The value as a number, or undefined if it's null/undefined.
+ */
+export const strictParseShort = (value: string | number): number | undefined => {
+  if (typeof value === "string") {
+    // parseInt can't be used here, because it will silently discard any
+    // existing decimals. We want to instead throw an error if there are any.
+    return expectShort(parseFloat(value));
+  }
+  return expectShort(value);
+};
+
+/**
+ * Parses a value into an 8-bit integer. If the value is null or undefined, undefined
+ * will be returned. If the value is a string, it will be parsed by parseFloat
+ * and the result will be asserted to be an integer. If the parsed value is not
+ * an integer, or the raw value is any type other than a string or number, an
+ * exception will be thrown.
+ *
+ * @param value A number or string representation of an 8-bit integer.
+ * @returns The value as a number, or undefined if it's null/undefined.
+ */
+export const strictParseByte = (value: string | number): number | undefined => {
+  if (typeof value === "string") {
+    // parseInt can't be used here, because it will silently discard any
+    // existing decimals. We want to instead throw an error if there are any.
+    return expectByte(parseFloat(value));
+  }
+  return expectByte(value);
 };

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -149,7 +149,9 @@ export const expectShort = (value: any): number | undefined => expectSizedInt(va
  */
 export const expectByte = (value: any): number | undefined => expectSizedInt(value, Int8Array);
 
-const expectSizedInt = (value: any, intArray: any): number | undefined => {
+type SizedIntArray = Int32ArrayConstructor | Int16ArrayConstructor | Int8ArrayConstructor;
+
+const expectSizedInt = (value: any, intArray: SizedIntArray): number | undefined => {
   const expected = expectLong(value);
   if (expected !== undefined && intArray.of(expected)[0] !== expected) {
     throw new TypeError(`Expected ${intArray.name.match(/\d+/)[0]}-bit integer, got ${value}`);

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -129,7 +129,7 @@ export const expectInt = expectLong;
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export const expectInt32 = (value: any): number | undefined => expectSizedInt(value, Int32Array);
+export const expectInt32 = (value: any): number | undefined => expectSizedInt(value, 32);
 
 /**
  * Asserts a value is a 16-bit integer and returns it.
@@ -138,7 +138,7 @@ export const expectInt32 = (value: any): number | undefined => expectSizedInt(va
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export const expectShort = (value: any): number | undefined => expectSizedInt(value, Int16Array);
+export const expectShort = (value: any): number | undefined => expectSizedInt(value, 16);
 
 /**
  * Asserts a value is an 8-bit integer and returns it.
@@ -147,16 +147,27 @@ export const expectShort = (value: any): number | undefined => expectSizedInt(va
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export const expectByte = (value: any): number | undefined => expectSizedInt(value, Int8Array);
+export const expectByte = (value: any): number | undefined => expectSizedInt(value, 8);
 
-type SizedIntArray = Int32ArrayConstructor | Int16ArrayConstructor | Int8ArrayConstructor;
+type IntSize = 32 | 16 | 8;
 
-const expectSizedInt = (value: any, intArray: SizedIntArray): number | undefined => {
+const expectSizedInt = (value: any, size: IntSize): number | undefined => {
   const expected = expectLong(value);
-  if (expected !== undefined && intArray.of(expected)[0] !== expected) {
-    throw new TypeError(`Expected ${intArray.name.match(/\d+/)[0]}-bit integer, got ${value}`);
+  if (expected !== undefined && castInt(expected, size) !== expected) {
+    throw new TypeError(`Expected ${size}-bit integer, got ${value}`);
   }
   return expected;
+};
+
+const castInt = (value: number, size: IntSize) => {
+  switch (size) {
+    case 32:
+      return Int32Array.of(value)[0];
+    case 16:
+      return Int16Array.of(value)[0];
+    case 8:
+      return Int8Array.of(value)[0];
+  }
 };
 
 /**


### PR DESCRIPTION
### Issue

n/a

### Description

This adds assertion and parse utilities for differently sized numbers.

### Testing

So many tests.

### Additional context

This depends on: https://github.com/awslabs/smithy-typescript/pull/404

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
