### PR TITLE
fix(parse): reject numeric strings with non-numbers

### DIFF
--- a/packages/smithy-client/src/parse-utils.spec.ts
+++ b/packages/smithy-client/src/parse-utils.spec.ts
@@ -320,13 +320,44 @@ describe("strictParseDouble", () => {
     expect(strictParseDouble("NaN")).toEqual(NaN);
   });
 
-  it("rejects implicit NaN", () => {
-    expect(() => strictParseDouble("foo")).toThrowError();
+  describe("rejects implicit NaN", () => {
+    it.each([
+      "foo",
+      "123ABC",
+      "ABC123",
+      "12AB3C",
+      "1.A",
+      "1.1A",
+      "1.1A1",
+      "0xFF",
+      "0XFF",
+      "0b1111",
+      "0B1111",
+      "0777",
+      "0o777",
+      "0O777",
+      "1n",
+      "1N",
+      "1_000",
+      "e",
+      "e1",
+      ".1",
+    ])("rejects %s", (value) => {
+      expect(() => strictParseDouble(value)).toThrowError();
+    });
   });
 
   it("accepts numeric strings", () => {
     expect(strictParseDouble("1")).toEqual(1);
+    expect(strictParseDouble("-1")).toEqual(-1);
     expect(strictParseDouble("1.1")).toEqual(1.1);
+    expect(strictParseDouble("1e1")).toEqual(10);
+    expect(strictParseDouble("-1e1")).toEqual(-10);
+    expect(strictParseDouble("1e+1")).toEqual(10);
+    expect(strictParseDouble("1e-1")).toEqual(0.1);
+    expect(strictParseDouble("1E1")).toEqual(10);
+    expect(strictParseDouble("1E+1")).toEqual(10);
+    expect(strictParseDouble("1E-1")).toEqual(0.1);
   });
 
   describe("accepts numbers", () => {
@@ -347,8 +378,31 @@ describe("strictParseFloat32", () => {
     expect(strictParseFloat32("NaN")).toEqual(NaN);
   });
 
-  it("rejects implicit NaN", () => {
-    expect(() => strictParseFloat32("foo")).toThrowError();
+  describe("rejects implicit NaN", () => {
+    it.each([
+      "foo",
+      "123ABC",
+      "ABC123",
+      "12AB3C",
+      "1.A",
+      "1.1A",
+      "1.1A1",
+      "0xFF",
+      "0XFF",
+      "0b1111",
+      "0B1111",
+      "0777",
+      "0o777",
+      "0O777",
+      "1n",
+      "1N",
+      "1_000",
+      "e",
+      "e1",
+      ".1",
+    ])("rejects %s", (value) => {
+      expect(() => strictParseFloat32(value)).toThrowError();
+    });
   });
 
   describe("rejects doubles", () => {
@@ -359,7 +413,15 @@ describe("strictParseFloat32", () => {
 
   it("accepts numeric strings", () => {
     expect(strictParseFloat32("1")).toEqual(1);
+    expect(strictParseFloat32("-1")).toEqual(-1);
     expect(strictParseFloat32("1.1")).toEqual(1.1);
+    expect(strictParseFloat32("1e1")).toEqual(10);
+    expect(strictParseFloat32("-1e1")).toEqual(-10);
+    expect(strictParseFloat32("1e+1")).toEqual(10);
+    expect(strictParseFloat32("1e-1")).toEqual(0.1);
+    expect(strictParseFloat32("1E1")).toEqual(10);
+    expect(strictParseFloat32("1E+1")).toEqual(10);
+    expect(strictParseFloat32("1E-1")).toEqual(0.1);
   });
 
   describe("accepts numbers", () => {
@@ -489,12 +551,26 @@ describe("strictParseLong", () => {
   });
 
   describe("rejects non-integers", () => {
-    it.each([1.1, "1.1", "NaN", "Infinity", "-Infinity", NaN, Infinity, -Infinity, true, false, [], {}])(
-      "rejects %s",
-      (value) => {
-        expect(() => strictParseLong(value as any)).toThrowError();
-      }
-    );
+    it.each([
+      1.1,
+      "1.1",
+      "NaN",
+      "Infinity",
+      "-Infinity",
+      NaN,
+      Infinity,
+      -Infinity,
+      true,
+      false,
+      [],
+      {},
+      "foo",
+      "123ABC",
+      "ABC123",
+      "12AB3C",
+    ])("rejects %s", (value) => {
+      expect(() => strictParseLong(value as any)).toThrowError();
+    });
   });
 });
 
@@ -530,6 +606,10 @@ describe("strictParseInt32", () => {
       -(2 ** 63 + 1),
       2 ** 31,
       -(2 ** 31 + 1),
+      "foo",
+      "123ABC",
+      "ABC123",
+      "12AB3C",
     ])("rejects %s", (value) => {
       expect(() => strictParseInt32(value as any)).toThrowError();
     });
@@ -570,6 +650,10 @@ describe("strictParseShort", () => {
       -(2 ** 31 + 1),
       2 ** 15,
       -(2 ** 15 + 1),
+      "foo",
+      "123ABC",
+      "ABC123",
+      "12AB3C",
     ])("rejects %s", (value) => {
       expect(() => strictParseShort(value as any)).toThrowError();
     });
@@ -612,6 +696,10 @@ describe("strictParseByte", () => {
       -(2 ** 15 + 1),
       128,
       -129,
+      "foo",
+      "123ABC",
+      "ABC123",
+      "12AB3C",
     ])("rejects %s", (value) => {
       expect(() => strictParseByte(value as any)).toThrowError();
     });

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -233,15 +233,8 @@ export const expectString = (value: any): string | undefined => {
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseDouble = (value: string | number): number | undefined => {
-  if (value === "NaN") {
-    return NaN;
-  }
   if (typeof value == "string") {
-    const parsed: number = parseFloat(value);
-    if (Number.isNaN(parsed)) {
-      throw new TypeError(`Expected real number, got implicit NaN`);
-    }
-    return expectNumber(parsed);
+    return expectNumber(parseNumber(value));
   }
   return expectNumber(value);
 };
@@ -262,17 +255,26 @@ export const strictParseFloat = strictParseDouble;
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseFloat32 = (value: string | number): number | undefined => {
-  if (value === "NaN") {
-    return NaN;
-  }
   if (typeof value == "string") {
-    const parsed: number = parseFloat(value);
-    if (Number.isNaN(parsed)) {
-      throw new TypeError(`Expected real number, got implicit NaN`);
-    }
-    return expectFloat32(parsed);
+    return expectFloat32(parseNumber(value));
   }
   return expectFloat32(value);
+};
+
+// This regex matches JSON-style numbers. In short:
+// * The integral may start with a negative sign, but not a positive one
+// * No leading 0 on the integral unless it's immediately followed by a '.'
+// * Exponent indicated by a case-insensitive 'E' optionally followed by a
+//   positive/negative sign and some number of digits.
+// It also matches both positive and negative infinity as well and explicit NaN.
+const NUMBER_REGEX = /(-?((0(\.\d+)?)|(([1-9]\d*(\.\d)?)\d*)((e|E)(\+|-)?\d+)?))|(-?Infinity)|(NaN)/g;
+
+const parseNumber = (value: string): number => {
+  const matches = value.match(NUMBER_REGEX);
+  if (matches === null || matches[0].length !== value.length) {
+    throw new TypeError(`Expected real number, got implicit NaN`);
+  }
+  return parseFloat(value);
 };
 
 /**
@@ -346,7 +348,7 @@ export const strictParseLong = (value: string | number): number | undefined => {
   if (typeof value === "string") {
     // parseInt can't be used here, because it will silently discard any
     // existing decimals. We want to instead throw an error if there are any.
-    return expectLong(parseFloat(value));
+    return expectLong(parseNumber(value));
   }
   return expectLong(value);
 };
@@ -370,7 +372,7 @@ export const strictParseInt32 = (value: string | number): number | undefined => 
   if (typeof value === "string") {
     // parseInt can't be used here, because it will silently discard any
     // existing decimals. We want to instead throw an error if there are any.
-    return expectInt32(parseFloat(value));
+    return expectInt32(parseNumber(value));
   }
   return expectInt32(value);
 };
@@ -389,7 +391,7 @@ export const strictParseShort = (value: string | number): number | undefined => 
   if (typeof value === "string") {
     // parseInt can't be used here, because it will silently discard any
     // existing decimals. We want to instead throw an error if there are any.
-    return expectShort(parseFloat(value));
+    return expectShort(parseNumber(value));
   }
   return expectShort(value);
 };
@@ -408,7 +410,7 @@ export const strictParseByte = (value: string | number): number | undefined => {
   if (typeof value === "string") {
     // parseInt can't be used here, because it will silently discard any
     // existing decimals. We want to instead throw an error if there are any.
-    return expectByte(parseFloat(value));
+    return expectByte(parseNumber(value));
   }
   return expectByte(value);
 };

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -267,7 +267,7 @@ export const strictParseFloat32 = (value: string | number): number | undefined =
 // * Exponent indicated by a case-insensitive 'E' optionally followed by a
 //   positive/negative sign and some number of digits.
 // It also matches both positive and negative infinity as well and explicit NaN.
-const NUMBER_REGEX = /(-?((0(\.\d+)?)|(([1-9]\d*(\.\d)?)\d*)((e|E)(\+|-)?\d+)?))|(-?Infinity)|(NaN)/g;
+const NUMBER_REGEX = /(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)|(-?Infinity)|(NaN)/g;
 
 const parseNumber = (value: string): number => {
   const matches = value.match(NUMBER_REGEX);


### PR DESCRIPTION
### Issue

N/A

### Description

This updates the number parsing utilities to reject strings like "1A", which `parseFloat` would ordinarily happily accept as the value `1`. It also updates it to reject the wide swath of alternative number formats that JS numbers can have.

### Testing

Additional unit tests were added.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
