### PR TITLE
fix(middleware-sdk-rds): double encoding the presigned url

### DIFF
--- a/clients/client-docdb/commands/CreateDBClusterCommand.ts
+++ b/clients/client-docdb/commands/CreateDBClusterCommand.ts
@@ -4,7 +4,6 @@ import {
   deserializeAws_queryCreateDBClusterCommand,
   serializeAws_queryCreateDBClusterCommand,
 } from "../protocols/Aws_query";
-import { getCrossRegionPresignedUrlPlugin } from "@aws-sdk/middleware-sdk-rds";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -61,7 +60,6 @@ export class CreateDBClusterCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateDBClusterCommandInput, CreateDBClusterCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getCrossRegionPresignedUrlPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/signature-v4": "3.25.0",
     "@aws-sdk/types": "3.25.0",
     "@aws-sdk/util-format-url": "3.25.0",
-    "@aws-sdk/util-uri-escape": "3.23.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-rds/src/index.spec.ts
+++ b/packages/middleware-sdk-rds/src/index.spec.ts
@@ -32,16 +32,16 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.TargetDBSnapshotIdentifier).toEqual(params.TargetDBSnapshotIdentifier);
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
-    expect(presignedUrl).toMatch(/https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/);
-    expect(presignedUrl).toMatch(/Action%3DCopyDBSnapshot/);
-    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
+    expect(presignedUrl).toMatch(/https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/);
+    expect(presignedUrl).toMatch(/Action\=CopyDBSnapshot/);
+    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
   });
 
   it("should build CreateDBInstanceReadReplica cross origin presigned url correctly ", async () => {
@@ -57,16 +57,16 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.DBInstanceIdentifier).toEqual(params.DBInstanceIdentifier);
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
-    expect(presignedUrl).toMatch(/https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/);
-    expect(presignedUrl).toMatch(/Action%3DCreateDBInstanceReadReplica/);
-    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
+    expect(presignedUrl).toMatch(/https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/);
+    expect(presignedUrl).toMatch(/Action\=CreateDBInstanceReadReplica/);
+    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
   });
 
   it("should build CreateDBCluster cross origin presigned url correctly ", async () => {
@@ -82,16 +82,16 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.DBClusterIdentifier).toEqual(params.DBClusterIdentifier);
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
-    expect(presignedUrl).toMatch(/https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/);
-    expect(presignedUrl).toMatch(/Action%3DCreateDBCluster/);
-    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
+    expect(presignedUrl).toMatch(/https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/);
+    expect(presignedUrl).toMatch(/Action\=CreateDBCluster/);
+    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
   });
 
   it("should build CopyDBClusterSnapshot cross origin presigned url correctly ", async () => {
@@ -107,16 +107,16 @@ describe("middleware-sdk-rds", () => {
     expect(middlewareOutput.input.TargetDBClusterSnapshotIdentifier).toEqual(params.TargetDBClusterSnapshotIdentifier);
     expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
     const presignedUrl = middlewareOutput.input.PreSignedUrl;
-    expect(presignedUrl).toMatch(/https%3A%2F%2Frds\.src\-region\.amazonaws\.com%2F%3F/);
-    expect(presignedUrl).toMatch(/Action%3DCopyDBClusterSnapshot/);
-    expect(presignedUrl).toMatch(/Version%3D2014\-10\-31/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
+    expect(presignedUrl).toMatch(/https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/);
+    expect(presignedUrl).toMatch(/Action\=CopyDBClusterSnapshot/);
+    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
   });
 
   it("should not generate PreSignedUrl if source identifier is not ARN", async () => {

--- a/packages/middleware-sdk-rds/src/index.spec.ts
+++ b/packages/middleware-sdk-rds/src/index.spec.ts
@@ -119,6 +119,29 @@ describe("middleware-sdk-rds", () => {
     expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
   });
 
+  it("should build StartDBInstanceAutomatedBackupsReplication cross origin presigned url correctly ", async () => {
+    const params = {
+      SourceDBInstanceArn: arn,
+      KmsKeyId: "000-111",
+    };
+    await handler({ input: params });
+    expect(nextHandler.mock.calls.length).toBe(1);
+    const middlewareOutput = nextHandler.mock.calls[0][0];
+    expect(middlewareOutput.input.SourceDBInstanceArn).toEqual(params.SourceDBInstanceArn);
+    expect(middlewareOutput.input.KmsKeyId).toEqual(params.KmsKeyId);
+    const presignedUrl = middlewareOutput.input.PreSignedUrl;
+    expect(presignedUrl).toMatch(/https\:\/\/rds\.src\-region\.amazonaws\.com\/\?/);
+    expect(presignedUrl).toMatch(/Action\=StartDBInstanceAutomatedBackupsReplication/);
+    expect(presignedUrl).toMatch(/Version\=2014\-10\-31/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires=([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature=000000/);
+  });
+
   it("should not generate PreSignedUrl if source identifier is not ARN", async () => {
     const params = {
       SourceDBClusterSnapshotIdentifier: sourceIdentifier,

--- a/packages/middleware-sdk-rds/src/index.ts
+++ b/packages/middleware-sdk-rds/src/index.ts
@@ -22,6 +22,7 @@ const sourceIds: string[] = [
   "SourceDBInstanceIdentifier",
   "ReplicationSourceIdentifier",
   "SourceDBClusterSnapshotIdentifier",
+  "SourceDBInstanceArn",
 ];
 
 const sourceIdToCommandKeyMap: { [key: string]: string } = {
@@ -29,6 +30,7 @@ const sourceIdToCommandKeyMap: { [key: string]: string } = {
   SourceDBInstanceIdentifier: "CreateDBInstanceReadReplica",
   ReplicationSourceIdentifier: "CreateDBCluster",
   SourceDBClusterSnapshotIdentifier: "CopyDBClusterSnapshot",
+  SourceDBInstanceArn: "StartDBInstanceAutomatedBackupsReplication",
 };
 
 const version = "2014-10-31";

--- a/packages/middleware-sdk-rds/src/index.ts
+++ b/packages/middleware-sdk-rds/src/index.ts
@@ -14,7 +14,6 @@ import {
   Provider,
 } from "@aws-sdk/types";
 import { formatUrl } from "@aws-sdk/util-format-url";
-import { escapeUri } from "@aws-sdk/util-uri-escape";
 
 const regARN = /arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=/,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?/;
 
@@ -94,7 +93,7 @@ export function crossRegionPresignedUrlMiddleware(options: PreviouslyResolved): 
           ...args,
           input: {
             ...args.input,
-            PreSignedUrl: escapeUri(formatUrl(presignedRequest)),
+            PreSignedUrl: formatUrl(presignedRequest),
           },
         };
       }


### PR DESCRIPTION
### Issue
ref JS-2709

### Description
Previously users will see `PreSignedurl could not be authenticated` error for cross regional copy of snapshots. This is because the presigned url populated automatically be SDK was URIEncoded twice in the body. This change remove the extra uri encoding. 

This change basically is revert of https://github.com/aws/aws-sdk-js-v3/pull/773

### Testing
**[UPDATE]** Unit test, Manual test API:
* `RDS: :CopyDBClusterSnapshot`
* `RDS::CreateDBCluster`
* `RDS::CopyDBSnapshot`
* `RDS::CreateDBInstanceReadReplica`
* `RDS::StartDBInstanceAutomatedBackupsReplication`
* `DocDB::CopyDBClusterSnapshot`
* `Neptune::CopyDBClusterSnapshot`
* `Neptune::CreateDBCluster`.

I remove the support of presigned URL on `DocDB::CreateDBCluster`, because the source identifier parameter does not exist, so a URL cannot be generated. 

`Neptune::CopyDBClusterSnapshot`, `Neptune::CreateDBCluster` presigned URL is not supported currently, but I find it's ok to still populate the value, the server side doesn't complain.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
