### PR TITLE
feat(smithy-client): stricter parsing of request/response bodies

### DIFF
--- a/packages/smithy-client/src/parse-utils.spec.ts
+++ b/packages/smithy-client/src/parse-utils.spec.ts
@@ -1,4 +1,12 @@
-import { expectInt, limitedParseFloat, parseBoolean, strictParseFloat, strictParseInt } from "./parse-utils";
+import {
+  expectInt,
+  expectNonNull,
+  expectObject,
+  limitedParseFloat,
+  parseBoolean,
+  strictParseFloat,
+  strictParseInt,
+} from "./parse-utils";
 import { expectBoolean, expectNumber, expectString } from "./parse-utils";
 
 describe("parseBoolean", () => {
@@ -96,6 +104,38 @@ describe("expectInt", () => {
     it.each([1.1, "1", "1.1", NaN, true, [], {}])("rejects %s", (value) => {
       expect(() => expectInt(value)).toThrowError();
     });
+  });
+});
+
+describe("expectNonNull", () => {
+  it.each([1, 1.1, "1", NaN, true, [], ["a", 123], { a: 123 }, [{ a: 123 }], "{ a : 123 }", '{"a":123}'])(
+    "accepts %s",
+    (value) => {
+      expect(expectNonNull(value)).toEqual(value);
+    }
+  );
+
+  it.each([null, undefined])("rejects %s", (value) => {
+    expect(() => expectNonNull(value)).toThrowError();
+  });
+});
+
+describe("expectObject", () => {
+  it("accepts objects", () => {
+    expect(expectObject({ a: 123 })).toEqual({ a: 123 });
+  });
+
+  it.each([null, undefined])("accepts %s", (value) => {
+    expect(expectObject(value)).toEqual(undefined);
+  });
+
+  describe("rejects non-objects", () => {
+    it.each([1, 1.1, "1", NaN, true, [], ["a", 123], [{ a: 123 }], "{ a : 123 }", '{"a":123}'])(
+      "rejects %s",
+      (value) => {
+        expect(() => expectObject(value)).toThrowError();
+      }
+    );
   });
 });
 

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -67,6 +67,41 @@ export const expectInt = (value: any): number | undefined => {
 };
 
 /**
+ * Asserts a value is not null or undefined and returns it, or throws an error.
+ *
+ * @param value A value that is expected to be defined
+ * @param location The location where we're expecting to find a defined object (optional)
+ * @returns The value if it's not undefined, otherwise throws an error
+ */
+export const expectNonNull = <T>(value: T | null | undefined, location?: string): T => {
+  if (value === null || value === undefined) {
+    if (location) {
+      throw new TypeError(`Expected a non-null value for ${location}`);
+    }
+    throw new TypeError("Expected a non-null value");
+  }
+  return value;
+};
+
+/**
+ * Asserts a value is an JSON-like object and returns it. This is expected to be used
+ * with values parsed from JSON (arrays, objects, numbers, strings, booleans).
+ *
+ * @param value A value that is expected to be an object
+ * @returns The value if it's an object, undefined if it's null/undefined,
+ *   otherwise an error is thrown.
+ */
+export const expectObject = (value: any): { [key: string]: any } | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value;
+  }
+  throw new TypeError(`Expected object, got ${typeof value}`);
+};
+
+/**
  * Asserts a value is a string and returns it.
  *
  * @param value A value that is expected to be a string.


### PR DESCRIPTION
### Description
Structured, non-payload-bound requests (to servers) and responses (to clients) should always be a JSON object in the REST/JSON protocol. This adds parsing utility functions so we can update the generator to assert that these requests/responses are JSON objects that are not null.

### Testing
I have a local change to the generator, and I regenerated all clients and client and server protocol tests, and ran the protocol tests. They passed.

### Additional context
I will have a PR to update the generator, and to update the generated code, after this.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
