### PR TITLE
fix(property-provider): do not make extra provider calls when concurrent

### DIFF
--- a/packages/property-provider/src/memoize.spec.ts
+++ b/packages/property-provider/src/memoize.spec.ts
@@ -28,11 +28,10 @@ describe("memoize", () => {
 
     it("should not make extra request for concurrent calls", async () => {
       const memoized = memoize(provider);
-      const result = await memoized();
       const results = await Promise.all([...Array(repeatTimes).keys()].map(() => memoized()));
       expect(provider).toHaveBeenCalledTimes(1);
       for (const res of results) {
-        expect(res).toStrictEqual(result);
+        expect(res).toStrictEqual(mockReturn);
       }
     });
 
@@ -144,11 +143,10 @@ describe("memoize", () => {
     describe("should not make extra request for concurrent calls", () => {
       const requiresRefreshFalseTest = async () => {
         const memoized = memoize(provider, isExpired, requiresRefresh);
-        const result = await memoized();
         const results = await Promise.all([...Array(repeatTimes).keys()].map(() => memoized()));
         expect(provider).toHaveBeenCalledTimes(1);
         for (const res of results) {
-          expect(res).toStrictEqual(result);
+          expect(res).toStrictEqual(mockReturn);
         }
       };
 

--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -56,8 +56,6 @@ export const memoize: MemoizeOverload = <T>(
     try {
       resolved = await pending;
       hasResult = true;
-    } catch (e) {
-      throw e;
     } finally {
       pending = undefined;
     }
@@ -68,7 +66,7 @@ export const memoize: MemoizeOverload = <T>(
     // This is a static memoization; no need to incorporate refreshing
     return async () => {
       if (!hasResult) {
-        return await coalesceProvider();
+        resolved = await coalesceProvider();
       }
       return resolved;
     };
@@ -78,7 +76,7 @@ export const memoize: MemoizeOverload = <T>(
 
   return async () => {
     if (!hasResult) {
-      await coalesceProvider();
+      resolved = await coalesceProvider();
     }
     if (isConstant) {
       return resolved;


### PR DESCRIPTION
### Description
This change fix a regression introduced in https://github.com/aws/aws-sdk-js-v3/pull/2680. It was caused by the code I removed without understanding the purpose: https://github.com/aws/aws-sdk-js-v3/pull/2680#discussion_r690504358. The bug will cause the provider being invoked multiple times before being cached. 

With this change, I port back that feature that provider will only be executed once during concurrent calls.  The unit test now has better description to prevent being removed.

### Testing
Unit test, Manual test.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
