### PR TITLE
chore(codegen): regenerate with strict body parsing

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
@@ -113,6 +113,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseInt32 as __strictParseInt32,
@@ -1179,7 +1181,7 @@ export const deserializeAws_restJson1CreateAccessPreviewCommand = async (
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -1282,7 +1284,7 @@ export const deserializeAws_restJson1CreateAnalyzerCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1642,7 +1644,7 @@ export const deserializeAws_restJson1GetAccessPreviewCommand = async (
     $metadata: deserializeMetadata(output),
     accessPreview: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPreview !== undefined && data.accessPreview !== null) {
     contents.accessPreview = deserializeAws_restJson1AccessPreview(data.accessPreview, context);
   }
@@ -1729,7 +1731,7 @@ export const deserializeAws_restJson1GetAnalyzedResourceCommand = async (
     $metadata: deserializeMetadata(output),
     resource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resource !== undefined && data.resource !== null) {
     contents.resource = deserializeAws_restJson1AnalyzedResource(data.resource, context);
   }
@@ -1816,7 +1818,7 @@ export const deserializeAws_restJson1GetAnalyzerCommand = async (
     $metadata: deserializeMetadata(output),
     analyzer: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analyzer !== undefined && data.analyzer !== null) {
     contents.analyzer = deserializeAws_restJson1AnalyzerSummary(data.analyzer, context);
   }
@@ -1903,7 +1905,7 @@ export const deserializeAws_restJson1GetArchiveRuleCommand = async (
     $metadata: deserializeMetadata(output),
     archiveRule: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.archiveRule !== undefined && data.archiveRule !== null) {
     contents.archiveRule = deserializeAws_restJson1ArchiveRuleSummary(data.archiveRule, context);
   }
@@ -1990,7 +1992,7 @@ export const deserializeAws_restJson1GetFindingCommand = async (
     $metadata: deserializeMetadata(output),
     finding: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.finding !== undefined && data.finding !== null) {
     contents.finding = deserializeAws_restJson1Finding(data.finding, context);
   }
@@ -2078,7 +2080,7 @@ export const deserializeAws_restJson1GetGeneratedPolicyCommand = async (
     generatedPolicyResult: undefined,
     jobDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.generatedPolicyResult !== undefined && data.generatedPolicyResult !== null) {
     contents.generatedPolicyResult = deserializeAws_restJson1GeneratedPolicyResult(data.generatedPolicyResult, context);
   }
@@ -2161,7 +2163,7 @@ export const deserializeAws_restJson1ListAccessPreviewFindingsCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1AccessPreviewFindingsList(data.findings, context);
   }
@@ -2260,7 +2262,7 @@ export const deserializeAws_restJson1ListAccessPreviewsCommand = async (
     accessPreviews: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPreviews !== undefined && data.accessPreviews !== null) {
     contents.accessPreviews = deserializeAws_restJson1AccessPreviewsList(data.accessPreviews, context);
   }
@@ -2351,7 +2353,7 @@ export const deserializeAws_restJson1ListAnalyzedResourcesCommand = async (
     analyzedResources: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analyzedResources !== undefined && data.analyzedResources !== null) {
     contents.analyzedResources = deserializeAws_restJson1AnalyzedResourcesList(data.analyzedResources, context);
   }
@@ -2442,7 +2444,7 @@ export const deserializeAws_restJson1ListAnalyzersCommand = async (
     analyzers: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analyzers !== undefined && data.analyzers !== null) {
     contents.analyzers = deserializeAws_restJson1AnalyzersList(data.analyzers, context);
   }
@@ -2525,7 +2527,7 @@ export const deserializeAws_restJson1ListArchiveRulesCommand = async (
     archiveRules: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.archiveRules !== undefined && data.archiveRules !== null) {
     contents.archiveRules = deserializeAws_restJson1ArchiveRulesList(data.archiveRules, context);
   }
@@ -2608,7 +2610,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1FindingsList(data.findings, context);
   }
@@ -2699,7 +2701,7 @@ export const deserializeAws_restJson1ListPolicyGenerationsCommand = async (
     nextToken: undefined,
     policyGenerations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2781,7 +2783,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2868,7 +2870,7 @@ export const deserializeAws_restJson1StartPolicyGenerationCommand = async (
     $metadata: deserializeMetadata(output),
     jobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobId !== undefined && data.jobId !== null) {
     contents.jobId = __expectString(data.jobId);
   }
@@ -3379,7 +3381,7 @@ export const deserializeAws_restJson1ValidatePolicyCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1ValidatePolicyFindingList(data.findings, context);
   }

--- a/clients/client-amp/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/protocols/Aws_restJson1.ts
@@ -21,6 +21,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseInt32 as __strictParseInt32,
@@ -194,7 +196,7 @@ export const deserializeAws_restJson1CreateWorkspaceCommand = async (
     status: undefined,
     workspaceId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -378,7 +380,7 @@ export const deserializeAws_restJson1DescribeWorkspaceCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -466,7 +468,7 @@ export const deserializeAws_restJson1ListWorkspacesCommand = async (
     nextToken: undefined,
     workspaces: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-amplify/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1.ts
@@ -91,6 +91,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1625,7 +1627,7 @@ export const deserializeAws_restJson1CreateAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -1712,7 +1714,7 @@ export const deserializeAws_restJson1CreateBackendEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     backendEnvironment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironment !== undefined && data.backendEnvironment !== null) {
     contents.backendEnvironment = deserializeAws_restJson1BackendEnvironment(data.backendEnvironment, context);
   }
@@ -1799,7 +1801,7 @@ export const deserializeAws_restJson1CreateBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -1896,7 +1898,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     jobId: undefined,
     zipUploadUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fileUploadUrls !== undefined && data.fileUploadUrls !== null) {
     contents.fileUploadUrls = deserializeAws_restJson1FileUploadUrls(data.fileUploadUrls, context);
   }
@@ -1981,7 +1983,7 @@ export const deserializeAws_restJson1CreateDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -2076,7 +2078,7 @@ export const deserializeAws_restJson1CreateWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }
@@ -2171,7 +2173,7 @@ export const deserializeAws_restJson1DeleteAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -2258,7 +2260,7 @@ export const deserializeAws_restJson1DeleteBackendEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     backendEnvironment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironment !== undefined && data.backendEnvironment !== null) {
     contents.backendEnvironment = deserializeAws_restJson1BackendEnvironment(data.backendEnvironment, context);
   }
@@ -2345,7 +2347,7 @@ export const deserializeAws_restJson1DeleteBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -2432,7 +2434,7 @@ export const deserializeAws_restJson1DeleteDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -2519,7 +2521,7 @@ export const deserializeAws_restJson1DeleteJobCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -2606,7 +2608,7 @@ export const deserializeAws_restJson1DeleteWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }
@@ -2693,7 +2695,7 @@ export const deserializeAws_restJson1GenerateAccessLogsCommand = async (
     $metadata: deserializeMetadata(output),
     logUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logUrl !== undefined && data.logUrl !== null) {
     contents.logUrl = __expectString(data.logUrl);
   }
@@ -2772,7 +2774,7 @@ export const deserializeAws_restJson1GetAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -2852,7 +2854,7 @@ export const deserializeAws_restJson1GetArtifactUrlCommand = async (
     artifactId: undefined,
     artifactUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.artifactId !== undefined && data.artifactId !== null) {
     contents.artifactId = __expectString(data.artifactId);
   }
@@ -2942,7 +2944,7 @@ export const deserializeAws_restJson1GetBackendEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     backendEnvironment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironment !== undefined && data.backendEnvironment !== null) {
     contents.backendEnvironment = deserializeAws_restJson1BackendEnvironment(data.backendEnvironment, context);
   }
@@ -3021,7 +3023,7 @@ export const deserializeAws_restJson1GetBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -3100,7 +3102,7 @@ export const deserializeAws_restJson1GetDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -3179,7 +3181,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -3266,7 +3268,7 @@ export const deserializeAws_restJson1GetWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }
@@ -3354,7 +3356,7 @@ export const deserializeAws_restJson1ListAppsCommand = async (
     apps: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apps !== undefined && data.apps !== null) {
     contents.apps = deserializeAws_restJson1Apps(data.apps, context);
   }
@@ -3429,7 +3431,7 @@ export const deserializeAws_restJson1ListArtifactsCommand = async (
     artifacts: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.artifacts !== undefined && data.artifacts !== null) {
     contents.artifacts = deserializeAws_restJson1Artifacts(data.artifacts, context);
   }
@@ -3512,7 +3514,7 @@ export const deserializeAws_restJson1ListBackendEnvironmentsCommand = async (
     backendEnvironments: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironments !== undefined && data.backendEnvironments !== null) {
     contents.backendEnvironments = deserializeAws_restJson1BackendEnvironments(data.backendEnvironments, context);
   }
@@ -3587,7 +3589,7 @@ export const deserializeAws_restJson1ListBranchesCommand = async (
     branches: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branches !== undefined && data.branches !== null) {
     contents.branches = deserializeAws_restJson1Branches(data.branches, context);
   }
@@ -3662,7 +3664,7 @@ export const deserializeAws_restJson1ListDomainAssociationsCommand = async (
     domainAssociations: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociations !== undefined && data.domainAssociations !== null) {
     contents.domainAssociations = deserializeAws_restJson1DomainAssociations(data.domainAssociations, context);
   }
@@ -3737,7 +3739,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     jobSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummaries !== undefined && data.jobSummaries !== null) {
     contents.jobSummaries = deserializeAws_restJson1JobSummaries(data.jobSummaries, context);
   }
@@ -3819,7 +3821,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -3891,7 +3893,7 @@ export const deserializeAws_restJson1ListWebhooksCommand = async (
     nextToken: undefined,
     webhooks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3973,7 +3975,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -4060,7 +4062,7 @@ export const deserializeAws_restJson1StartJobCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -4147,7 +4149,7 @@ export const deserializeAws_restJson1StopJobCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -4368,7 +4370,7 @@ export const deserializeAws_restJson1UpdateAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -4447,7 +4449,7 @@ export const deserializeAws_restJson1UpdateBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -4534,7 +4536,7 @@ export const deserializeAws_restJson1UpdateDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -4621,7 +4623,7 @@ export const deserializeAws_restJson1UpdateWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }

--- a/clients/client-amplifybackend/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifybackend/protocols/Aws_restJson1.ts
@@ -78,6 +78,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1142,7 +1144,7 @@ export const deserializeAws_restJson1CloneBackendCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1241,7 +1243,7 @@ export const deserializeAws_restJson1CreateBackendCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1340,7 +1342,7 @@ export const deserializeAws_restJson1CreateBackendAPICommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1439,7 +1441,7 @@ export const deserializeAws_restJson1CreateBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1536,7 +1538,7 @@ export const deserializeAws_restJson1CreateBackendConfigCommand = async (
     JobId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1627,7 +1629,7 @@ export const deserializeAws_restJson1CreateTokenCommand = async (
     SessionId: undefined,
     Ttl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1720,7 +1722,7 @@ export const deserializeAws_restJson1DeleteBackendCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1819,7 +1821,7 @@ export const deserializeAws_restJson1DeleteBackendAPICommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1918,7 +1920,7 @@ export const deserializeAws_restJson1DeleteBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2012,7 +2014,7 @@ export const deserializeAws_restJson1DeleteTokenCommand = async (
     $metadata: deserializeMetadata(output),
     IsSuccess: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.isSuccess !== undefined && data.isSuccess !== null) {
     contents.IsSuccess = __expectBoolean(data.isSuccess);
   }
@@ -2096,7 +2098,7 @@ export const deserializeAws_restJson1GenerateBackendAPIModelsCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2195,7 +2197,7 @@ export const deserializeAws_restJson1GetBackendCommand = async (
     BackendEnvironmentName: undefined,
     Error: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.amplifyMetaConfig !== undefined && data.amplifyMetaConfig !== null) {
     contents.AmplifyMetaConfig = __expectString(data.amplifyMetaConfig);
   }
@@ -2293,7 +2295,7 @@ export const deserializeAws_restJson1GetBackendAPICommand = async (
     ResourceConfig: undefined,
     ResourceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2385,7 +2387,7 @@ export const deserializeAws_restJson1GetBackendAPIModelsCommand = async (
     Models: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.models !== undefined && data.models !== null) {
     contents.Models = __expectString(data.models);
   }
@@ -2471,7 +2473,7 @@ export const deserializeAws_restJson1GetBackendAuthCommand = async (
     ResourceConfig: undefined,
     ResourceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2569,7 +2571,7 @@ export const deserializeAws_restJson1GetBackendJobCommand = async (
     Status: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2672,7 +2674,7 @@ export const deserializeAws_restJson1GetTokenCommand = async (
     SessionId: undefined,
     Ttl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2765,7 +2767,7 @@ export const deserializeAws_restJson1ImportBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2860,7 +2862,7 @@ export const deserializeAws_restJson1ListBackendJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.Jobs = deserializeAws_restJson1ListOfBackendJobRespObj(data.jobs, context);
   }
@@ -2946,7 +2948,7 @@ export const deserializeAws_restJson1RemoveAllBackendsCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3037,7 +3039,7 @@ export const deserializeAws_restJson1RemoveBackendConfigCommand = async (
     $metadata: deserializeMetadata(output),
     Error: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.error !== undefined && data.error !== null) {
     contents.Error = __expectString(data.error);
   }
@@ -3121,7 +3123,7 @@ export const deserializeAws_restJson1UpdateBackendAPICommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3220,7 +3222,7 @@ export const deserializeAws_restJson1UpdateBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3317,7 +3319,7 @@ export const deserializeAws_restJson1UpdateBackendConfigCommand = async (
     Error: undefined,
     LoginAuthConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3412,7 +3414,7 @@ export const deserializeAws_restJson1UpdateBackendJobCommand = async (
     Status: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -279,6 +279,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -5161,7 +5163,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
     tags: undefined,
     value: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -5292,7 +5294,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
     providerARNs: undefined,
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authType !== undefined && data.authType !== null) {
     contents.authType = __expectString(data.authType);
   }
@@ -5416,7 +5418,7 @@ export const deserializeAws_restJson1CreateBasePathMappingCommand = async (
     restApiId: undefined,
     stage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.basePath !== undefined && data.basePath !== null) {
     contents.basePath = __expectString(data.basePath);
   }
@@ -5520,7 +5522,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     description: undefined,
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiSummary !== undefined && data.apiSummary !== null) {
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
@@ -5634,7 +5636,7 @@ export const deserializeAws_restJson1CreateDocumentationPartCommand = async (
     location: undefined,
     properties: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -5737,7 +5739,7 @@ export const deserializeAws_restJson1CreateDocumentationVersionCommand = async (
     description: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -5854,7 +5856,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
     securityPolicy: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -5996,7 +5998,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
     name: undefined,
     schema: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.contentType = __expectString(data.contentType);
   }
@@ -6106,7 +6108,7 @@ export const deserializeAws_restJson1CreateRequestValidatorCommand = async (
     validateRequestBody: undefined,
     validateRequestParameters: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -6214,7 +6216,7 @@ export const deserializeAws_restJson1CreateResourceCommand = async (
     pathPart: undefined,
     resourceMethods: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -6333,7 +6335,7 @@ export const deserializeAws_restJson1CreateRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -6472,7 +6474,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     variables: undefined,
     webAclArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -6622,7 +6624,7 @@ export const deserializeAws_restJson1CreateUsagePlanCommand = async (
     tags: undefined,
     throttle: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiStages !== undefined && data.apiStages !== null) {
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
@@ -6741,7 +6743,7 @@ export const deserializeAws_restJson1CreateUsagePlanKeyCommand = async (
     type: undefined,
     value: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -6851,7 +6853,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
     tags: undefined,
     targetArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -8894,7 +8896,7 @@ export const deserializeAws_restJson1GenerateClientCertificateCommand = async (
     pemEncodedCertificate: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
@@ -8999,7 +9001,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     features: undefined,
     throttleSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyVersion !== undefined && data.apiKeyVersion !== null) {
     contents.apiKeyVersion = __expectString(data.apiKeyVersion);
   }
@@ -9096,7 +9098,7 @@ export const deserializeAws_restJson1GetApiKeyCommand = async (
     tags: undefined,
     value: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -9204,7 +9206,7 @@ export const deserializeAws_restJson1GetApiKeysCommand = async (
     position: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfApiKey(data.item, context);
   }
@@ -9298,7 +9300,7 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
     providerARNs: undefined,
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authType !== undefined && data.authType !== null) {
     contents.authType = __expectString(data.authType);
   }
@@ -9405,7 +9407,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfAuthorizer(data.item, context);
   }
@@ -9489,7 +9491,7 @@ export const deserializeAws_restJson1GetBasePathMappingCommand = async (
     restApiId: undefined,
     stage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.basePath !== undefined && data.basePath !== null) {
     contents.basePath = __expectString(data.basePath);
   }
@@ -9575,7 +9577,7 @@ export const deserializeAws_restJson1GetBasePathMappingsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfBasePathMapping(data.item, context);
   }
@@ -9662,7 +9664,7 @@ export const deserializeAws_restJson1GetClientCertificateCommand = async (
     pemEncodedCertificate: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
@@ -9757,7 +9759,7 @@ export const deserializeAws_restJson1GetClientCertificatesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfClientCertificate(data.item, context);
   }
@@ -9842,7 +9844,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     description: undefined,
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiSummary !== undefined && data.apiSummary !== null) {
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
@@ -9939,7 +9941,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDeployment(data.item, context);
   }
@@ -10031,7 +10033,7 @@ export const deserializeAws_restJson1GetDocumentationPartCommand = async (
     location: undefined,
     properties: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -10117,7 +10119,7 @@ export const deserializeAws_restJson1GetDocumentationPartsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDocumentationPart(data.item, context);
   }
@@ -10201,7 +10203,7 @@ export const deserializeAws_restJson1GetDocumentationVersionCommand = async (
     description: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -10279,7 +10281,7 @@ export const deserializeAws_restJson1GetDocumentationVersionsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDocumentationVersion(data.item, context);
   }
@@ -10377,7 +10379,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
     securityPolicy: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -10508,7 +10510,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDomainName(data.item, context);
   }
@@ -10695,7 +10697,7 @@ export const deserializeAws_restJson1GetGatewayResponseCommand = async (
     responseType: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
     contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
@@ -10787,7 +10789,7 @@ export const deserializeAws_restJson1GetGatewayResponsesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfGatewayResponse(data.item, context);
   }
@@ -10883,7 +10885,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     type: undefined,
     uri: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cacheKeyParameters !== undefined && data.cacheKeyParameters !== null) {
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
@@ -11011,7 +11013,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
     selectionPattern: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
     contents.contentHandling = __expectString(data.contentHandling);
   }
@@ -11112,7 +11114,7 @@ export const deserializeAws_restJson1GetMethodCommand = async (
     requestParameters: undefined,
     requestValidatorId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
     contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
@@ -11215,7 +11217,7 @@ export const deserializeAws_restJson1GetMethodResponseCommand = async (
     responseParameters: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.responseModels = deserializeAws_restJson1MapOfStringToString(data.responseModels, context);
   }
@@ -11296,7 +11298,7 @@ export const deserializeAws_restJson1GetModelCommand = async (
     name: undefined,
     schema: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.contentType = __expectString(data.contentType);
   }
@@ -11388,7 +11390,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfModel(data.item, context);
   }
@@ -11470,7 +11472,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     value: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.value !== undefined && data.value !== null) {
     contents.value = __expectString(data.value);
   }
@@ -11552,7 +11554,7 @@ export const deserializeAws_restJson1GetRequestValidatorCommand = async (
     validateRequestBody: undefined,
     validateRequestParameters: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -11641,7 +11643,7 @@ export const deserializeAws_restJson1GetRequestValidatorsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfRequestValidator(data.item, context);
   }
@@ -11727,7 +11729,7 @@ export const deserializeAws_restJson1GetResourceCommand = async (
     pathPart: undefined,
     resourceMethods: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -11811,7 +11813,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfResource(data.item, context);
   }
@@ -11905,7 +11907,7 @@ export const deserializeAws_restJson1GetRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -12021,7 +12023,7 @@ export const deserializeAws_restJson1GetRestApisCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfRestApi(data.item, context);
   }
@@ -12207,7 +12209,7 @@ export const deserializeAws_restJson1GetSdkTypeCommand = async (
     friendlyName: undefined,
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationProperties !== undefined && data.configurationProperties !== null) {
     contents.configurationProperties = deserializeAws_restJson1ListOfSdkConfigurationProperty(
       data.configurationProperties,
@@ -12298,7 +12300,7 @@ export const deserializeAws_restJson1GetSdkTypesCommand = async (
     $metadata: deserializeMetadata(output),
     items: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfSdkType(data.item, context);
   }
@@ -12393,7 +12395,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     variables: undefined,
     webAclArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -12536,7 +12538,7 @@ export const deserializeAws_restJson1GetStagesCommand = async (
     $metadata: deserializeMetadata(output),
     item: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.item = deserializeAws_restJson1ListOfStage(data.item, context);
   }
@@ -12631,7 +12633,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
@@ -12714,7 +12716,7 @@ export const deserializeAws_restJson1GetUsageCommand = async (
     startDate: undefined,
     usagePlanId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endDate !== undefined && data.endDate !== null) {
     contents.endDate = __expectString(data.endDate);
   }
@@ -12812,7 +12814,7 @@ export const deserializeAws_restJson1GetUsagePlanCommand = async (
     tags: undefined,
     throttle: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiStages !== undefined && data.apiStages !== null) {
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
@@ -12915,7 +12917,7 @@ export const deserializeAws_restJson1GetUsagePlanKeyCommand = async (
     type: undefined,
     value: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -13004,7 +13006,7 @@ export const deserializeAws_restJson1GetUsagePlanKeysCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfUsagePlanKey(data.item, context);
   }
@@ -13087,7 +13089,7 @@ export const deserializeAws_restJson1GetUsagePlansCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfUsagePlan(data.item, context);
   }
@@ -13175,7 +13177,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
     tags: undefined,
     targetArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -13273,7 +13275,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfVpcLink(data.item, context);
   }
@@ -13356,7 +13358,7 @@ export const deserializeAws_restJson1ImportApiKeysCommand = async (
     ids: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ids !== undefined && data.ids !== null) {
     contents.ids = deserializeAws_restJson1ListOfString(data.ids, context);
   }
@@ -13455,7 +13457,7 @@ export const deserializeAws_restJson1ImportDocumentationPartsCommand = async (
     ids: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ids !== undefined && data.ids !== null) {
     contents.ids = deserializeAws_restJson1ListOfString(data.ids, context);
   }
@@ -13565,7 +13567,7 @@ export const deserializeAws_restJson1ImportRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -13700,7 +13702,7 @@ export const deserializeAws_restJson1PutGatewayResponseCommand = async (
     responseType: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
     contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
@@ -13821,7 +13823,7 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     type: undefined,
     uri: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cacheKeyParameters !== undefined && data.cacheKeyParameters !== null) {
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
@@ -13965,7 +13967,7 @@ export const deserializeAws_restJson1PutIntegrationResponseCommand = async (
     selectionPattern: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
     contents.contentHandling = __expectString(data.contentHandling);
   }
@@ -14082,7 +14084,7 @@ export const deserializeAws_restJson1PutMethodCommand = async (
     requestParameters: undefined,
     requestValidatorId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
     contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
@@ -14209,7 +14211,7 @@ export const deserializeAws_restJson1PutMethodResponseCommand = async (
     responseParameters: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.responseModels = deserializeAws_restJson1MapOfStringToString(data.responseModels, context);
   }
@@ -14322,7 +14324,7 @@ export const deserializeAws_restJson1PutRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -14550,7 +14552,7 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
     policy: undefined,
     principalId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.authorization = deserializeAws_restJson1MapOfStringToList(data.authorization, context);
   }
@@ -14652,7 +14654,7 @@ export const deserializeAws_restJson1TestInvokeMethodCommand = async (
     multiValueHeaders: undefined,
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.body !== undefined && data.body !== null) {
     contents.body = __expectString(data.body);
   }
@@ -14840,7 +14842,7 @@ export const deserializeAws_restJson1UpdateAccountCommand = async (
     features: undefined,
     throttleSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyVersion !== undefined && data.apiKeyVersion !== null) {
     contents.apiKeyVersion = __expectString(data.apiKeyVersion);
   }
@@ -14953,7 +14955,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
     tags: undefined,
     value: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -15084,7 +15086,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
     providerARNs: undefined,
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authType !== undefined && data.authType !== null) {
     contents.authType = __expectString(data.authType);
   }
@@ -15208,7 +15210,7 @@ export const deserializeAws_restJson1UpdateBasePathMappingCommand = async (
     restApiId: undefined,
     stage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.basePath !== undefined && data.basePath !== null) {
     contents.basePath = __expectString(data.basePath);
   }
@@ -15314,7 +15316,7 @@ export const deserializeAws_restJson1UpdateClientCertificateCommand = async (
     pemEncodedCertificate: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
@@ -15427,7 +15429,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     description: undefined,
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiSummary !== undefined && data.apiSummary !== null) {
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
@@ -15541,7 +15543,7 @@ export const deserializeAws_restJson1UpdateDocumentationPartCommand = async (
     location: undefined,
     properties: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -15644,7 +15646,7 @@ export const deserializeAws_restJson1UpdateDocumentationVersionCommand = async (
     description: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -15761,7 +15763,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
     securityPolicy: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -15911,7 +15913,7 @@ export const deserializeAws_restJson1UpdateGatewayResponseCommand = async (
     responseType: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
     contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
@@ -16032,7 +16034,7 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     type: undefined,
     uri: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cacheKeyParameters !== undefined && data.cacheKeyParameters !== null) {
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
@@ -16176,7 +16178,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
     selectionPattern: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
     contents.contentHandling = __expectString(data.contentHandling);
   }
@@ -16293,7 +16295,7 @@ export const deserializeAws_restJson1UpdateMethodCommand = async (
     requestParameters: undefined,
     requestValidatorId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
     contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
@@ -16412,7 +16414,7 @@ export const deserializeAws_restJson1UpdateMethodResponseCommand = async (
     responseParameters: undefined,
     statusCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.responseModels = deserializeAws_restJson1MapOfStringToString(data.responseModels, context);
   }
@@ -16517,7 +16519,7 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
     name: undefined,
     schema: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.contentType = __expectString(data.contentType);
   }
@@ -16627,7 +16629,7 @@ export const deserializeAws_restJson1UpdateRequestValidatorCommand = async (
     validateRequestBody: undefined,
     validateRequestParameters: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -16735,7 +16737,7 @@ export const deserializeAws_restJson1UpdateResourceCommand = async (
     pathPart: undefined,
     resourceMethods: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -16846,7 +16848,7 @@ export const deserializeAws_restJson1UpdateRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -16993,7 +16995,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     variables: undefined,
     webAclArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -17140,7 +17142,7 @@ export const deserializeAws_restJson1UpdateUsageCommand = async (
     startDate: undefined,
     usagePlanId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endDate !== undefined && data.endDate !== null) {
     contents.endDate = __expectString(data.endDate);
   }
@@ -17254,7 +17256,7 @@ export const deserializeAws_restJson1UpdateUsagePlanCommand = async (
     tags: undefined,
     throttle: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiStages !== undefined && data.apiStages !== null) {
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
@@ -17376,7 +17378,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
     tags: undefined,
     targetArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }

--- a/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
@@ -10,6 +10,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -193,7 +195,7 @@ export const deserializeAws_restJson1GetConnectionCommand = async (
     Identity: undefined,
     LastActiveAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectedAt !== undefined && data.connectedAt !== null) {
     contents.ConnectedAt = new Date(data.connectedAt);
   }

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
@@ -142,6 +142,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -3182,7 +3184,7 @@ export const deserializeAws_restJson1CreateApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -3309,7 +3311,7 @@ export const deserializeAws_restJson1CreateApiMappingCommand = async (
     ApiMappingKey: undefined,
     Stage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiId !== undefined && data.apiId !== null) {
     contents.ApiId = __expectString(data.apiId);
   }
@@ -3407,7 +3409,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
     JwtConfiguration: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
     contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
@@ -3521,7 +3523,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     DeploymentStatusMessage: undefined,
     Description: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
@@ -3619,7 +3621,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
     MutualTlsAuthentication: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
     contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
@@ -3743,7 +3745,7 @@ export const deserializeAws_restJson1CreateIntegrationCommand = async (
     TimeoutInMillis: undefined,
     TlsConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -3887,7 +3889,7 @@ export const deserializeAws_restJson1CreateIntegrationResponseCommand = async (
     ResponseTemplates: undefined,
     TemplateSelectionExpression: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
     contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
@@ -3985,7 +3987,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
     Name: undefined,
     Schema: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.ContentType = __expectString(data.contentType);
   }
@@ -4088,7 +4090,7 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
     RouteResponseSelectionExpression: undefined,
     Target: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -4207,7 +4209,7 @@ export const deserializeAws_restJson1CreateRouteResponseCommand = async (
     RouteResponseId: undefined,
     RouteResponseKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
     contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
@@ -4311,7 +4313,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     StageVariables: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -4437,7 +4439,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
     VpcLinkStatusMessage: undefined,
     VpcLinkVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
   }
@@ -5560,7 +5562,7 @@ export const deserializeAws_restJson1GetApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -5671,7 +5673,7 @@ export const deserializeAws_restJson1GetApiMappingCommand = async (
     ApiMappingKey: undefined,
     Stage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiId !== undefined && data.apiId !== null) {
     contents.ApiId = __expectString(data.apiId);
   }
@@ -5752,7 +5754,7 @@ export const deserializeAws_restJson1GetApiMappingsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfApiMapping(data.items, context);
   }
@@ -5827,7 +5829,7 @@ export const deserializeAws_restJson1GetApisCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfApi(data.items, context);
   }
@@ -5911,7 +5913,7 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
     JwtConfiguration: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
     contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
@@ -6005,7 +6007,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfAuthorizer(data.items, context);
   }
@@ -6084,7 +6086,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     DeploymentStatusMessage: undefined,
     Description: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
@@ -6163,7 +6165,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfDeployment(data.items, context);
   }
@@ -6241,7 +6243,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
     MutualTlsAuthentication: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
     contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
@@ -6323,7 +6325,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfDomainName(data.items, context);
   }
@@ -6416,7 +6418,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     TimeoutInMillis: undefined,
     TlsConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -6544,7 +6546,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
     ResponseTemplates: undefined,
     TemplateSelectionExpression: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
     contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
@@ -6623,7 +6625,7 @@ export const deserializeAws_restJson1GetIntegrationResponsesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfIntegrationResponse(data.items, context);
   }
@@ -6698,7 +6700,7 @@ export const deserializeAws_restJson1GetIntegrationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfIntegration(data.items, context);
   }
@@ -6776,7 +6778,7 @@ export const deserializeAws_restJson1GetModelCommand = async (
     Name: undefined,
     Schema: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.ContentType = __expectString(data.contentType);
   }
@@ -6852,7 +6854,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfModel(data.items, context);
   }
@@ -6926,7 +6928,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     Value: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.value !== undefined && data.value !== null) {
     contents.Value = __expectString(data.value);
   }
@@ -7001,7 +7003,7 @@ export const deserializeAws_restJson1GetRouteCommand = async (
     RouteResponseSelectionExpression: undefined,
     Target: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -7104,7 +7106,7 @@ export const deserializeAws_restJson1GetRouteResponseCommand = async (
     RouteResponseId: undefined,
     RouteResponseKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
     contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
@@ -7180,7 +7182,7 @@ export const deserializeAws_restJson1GetRouteResponsesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfRouteResponse(data.items, context);
   }
@@ -7255,7 +7257,7 @@ export const deserializeAws_restJson1GetRoutesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfRoute(data.items, context);
   }
@@ -7342,7 +7344,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     StageVariables: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -7445,7 +7447,7 @@ export const deserializeAws_restJson1GetStagesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfStage(data.items, context);
   }
@@ -7519,7 +7521,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -7606,7 +7608,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
     VpcLinkStatusMessage: undefined,
     VpcLinkVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
   }
@@ -7694,7 +7696,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfVpcLink(data.items, context);
   }
@@ -7775,7 +7777,7 @@ export const deserializeAws_restJson1ImportApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -7914,7 +7916,7 @@ export const deserializeAws_restJson1ReimportApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -8262,7 +8264,7 @@ export const deserializeAws_restJson1UpdateApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -8389,7 +8391,7 @@ export const deserializeAws_restJson1UpdateApiMappingCommand = async (
     ApiMappingKey: undefined,
     Stage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiId !== undefined && data.apiId !== null) {
     contents.ApiId = __expectString(data.apiId);
   }
@@ -8487,7 +8489,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
     JwtConfiguration: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
     contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
@@ -8601,7 +8603,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     DeploymentStatusMessage: undefined,
     Description: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
@@ -8699,7 +8701,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
     MutualTlsAuthentication: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
     contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
@@ -8815,7 +8817,7 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     TimeoutInMillis: undefined,
     TlsConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -8959,7 +8961,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
     ResponseTemplates: undefined,
     TemplateSelectionExpression: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
     contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
@@ -9057,7 +9059,7 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
     Name: undefined,
     Schema: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.ContentType = __expectString(data.contentType);
   }
@@ -9160,7 +9162,7 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
     RouteResponseSelectionExpression: undefined,
     Target: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -9279,7 +9281,7 @@ export const deserializeAws_restJson1UpdateRouteResponseCommand = async (
     RouteResponseId: undefined,
     RouteResponseKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
     contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
@@ -9383,7 +9385,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     StageVariables: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -9509,7 +9511,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
     VpcLinkStatusMessage: undefined,
     VpcLinkVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = new Date(data.createdDate);
   }

--- a/clients/client-app-mesh/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1.ts
@@ -244,6 +244,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1890,7 +1892,7 @@ export const deserializeAws_restJson1CreateGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -1999,7 +2001,7 @@ export const deserializeAws_restJson1CreateMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -2108,7 +2110,7 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -2217,7 +2219,7 @@ export const deserializeAws_restJson1CreateVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -2326,7 +2328,7 @@ export const deserializeAws_restJson1CreateVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -2435,7 +2437,7 @@ export const deserializeAws_restJson1CreateVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -2544,7 +2546,7 @@ export const deserializeAws_restJson1CreateVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };
@@ -2653,7 +2655,7 @@ export const deserializeAws_restJson1DeleteGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -2754,7 +2756,7 @@ export const deserializeAws_restJson1DeleteMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -2855,7 +2857,7 @@ export const deserializeAws_restJson1DeleteRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -2956,7 +2958,7 @@ export const deserializeAws_restJson1DeleteVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -3057,7 +3059,7 @@ export const deserializeAws_restJson1DeleteVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -3158,7 +3160,7 @@ export const deserializeAws_restJson1DeleteVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -3259,7 +3261,7 @@ export const deserializeAws_restJson1DeleteVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };
@@ -3360,7 +3362,7 @@ export const deserializeAws_restJson1DescribeGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -3453,7 +3455,7 @@ export const deserializeAws_restJson1DescribeMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -3546,7 +3548,7 @@ export const deserializeAws_restJson1DescribeRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -3639,7 +3641,7 @@ export const deserializeAws_restJson1DescribeVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -3732,7 +3734,7 @@ export const deserializeAws_restJson1DescribeVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -3825,7 +3827,7 @@ export const deserializeAws_restJson1DescribeVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -3918,7 +3920,7 @@ export const deserializeAws_restJson1DescribeVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };
@@ -4012,7 +4014,7 @@ export const deserializeAws_restJson1ListGatewayRoutesCommand = async (
     gatewayRoutes: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.gatewayRoutes !== undefined && data.gatewayRoutes !== null) {
     contents.gatewayRoutes = deserializeAws_restJson1GatewayRouteList(data.gatewayRoutes, context);
   }
@@ -4111,7 +4113,7 @@ export const deserializeAws_restJson1ListMeshesCommand = async (
     meshes: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.meshes !== undefined && data.meshes !== null) {
     contents.meshes = deserializeAws_restJson1MeshList(data.meshes, context);
   }
@@ -4210,7 +4212,7 @@ export const deserializeAws_restJson1ListRoutesCommand = async (
     nextToken: undefined,
     routes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4309,7 +4311,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     nextToken: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4408,7 +4410,7 @@ export const deserializeAws_restJson1ListVirtualGatewaysCommand = async (
     nextToken: undefined,
     virtualGateways: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4507,7 +4509,7 @@ export const deserializeAws_restJson1ListVirtualNodesCommand = async (
     nextToken: undefined,
     virtualNodes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4606,7 +4608,7 @@ export const deserializeAws_restJson1ListVirtualRoutersCommand = async (
     nextToken: undefined,
     virtualRouters: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4705,7 +4707,7 @@ export const deserializeAws_restJson1ListVirtualServicesCommand = async (
     nextToken: undefined,
     virtualServices: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4993,7 +4995,7 @@ export const deserializeAws_restJson1UpdateGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -5102,7 +5104,7 @@ export const deserializeAws_restJson1UpdateMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -5203,7 +5205,7 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -5312,7 +5314,7 @@ export const deserializeAws_restJson1UpdateVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -5421,7 +5423,7 @@ export const deserializeAws_restJson1UpdateVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -5530,7 +5532,7 @@ export const deserializeAws_restJson1UpdateVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -5639,7 +5641,7 @@ export const deserializeAws_restJson1UpdateVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-appconfig/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1.ts
@@ -100,6 +100,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
@@ -1404,7 +1406,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     Id: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1479,7 +1481,7 @@ export const deserializeAws_restJson1CreateConfigurationProfileCommand = async (
     RetrievalRoleArn: undefined,
     Validators: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -1575,7 +1577,7 @@ export const deserializeAws_restJson1CreateDeploymentStrategyCommand = async (
     Name: undefined,
     ReplicateTo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
     contents.DeploymentDurationInMinutes = __expectInt32(data.DeploymentDurationInMinutes);
   }
@@ -1664,7 +1666,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2216,7 +2218,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     Id: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -2376,7 +2378,7 @@ export const deserializeAws_restJson1GetConfigurationProfileCommand = async (
     RetrievalRoleArn: undefined,
     Validators: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2482,7 +2484,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     StartedAt: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2611,7 +2613,7 @@ export const deserializeAws_restJson1GetDeploymentStrategyCommand = async (
     Name: undefined,
     ReplicateTo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
     contents.DeploymentDurationInMinutes = __expectInt32(data.DeploymentDurationInMinutes);
   }
@@ -2708,7 +2710,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2884,7 +2886,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ApplicationList(data.Items, context);
   }
@@ -2951,7 +2953,7 @@ export const deserializeAws_restJson1ListConfigurationProfilesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ConfigurationProfileSummaryList(data.Items, context);
   }
@@ -3026,7 +3028,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1DeploymentList(data.Items, context);
   }
@@ -3101,7 +3103,7 @@ export const deserializeAws_restJson1ListDeploymentStrategiesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1DeploymentStrategyList(data.Items, context);
   }
@@ -3168,7 +3170,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1EnvironmentList(data.Items, context);
   }
@@ -3243,7 +3245,7 @@ export const deserializeAws_restJson1ListHostedConfigurationVersionsCommand = as
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1HostedConfigurationVersionSummaryList(data.Items, context);
   }
@@ -3317,7 +3319,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3405,7 +3407,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     StartedAt: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -3552,7 +3554,7 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
     StartedAt: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -3810,7 +3812,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     Id: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -3893,7 +3895,7 @@ export const deserializeAws_restJson1UpdateConfigurationProfileCommand = async (
     RetrievalRoleArn: undefined,
     Validators: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -3989,7 +3991,7 @@ export const deserializeAws_restJson1UpdateDeploymentStrategyCommand = async (
     Name: undefined,
     ReplicateTo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
     contents.DeploymentDurationInMinutes = __expectInt32(data.DeploymentDurationInMinutes);
   }
@@ -4086,7 +4088,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }

--- a/clients/client-appflow/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/protocols/Aws_restJson1.ts
@@ -178,6 +178,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -736,7 +738,7 @@ export const deserializeAws_restJson1CreateConnectorProfileCommand = async (
     $metadata: deserializeMetadata(output),
     connectorProfileArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorProfileArn !== undefined && data.connectorProfileArn !== null) {
     contents.connectorProfileArn = __expectString(data.connectorProfileArn);
   }
@@ -824,7 +826,7 @@ export const deserializeAws_restJson1CreateFlowCommand = async (
     flowArn: undefined,
     flowStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.flowArn = __expectString(data.flowArn);
   }
@@ -1064,7 +1066,7 @@ export const deserializeAws_restJson1DescribeConnectorEntityCommand = async (
     $metadata: deserializeMetadata(output),
     connectorEntityFields: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorEntityFields !== undefined && data.connectorEntityFields !== null) {
     contents.connectorEntityFields = deserializeAws_restJson1ConnectorEntityFieldList(
       data.connectorEntityFields,
@@ -1155,7 +1157,7 @@ export const deserializeAws_restJson1DescribeConnectorProfilesCommand = async (
     connectorProfileDetails: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorProfileDetails !== undefined && data.connectorProfileDetails !== null) {
     contents.connectorProfileDetails = deserializeAws_restJson1ConnectorProfileDetailList(
       data.connectorProfileDetails,
@@ -1225,7 +1227,7 @@ export const deserializeAws_restJson1DescribeConnectorsCommand = async (
     connectorConfigurations: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorConfigurations !== undefined && data.connectorConfigurations !== null) {
     contents.connectorConfigurations = deserializeAws_restJson1ConnectorConfigurationsMap(
       data.connectorConfigurations,
@@ -1309,7 +1311,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     tasks: undefined,
     triggerConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
@@ -1421,7 +1423,7 @@ export const deserializeAws_restJson1DescribeFlowExecutionRecordsCommand = async
     flowExecutions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowExecutions !== undefined && data.flowExecutions !== null) {
     contents.flowExecutions = deserializeAws_restJson1FlowExecutionList(data.flowExecutions, context);
   }
@@ -1495,7 +1497,7 @@ export const deserializeAws_restJson1ListConnectorEntitiesCommand = async (
     $metadata: deserializeMetadata(output),
     connectorEntityMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorEntityMap !== undefined && data.connectorEntityMap !== null) {
     contents.connectorEntityMap = deserializeAws_restJson1ConnectorEntityMap(data.connectorEntityMap, context);
   }
@@ -1583,7 +1585,7 @@ export const deserializeAws_restJson1ListFlowsCommand = async (
     flows: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flows !== undefined && data.flows !== null) {
     contents.flows = deserializeAws_restJson1FlowList(data.flows, context);
   }
@@ -1649,7 +1651,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1722,7 +1724,7 @@ export const deserializeAws_restJson1StartFlowCommand = async (
     flowArn: undefined,
     flowStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionId !== undefined && data.executionId !== null) {
     contents.executionId = __expectString(data.executionId);
   }
@@ -1808,7 +1810,7 @@ export const deserializeAws_restJson1StopFlowCommand = async (
     flowArn: undefined,
     flowStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.flowArn = __expectString(data.flowArn);
   }
@@ -2024,7 +2026,7 @@ export const deserializeAws_restJson1UpdateConnectorProfileCommand = async (
     $metadata: deserializeMetadata(output),
     connectorProfileArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorProfileArn !== undefined && data.connectorProfileArn !== null) {
     contents.connectorProfileArn = __expectString(data.connectorProfileArn);
   }
@@ -2111,7 +2113,7 @@ export const deserializeAws_restJson1UpdateFlowCommand = async (
     $metadata: deserializeMetadata(output),
     flowStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowStatus !== undefined && data.flowStatus !== null) {
     contents.flowStatus = __expectString(data.flowStatus);
   }

--- a/clients/client-appintegrations/protocols/Aws_restJson1.ts
+++ b/clients/client-appintegrations/protocols/Aws_restJson1.ts
@@ -42,6 +42,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -340,7 +342,7 @@ export const deserializeAws_restJson1CreateEventIntegrationCommand = async (
     $metadata: deserializeMetadata(output),
     EventIntegrationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventIntegrationArn !== undefined && data.EventIntegrationArn !== null) {
     contents.EventIntegrationArn = __expectString(data.EventIntegrationArn);
   }
@@ -523,7 +525,7 @@ export const deserializeAws_restJson1GetEventIntegrationCommand = async (
     Name: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -626,7 +628,7 @@ export const deserializeAws_restJson1ListEventIntegrationAssociationsCommand = a
     EventIntegrationAssociations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventIntegrationAssociations !== undefined && data.EventIntegrationAssociations !== null) {
     contents.EventIntegrationAssociations = deserializeAws_restJson1EventIntegrationAssociationsList(
       data.EventIntegrationAssociations,
@@ -720,7 +722,7 @@ export const deserializeAws_restJson1ListEventIntegrationsCommand = async (
     EventIntegrations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventIntegrations !== undefined && data.EventIntegrations !== null) {
     contents.EventIntegrations = deserializeAws_restJson1EventIntegrationsList(data.EventIntegrations, context);
   }
@@ -802,7 +804,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-applicationcostprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-applicationcostprofiler/protocols/Aws_restJson1.ts
@@ -34,6 +34,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -240,7 +242,7 @@ export const deserializeAws_restJson1DeleteReportDefinitionCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }
@@ -325,7 +327,7 @@ export const deserializeAws_restJson1GetReportDefinitionCommand = async (
     reportFrequency: undefined,
     reportId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
@@ -422,7 +424,7 @@ export const deserializeAws_restJson1ImportApplicationUsageCommand = async (
     $metadata: deserializeMetadata(output),
     importId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
   }
@@ -502,7 +504,7 @@ export const deserializeAws_restJson1ListReportDefinitionsCommand = async (
     nextToken: undefined,
     reportDefinitions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -584,7 +586,7 @@ export const deserializeAws_restJson1PutReportDefinitionCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }
@@ -671,7 +673,7 @@ export const deserializeAws_restJson1UpdateReportDefinitionCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }

--- a/clients/client-appsync/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1.ts
@@ -98,6 +98,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1765,7 +1767,7 @@ export const deserializeAws_restJson1CreateApiCacheCommand = async (
     $metadata: deserializeMetadata(output),
     apiCache: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiCache !== undefined && data.apiCache !== null) {
     contents.apiCache = deserializeAws_restJson1ApiCache(data.apiCache, context);
   }
@@ -1852,7 +1854,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
     $metadata: deserializeMetadata(output),
     apiKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKey !== undefined && data.apiKey !== null) {
     contents.apiKey = deserializeAws_restJson1ApiKey(data.apiKey, context);
   }
@@ -1955,7 +1957,7 @@ export const deserializeAws_restJson1CreateDataSourceCommand = async (
     $metadata: deserializeMetadata(output),
     dataSource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSource !== undefined && data.dataSource !== null) {
     contents.dataSource = deserializeAws_restJson1DataSource(data.dataSource, context);
   }
@@ -2042,7 +2044,7 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     functionConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functionConfiguration !== undefined && data.functionConfiguration !== null) {
     contents.functionConfiguration = deserializeAws_restJson1FunctionConfiguration(data.functionConfiguration, context);
   }
@@ -2121,7 +2123,7 @@ export const deserializeAws_restJson1CreateGraphqlApiCommand = async (
     $metadata: deserializeMetadata(output),
     graphqlApi: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApi !== undefined && data.graphqlApi !== null) {
     contents.graphqlApi = deserializeAws_restJson1GraphqlApi(data.graphqlApi, context);
   }
@@ -2216,7 +2218,7 @@ export const deserializeAws_restJson1CreateResolverCommand = async (
     $metadata: deserializeMetadata(output),
     resolver: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolver !== undefined && data.resolver !== null) {
     contents.resolver = deserializeAws_restJson1Resolver(data.resolver, context);
   }
@@ -2295,7 +2297,7 @@ export const deserializeAws_restJson1CreateTypeCommand = async (
     $metadata: deserializeMetadata(output),
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.type !== undefined && data.type !== null) {
     contents.type = deserializeAws_restJson1Type(data.type, context);
   }
@@ -3030,7 +3032,7 @@ export const deserializeAws_restJson1GetApiCacheCommand = async (
     $metadata: deserializeMetadata(output),
     apiCache: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiCache !== undefined && data.apiCache !== null) {
     contents.apiCache = deserializeAws_restJson1ApiCache(data.apiCache, context);
   }
@@ -3117,7 +3119,7 @@ export const deserializeAws_restJson1GetDataSourceCommand = async (
     $metadata: deserializeMetadata(output),
     dataSource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSource !== undefined && data.dataSource !== null) {
     contents.dataSource = deserializeAws_restJson1DataSource(data.dataSource, context);
   }
@@ -3204,7 +3206,7 @@ export const deserializeAws_restJson1GetFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     functionConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functionConfiguration !== undefined && data.functionConfiguration !== null) {
     contents.functionConfiguration = deserializeAws_restJson1FunctionConfiguration(data.functionConfiguration, context);
   }
@@ -3275,7 +3277,7 @@ export const deserializeAws_restJson1GetGraphqlApiCommand = async (
     $metadata: deserializeMetadata(output),
     graphqlApi: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApi !== undefined && data.graphqlApi !== null) {
     contents.graphqlApi = deserializeAws_restJson1GraphqlApi(data.graphqlApi, context);
   }
@@ -3439,7 +3441,7 @@ export const deserializeAws_restJson1GetResolverCommand = async (
     $metadata: deserializeMetadata(output),
     resolver: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolver !== undefined && data.resolver !== null) {
     contents.resolver = deserializeAws_restJson1Resolver(data.resolver, context);
   }
@@ -3511,7 +3513,7 @@ export const deserializeAws_restJson1GetSchemaCreationStatusCommand = async (
     details: undefined,
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = __expectString(data.details);
   }
@@ -3593,7 +3595,7 @@ export const deserializeAws_restJson1GetTypeCommand = async (
     $metadata: deserializeMetadata(output),
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.type !== undefined && data.type !== null) {
     contents.type = deserializeAws_restJson1Type(data.type, context);
   }
@@ -3681,7 +3683,7 @@ export const deserializeAws_restJson1ListApiKeysCommand = async (
     apiKeys: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeys !== undefined && data.apiKeys !== null) {
     contents.apiKeys = deserializeAws_restJson1ApiKeys(data.apiKeys, context);
   }
@@ -3764,7 +3766,7 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
     dataSources: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSources !== undefined && data.dataSources !== null) {
     contents.dataSources = deserializeAws_restJson1DataSources(data.dataSources, context);
   }
@@ -3847,7 +3849,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
     functions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functions !== undefined && data.functions !== null) {
     contents.functions = deserializeAws_restJson1Functions(data.functions, context);
   }
@@ -3930,7 +3932,7 @@ export const deserializeAws_restJson1ListGraphqlApisCommand = async (
     graphqlApis: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApis !== undefined && data.graphqlApis !== null) {
     contents.graphqlApis = deserializeAws_restJson1GraphqlApis(data.graphqlApis, context);
   }
@@ -4005,7 +4007,7 @@ export const deserializeAws_restJson1ListResolversCommand = async (
     nextToken: undefined,
     resolvers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4088,7 +4090,7 @@ export const deserializeAws_restJson1ListResolversByFunctionCommand = async (
     nextToken: undefined,
     resolvers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4170,7 +4172,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -4266,7 +4268,7 @@ export const deserializeAws_restJson1ListTypesCommand = async (
     nextToken: undefined,
     types: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4356,7 +4358,7 @@ export const deserializeAws_restJson1StartSchemaCreationCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -4625,7 +4627,7 @@ export const deserializeAws_restJson1UpdateApiCacheCommand = async (
     $metadata: deserializeMetadata(output),
     apiCache: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiCache !== undefined && data.apiCache !== null) {
     contents.apiCache = deserializeAws_restJson1ApiCache(data.apiCache, context);
   }
@@ -4712,7 +4714,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
     $metadata: deserializeMetadata(output),
     apiKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKey !== undefined && data.apiKey !== null) {
     contents.apiKey = deserializeAws_restJson1ApiKey(data.apiKey, context);
   }
@@ -4807,7 +4809,7 @@ export const deserializeAws_restJson1UpdateDataSourceCommand = async (
     $metadata: deserializeMetadata(output),
     dataSource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSource !== undefined && data.dataSource !== null) {
     contents.dataSource = deserializeAws_restJson1DataSource(data.dataSource, context);
   }
@@ -4894,7 +4896,7 @@ export const deserializeAws_restJson1UpdateFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     functionConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functionConfiguration !== undefined && data.functionConfiguration !== null) {
     contents.functionConfiguration = deserializeAws_restJson1FunctionConfiguration(data.functionConfiguration, context);
   }
@@ -4973,7 +4975,7 @@ export const deserializeAws_restJson1UpdateGraphqlApiCommand = async (
     $metadata: deserializeMetadata(output),
     graphqlApi: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApi !== undefined && data.graphqlApi !== null) {
     contents.graphqlApi = deserializeAws_restJson1GraphqlApi(data.graphqlApi, context);
   }
@@ -5068,7 +5070,7 @@ export const deserializeAws_restJson1UpdateResolverCommand = async (
     $metadata: deserializeMetadata(output),
     resolver: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolver !== undefined && data.resolver !== null) {
     contents.resolver = deserializeAws_restJson1Resolver(data.resolver, context);
   }
@@ -5147,7 +5149,7 @@ export const deserializeAws_restJson1UpdateTypeCommand = async (
     $metadata: deserializeMetadata(output),
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.type !== undefined && data.type !== null) {
     contents.type = deserializeAws_restJson1Type(data.type, context);
   }

--- a/clients/client-auditmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/protocols/Aws_restJson1.ts
@@ -186,6 +186,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -2027,7 +2029,7 @@ export const deserializeAws_restJson1BatchAssociateAssessmentReportEvidenceComma
     errors: undefined,
     evidenceIds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1AssessmentReportEvidenceErrors(data.errors, context);
   }
@@ -2110,7 +2112,7 @@ export const deserializeAws_restJson1BatchCreateDelegationByAssessmentCommand = 
     delegations: undefined,
     errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegations !== undefined && data.delegations !== null) {
     contents.delegations = deserializeAws_restJson1Delegations(data.delegations, context);
   }
@@ -2192,7 +2194,7 @@ export const deserializeAws_restJson1BatchDeleteDelegationByAssessmentCommand = 
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchDeleteDelegationByAssessmentErrors(data.errors, context);
   }
@@ -2272,7 +2274,7 @@ export const deserializeAws_restJson1BatchDisassociateAssessmentReportEvidenceCo
     errors: undefined,
     evidenceIds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1AssessmentReportEvidenceErrors(data.errors, context);
   }
@@ -2354,7 +2356,7 @@ export const deserializeAws_restJson1BatchImportEvidenceToAssessmentControlComma
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchImportEvidenceToAssessmentControlErrors(data.errors, context);
   }
@@ -2433,7 +2435,7 @@ export const deserializeAws_restJson1CreateAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -2512,7 +2514,7 @@ export const deserializeAws_restJson1CreateAssessmentFrameworkCommand = async (
     $metadata: deserializeMetadata(output),
     framework: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.framework !== undefined && data.framework !== null) {
     contents.framework = deserializeAws_restJson1Framework(data.framework, context);
   }
@@ -2591,7 +2593,7 @@ export const deserializeAws_restJson1CreateAssessmentReportCommand = async (
     $metadata: deserializeMetadata(output),
     assessmentReport: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentReport !== undefined && data.assessmentReport !== null) {
     contents.assessmentReport = deserializeAws_restJson1AssessmentReport(data.assessmentReport, context);
   }
@@ -2670,7 +2672,7 @@ export const deserializeAws_restJson1CreateControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1Control(data.control, context);
   }
@@ -3049,7 +3051,7 @@ export const deserializeAws_restJson1DeregisterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -3278,7 +3280,7 @@ export const deserializeAws_restJson1GetAccountStatusCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -3334,7 +3336,7 @@ export const deserializeAws_restJson1GetAssessmentCommand = async (
     assessment: undefined,
     userRole: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -3416,7 +3418,7 @@ export const deserializeAws_restJson1GetAssessmentFrameworkCommand = async (
     $metadata: deserializeMetadata(output),
     framework: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.framework !== undefined && data.framework !== null) {
     contents.framework = deserializeAws_restJson1Framework(data.framework, context);
   }
@@ -3495,7 +3497,7 @@ export const deserializeAws_restJson1GetAssessmentReportUrlCommand = async (
     $metadata: deserializeMetadata(output),
     preSignedUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preSignedUrl !== undefined && data.preSignedUrl !== null) {
     contents.preSignedUrl = deserializeAws_restJson1URL(data.preSignedUrl, context);
   }
@@ -3575,7 +3577,7 @@ export const deserializeAws_restJson1GetChangeLogsCommand = async (
     changeLogs: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.changeLogs !== undefined && data.changeLogs !== null) {
     contents.changeLogs = deserializeAws_restJson1ChangeLogs(data.changeLogs, context);
   }
@@ -3657,7 +3659,7 @@ export const deserializeAws_restJson1GetControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1Control(data.control, context);
   }
@@ -3737,7 +3739,7 @@ export const deserializeAws_restJson1GetDelegationsCommand = async (
     delegations: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegations !== undefined && data.delegations !== null) {
     contents.delegations = deserializeAws_restJson1DelegationMetadataList(data.delegations, context);
   }
@@ -3811,7 +3813,7 @@ export const deserializeAws_restJson1GetEvidenceCommand = async (
     $metadata: deserializeMetadata(output),
     evidence: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidence !== undefined && data.evidence !== null) {
     contents.evidence = deserializeAws_restJson1Evidence(data.evidence, context);
   }
@@ -3891,7 +3893,7 @@ export const deserializeAws_restJson1GetEvidenceByEvidenceFolderCommand = async 
     evidence: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidence !== undefined && data.evidence !== null) {
     contents.evidence = deserializeAws_restJson1EvidenceList(data.evidence, context);
   }
@@ -3973,7 +3975,7 @@ export const deserializeAws_restJson1GetEvidenceFolderCommand = async (
     $metadata: deserializeMetadata(output),
     evidenceFolder: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidenceFolder !== undefined && data.evidenceFolder !== null) {
     contents.evidenceFolder = deserializeAws_restJson1AssessmentEvidenceFolder(data.evidenceFolder, context);
   }
@@ -4053,7 +4055,7 @@ export const deserializeAws_restJson1GetEvidenceFoldersByAssessmentCommand = asy
     evidenceFolders: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidenceFolders !== undefined && data.evidenceFolders !== null) {
     contents.evidenceFolders = deserializeAws_restJson1AssessmentEvidenceFolders(data.evidenceFolders, context);
   }
@@ -4136,7 +4138,7 @@ export const deserializeAws_restJson1GetEvidenceFoldersByAssessmentControlComman
     evidenceFolders: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidenceFolders !== undefined && data.evidenceFolders !== null) {
     contents.evidenceFolders = deserializeAws_restJson1AssessmentEvidenceFolders(data.evidenceFolders, context);
   }
@@ -4219,7 +4221,7 @@ export const deserializeAws_restJson1GetOrganizationAdminAccountCommand = async 
     adminAccountId: undefined,
     organizationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccountId !== undefined && data.adminAccountId !== null) {
     contents.adminAccountId = __expectString(data.adminAccountId);
   }
@@ -4301,7 +4303,7 @@ export const deserializeAws_restJson1GetServicesInScopeCommand = async (
     $metadata: deserializeMetadata(output),
     serviceMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.serviceMetadata !== undefined && data.serviceMetadata !== null) {
     contents.serviceMetadata = deserializeAws_restJson1ServiceMetadataList(data.serviceMetadata, context);
   }
@@ -4372,7 +4374,7 @@ export const deserializeAws_restJson1GetSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     settings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.settings !== undefined && data.settings !== null) {
     contents.settings = deserializeAws_restJson1Settings(data.settings, context);
   }
@@ -4436,7 +4438,7 @@ export const deserializeAws_restJson1ListAssessmentFrameworksCommand = async (
     frameworkMetadataList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.frameworkMetadataList !== undefined && data.frameworkMetadataList !== null) {
     contents.frameworkMetadataList = deserializeAws_restJson1FrameworkMetadataList(data.frameworkMetadataList, context);
   }
@@ -4511,7 +4513,7 @@ export const deserializeAws_restJson1ListAssessmentReportsCommand = async (
     assessmentReports: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentReports !== undefined && data.assessmentReports !== null) {
     contents.assessmentReports = deserializeAws_restJson1AssessmentReportsMetadata(data.assessmentReports, context);
   }
@@ -4586,7 +4588,7 @@ export const deserializeAws_restJson1ListAssessmentsCommand = async (
     assessmentMetadata: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentMetadata !== undefined && data.assessmentMetadata !== null) {
     contents.assessmentMetadata = deserializeAws_restJson1ListAssessmentMetadata(data.assessmentMetadata, context);
   }
@@ -4661,7 +4663,7 @@ export const deserializeAws_restJson1ListControlsCommand = async (
     controlMetadataList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlMetadataList !== undefined && data.controlMetadataList !== null) {
     contents.controlMetadataList = deserializeAws_restJson1ControlMetadataList(data.controlMetadataList, context);
   }
@@ -4736,7 +4738,7 @@ export const deserializeAws_restJson1ListKeywordsForDataSourceCommand = async (
     keywords: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keywords !== undefined && data.keywords !== null) {
     contents.keywords = deserializeAws_restJson1Keywords(data.keywords, context);
   }
@@ -4811,7 +4813,7 @@ export const deserializeAws_restJson1ListNotificationsCommand = async (
     nextToken: undefined,
     notifications: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4885,7 +4887,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -4956,7 +4958,7 @@ export const deserializeAws_restJson1RegisterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -5036,7 +5038,7 @@ export const deserializeAws_restJson1RegisterOrganizationAdminAccountCommand = a
     adminAccountId: undefined,
     organizationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccountId !== undefined && data.adminAccountId !== null) {
     contents.adminAccountId = __expectString(data.adminAccountId);
   }
@@ -5252,7 +5254,7 @@ export const deserializeAws_restJson1UpdateAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -5331,7 +5333,7 @@ export const deserializeAws_restJson1UpdateAssessmentControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1AssessmentControl(data.control, context);
   }
@@ -5410,7 +5412,7 @@ export const deserializeAws_restJson1UpdateAssessmentControlSetStatusCommand = a
     $metadata: deserializeMetadata(output),
     controlSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlSet !== undefined && data.controlSet !== null) {
     contents.controlSet = deserializeAws_restJson1AssessmentControlSet(data.controlSet, context);
   }
@@ -5489,7 +5491,7 @@ export const deserializeAws_restJson1UpdateAssessmentFrameworkCommand = async (
     $metadata: deserializeMetadata(output),
     framework: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.framework !== undefined && data.framework !== null) {
     contents.framework = deserializeAws_restJson1Framework(data.framework, context);
   }
@@ -5568,7 +5570,7 @@ export const deserializeAws_restJson1UpdateAssessmentStatusCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -5647,7 +5649,7 @@ export const deserializeAws_restJson1UpdateControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1Control(data.control, context);
   }
@@ -5726,7 +5728,7 @@ export const deserializeAws_restJson1UpdateSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     settings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.settings !== undefined && data.settings !== null) {
     contents.settings = deserializeAws_restJson1Settings(data.settings, context);
   }
@@ -5801,7 +5803,7 @@ export const deserializeAws_restJson1ValidateAssessmentReportIntegrityCommand = 
     signatureValid: undefined,
     validationErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.signatureAlgorithm !== undefined && data.signatureAlgorithm !== null) {
     contents.signatureAlgorithm = __expectString(data.signatureAlgorithm);
   }

--- a/clients/client-backup/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1.ts
@@ -197,6 +197,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -2282,7 +2284,7 @@ export const deserializeAws_restJson1CreateBackupPlanCommand = async (
     CreationDate: undefined,
     VersionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdvancedBackupSettings !== undefined && data.AdvancedBackupSettings !== null) {
     contents.AdvancedBackupSettings = deserializeAws_restJson1AdvancedBackupSettings(
       data.AdvancedBackupSettings,
@@ -2386,7 +2388,7 @@ export const deserializeAws_restJson1CreateBackupSelectionCommand = async (
     CreationDate: undefined,
     SelectionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
@@ -2481,7 +2483,7 @@ export const deserializeAws_restJson1CreateBackupVaultCommand = async (
     BackupVaultName: undefined,
     CreationDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -2575,7 +2577,7 @@ export const deserializeAws_restJson1CreateFrameworkCommand = async (
     FrameworkArn: undefined,
     FrameworkName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FrameworkArn !== undefined && data.FrameworkArn !== null) {
     contents.FrameworkArn = __expectString(data.FrameworkArn);
   }
@@ -2666,7 +2668,7 @@ export const deserializeAws_restJson1CreateReportPlanCommand = async (
     ReportPlanArn: undefined,
     ReportPlanName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReportPlanArn !== undefined && data.ReportPlanArn !== null) {
     contents.ReportPlanArn = __expectString(data.ReportPlanArn);
   }
@@ -2759,7 +2761,7 @@ export const deserializeAws_restJson1DeleteBackupPlanCommand = async (
     DeletionDate: undefined,
     VersionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanArn !== undefined && data.BackupPlanArn !== null) {
     contents.BackupPlanArn = __expectString(data.BackupPlanArn);
   }
@@ -3439,7 +3441,7 @@ export const deserializeAws_restJson1DescribeBackupJobCommand = async (
     State: undefined,
     StatusMessage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountId !== undefined && data.AccountId !== null) {
     contents.AccountId = __expectString(data.AccountId);
   }
@@ -3588,7 +3590,7 @@ export const deserializeAws_restJson1DescribeBackupVaultCommand = async (
     EncryptionKeyArn: undefined,
     NumberOfRecoveryPoints: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -3682,7 +3684,7 @@ export const deserializeAws_restJson1DescribeCopyJobCommand = async (
     $metadata: deserializeMetadata(output),
     CopyJob: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CopyJob !== undefined && data.CopyJob !== null) {
     contents.CopyJob = deserializeAws_restJson1CopyJob(data.CopyJob, context);
   }
@@ -3768,7 +3770,7 @@ export const deserializeAws_restJson1DescribeFrameworkCommand = async (
     FrameworkStatus: undefined,
     IdempotencyToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
@@ -3869,7 +3871,7 @@ export const deserializeAws_restJson1DescribeGlobalSettingsCommand = async (
     GlobalSettings: undefined,
     LastUpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalSettings !== undefined && data.GlobalSettings !== null) {
     contents.GlobalSettings = deserializeAws_restJson1GlobalSettings(data.GlobalSettings, context);
   }
@@ -3937,7 +3939,7 @@ export const deserializeAws_restJson1DescribeProtectedResourceCommand = async (
     ResourceArn: undefined,
     ResourceType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastBackupTime !== undefined && data.LastBackupTime !== null) {
     contents.LastBackupTime = new Date(Math.round(data.LastBackupTime * 1000));
   }
@@ -4040,7 +4042,7 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
     StatusMessage: undefined,
     StorageClass: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupSizeInBytes !== undefined && data.BackupSizeInBytes !== null) {
     contents.BackupSizeInBytes = __expectLong(data.BackupSizeInBytes);
   }
@@ -4173,7 +4175,7 @@ export const deserializeAws_restJson1DescribeRegionSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTypeOptInPreference: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceTypeOptInPreference !== undefined && data.ResourceTypeOptInPreference !== null) {
     contents.ResourceTypeOptInPreference = deserializeAws_restJson1ResourceTypeOptInPreference(
       data.ResourceTypeOptInPreference,
@@ -4231,7 +4233,7 @@ export const deserializeAws_restJson1DescribeReportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ReportJob: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReportJob !== undefined && data.ReportJob !== null) {
     contents.ReportJob = deserializeAws_restJson1ReportJob(data.ReportJob, context);
   }
@@ -4302,7 +4304,7 @@ export const deserializeAws_restJson1DescribeReportPlanCommand = async (
     $metadata: deserializeMetadata(output),
     ReportPlan: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReportPlan !== undefined && data.ReportPlan !== null) {
     contents.ReportPlan = deserializeAws_restJson1ReportPlan(data.ReportPlan, context);
   }
@@ -4393,7 +4395,7 @@ export const deserializeAws_restJson1DescribeRestoreJobCommand = async (
     Status: undefined,
     StatusMessage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountId !== undefined && data.AccountId !== null) {
     contents.AccountId = __expectString(data.AccountId);
   }
@@ -4607,7 +4609,7 @@ export const deserializeAws_restJson1ExportBackupPlanTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPlanTemplateJson: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanTemplateJson !== undefined && data.BackupPlanTemplateJson !== null) {
     contents.BackupPlanTemplateJson = __expectString(data.BackupPlanTemplateJson);
   }
@@ -4694,7 +4696,7 @@ export const deserializeAws_restJson1GetBackupPlanCommand = async (
     LastExecutionDate: undefined,
     VersionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdvancedBackupSettings !== undefined && data.AdvancedBackupSettings !== null) {
     contents.AdvancedBackupSettings = deserializeAws_restJson1AdvancedBackupSettings(
       data.AdvancedBackupSettings,
@@ -4800,7 +4802,7 @@ export const deserializeAws_restJson1GetBackupPlanFromJSONCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPlan: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlan !== undefined && data.BackupPlan !== null) {
     contents.BackupPlan = deserializeAws_restJson1BackupPlan(data.BackupPlan, context);
   }
@@ -4887,7 +4889,7 @@ export const deserializeAws_restJson1GetBackupPlanFromTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPlanDocument: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanDocument !== undefined && data.BackupPlanDocument !== null) {
     contents.BackupPlanDocument = deserializeAws_restJson1BackupPlan(data.BackupPlanDocument, context);
   }
@@ -4970,7 +4972,7 @@ export const deserializeAws_restJson1GetBackupSelectionCommand = async (
     CreatorRequestId: undefined,
     SelectionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
@@ -5063,7 +5065,7 @@ export const deserializeAws_restJson1GetBackupVaultAccessPolicyCommand = async (
     BackupVaultName: undefined,
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -5151,7 +5153,7 @@ export const deserializeAws_restJson1GetBackupVaultNotificationsCommand = async 
     BackupVaultName: undefined,
     SNSTopicArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -5241,7 +5243,7 @@ export const deserializeAws_restJson1GetRecoveryPointRestoreMetadataCommand = as
     RecoveryPointArn: undefined,
     RestoreMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -5326,7 +5328,7 @@ export const deserializeAws_restJson1GetSupportedResourceTypesCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTypes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceTypes !== undefined && data.ResourceTypes !== null) {
     contents.ResourceTypes = deserializeAws_restJson1ResourceTypes(data.ResourceTypes, context);
   }
@@ -5382,7 +5384,7 @@ export const deserializeAws_restJson1ListBackupJobsCommand = async (
     BackupJobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupJobs !== undefined && data.BackupJobs !== null) {
     contents.BackupJobs = deserializeAws_restJson1BackupJobsList(data.BackupJobs, context);
   }
@@ -5449,7 +5451,7 @@ export const deserializeAws_restJson1ListBackupPlansCommand = async (
     BackupPlansList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlansList !== undefined && data.BackupPlansList !== null) {
     contents.BackupPlansList = deserializeAws_restJson1BackupPlansList(data.BackupPlansList, context);
   }
@@ -5532,7 +5534,7 @@ export const deserializeAws_restJson1ListBackupPlanTemplatesCommand = async (
     BackupPlanTemplatesList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanTemplatesList !== undefined && data.BackupPlanTemplatesList !== null) {
     contents.BackupPlanTemplatesList = deserializeAws_restJson1BackupPlanTemplatesList(
       data.BackupPlanTemplatesList,
@@ -5618,7 +5620,7 @@ export const deserializeAws_restJson1ListBackupPlanVersionsCommand = async (
     BackupPlanVersionsList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanVersionsList !== undefined && data.BackupPlanVersionsList !== null) {
     contents.BackupPlanVersionsList = deserializeAws_restJson1BackupPlanVersionsList(
       data.BackupPlanVersionsList,
@@ -5704,7 +5706,7 @@ export const deserializeAws_restJson1ListBackupSelectionsCommand = async (
     BackupSelectionsList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupSelectionsList !== undefined && data.BackupSelectionsList !== null) {
     contents.BackupSelectionsList = deserializeAws_restJson1BackupSelectionsList(data.BackupSelectionsList, context);
   }
@@ -5787,7 +5789,7 @@ export const deserializeAws_restJson1ListBackupVaultsCommand = async (
     BackupVaultList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultList !== undefined && data.BackupVaultList !== null) {
     contents.BackupVaultList = deserializeAws_restJson1BackupVaultList(data.BackupVaultList, context);
   }
@@ -5870,7 +5872,7 @@ export const deserializeAws_restJson1ListCopyJobsCommand = async (
     CopyJobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CopyJobs !== undefined && data.CopyJobs !== null) {
     contents.CopyJobs = deserializeAws_restJson1CopyJobsList(data.CopyJobs, context);
   }
@@ -5937,7 +5939,7 @@ export const deserializeAws_restJson1ListFrameworksCommand = async (
     Frameworks: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Frameworks !== undefined && data.Frameworks !== null) {
     contents.Frameworks = deserializeAws_restJson1FrameworkList(data.Frameworks, context);
   }
@@ -6004,7 +6006,7 @@ export const deserializeAws_restJson1ListProtectedResourcesCommand = async (
     NextToken: undefined,
     Results: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6071,7 +6073,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByBackupVaultCommand = as
     NextToken: undefined,
     RecoveryPoints: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6154,7 +6156,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByResourceCommand = async
     NextToken: undefined,
     RecoveryPoints: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6237,7 +6239,7 @@ export const deserializeAws_restJson1ListReportJobsCommand = async (
     NextToken: undefined,
     ReportJobs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6304,7 +6306,7 @@ export const deserializeAws_restJson1ListReportPlansCommand = async (
     NextToken: undefined,
     ReportPlans: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6371,7 +6373,7 @@ export const deserializeAws_restJson1ListRestoreJobsCommand = async (
     NextToken: undefined,
     RestoreJobs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6454,7 +6456,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6688,7 +6690,7 @@ export const deserializeAws_restJson1StartBackupJobCommand = async (
     CreationDate: undefined,
     RecoveryPointArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupJobId !== undefined && data.BackupJobId !== null) {
     contents.BackupJobId = __expectString(data.BackupJobId);
   }
@@ -6790,7 +6792,7 @@ export const deserializeAws_restJson1StartCopyJobCommand = async (
     CopyJobId: undefined,
     CreationDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CopyJobId !== undefined && data.CopyJobId !== null) {
     contents.CopyJobId = __expectString(data.CopyJobId);
   }
@@ -6888,7 +6890,7 @@ export const deserializeAws_restJson1StartReportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ReportJobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReportJobId !== undefined && data.ReportJobId !== null) {
     contents.ReportJobId = __expectString(data.ReportJobId);
   }
@@ -6967,7 +6969,7 @@ export const deserializeAws_restJson1StartRestoreJobCommand = async (
     $metadata: deserializeMetadata(output),
     RestoreJobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RestoreJobId !== undefined && data.RestoreJobId !== null) {
     contents.RestoreJobId = __expectString(data.RestoreJobId);
   }
@@ -7291,7 +7293,7 @@ export const deserializeAws_restJson1UpdateBackupPlanCommand = async (
     CreationDate: undefined,
     VersionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdvancedBackupSettings !== undefined && data.AdvancedBackupSettings !== null) {
     contents.AdvancedBackupSettings = deserializeAws_restJson1AdvancedBackupSettings(
       data.AdvancedBackupSettings,
@@ -7387,7 +7389,7 @@ export const deserializeAws_restJson1UpdateFrameworkCommand = async (
     FrameworkArn: undefined,
     FrameworkName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
@@ -7566,7 +7568,7 @@ export const deserializeAws_restJson1UpdateRecoveryPointLifecycleCommand = async
     Lifecycle: undefined,
     RecoveryPointArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -7723,7 +7725,7 @@ export const deserializeAws_restJson1UpdateReportPlanCommand = async (
     ReportPlanArn: undefined,
     ReportPlanName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }

--- a/clients/client-batch/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1.ts
@@ -98,6 +98,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -776,7 +778,7 @@ export const deserializeAws_restJson1CreateComputeEnvironmentCommand = async (
     computeEnvironmentArn: undefined,
     computeEnvironmentName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.computeEnvironmentArn !== undefined && data.computeEnvironmentArn !== null) {
     contents.computeEnvironmentArn = __expectString(data.computeEnvironmentArn);
   }
@@ -843,7 +845,7 @@ export const deserializeAws_restJson1CreateJobQueueCommand = async (
     jobQueueArn: undefined,
     jobQueueName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobQueueArn !== undefined && data.jobQueueArn !== null) {
     contents.jobQueueArn = __expectString(data.jobQueueArn);
   }
@@ -1087,7 +1089,7 @@ export const deserializeAws_restJson1DescribeComputeEnvironmentsCommand = async 
     computeEnvironments: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.computeEnvironments !== undefined && data.computeEnvironments !== null) {
     contents.computeEnvironments = deserializeAws_restJson1ComputeEnvironmentDetailList(
       data.computeEnvironments,
@@ -1157,7 +1159,7 @@ export const deserializeAws_restJson1DescribeJobDefinitionsCommand = async (
     jobDefinitions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobDefinitions !== undefined && data.jobDefinitions !== null) {
     contents.jobDefinitions = deserializeAws_restJson1JobDefinitionList(data.jobDefinitions, context);
   }
@@ -1224,7 +1226,7 @@ export const deserializeAws_restJson1DescribeJobQueuesCommand = async (
     jobQueues: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobQueues !== undefined && data.jobQueues !== null) {
     contents.jobQueues = deserializeAws_restJson1JobQueueDetailList(data.jobQueues, context);
   }
@@ -1290,7 +1292,7 @@ export const deserializeAws_restJson1DescribeJobsCommand = async (
     $metadata: deserializeMetadata(output),
     jobs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1JobDetailList(data.jobs, context);
   }
@@ -1354,7 +1356,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     jobSummaryList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummaryList !== undefined && data.jobSummaryList !== null) {
     contents.jobSummaryList = deserializeAws_restJson1JobSummaryList(data.jobSummaryList, context);
   }
@@ -1420,7 +1422,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagrisTagsMap(data.tags, context);
   }
@@ -1485,7 +1487,7 @@ export const deserializeAws_restJson1RegisterJobDefinitionCommand = async (
     jobDefinitionName: undefined,
     revision: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobDefinitionArn !== undefined && data.jobDefinitionArn !== null) {
     contents.jobDefinitionArn = __expectString(data.jobDefinitionArn);
   }
@@ -1556,7 +1558,7 @@ export const deserializeAws_restJson1SubmitJobCommand = async (
     jobId: undefined,
     jobName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobArn !== undefined && data.jobArn !== null) {
     contents.jobArn = __expectString(data.jobArn);
   }
@@ -1803,7 +1805,7 @@ export const deserializeAws_restJson1UpdateComputeEnvironmentCommand = async (
     computeEnvironmentArn: undefined,
     computeEnvironmentName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.computeEnvironmentArn !== undefined && data.computeEnvironmentArn !== null) {
     contents.computeEnvironmentArn = __expectString(data.computeEnvironmentArn);
   }
@@ -1870,7 +1872,7 @@ export const deserializeAws_restJson1UpdateJobQueueCommand = async (
     jobQueueArn: undefined,
     jobQueueName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobQueueArn !== undefined && data.jobQueueArn !== null) {
     contents.jobQueueArn = __expectString(data.jobQueueArn);
   }

--- a/clients/client-braket/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/protocols/Aws_restJson1.ts
@@ -29,6 +29,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   LazyJsonString as __LazyJsonString,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -329,7 +331,7 @@ export const deserializeAws_restJson1CancelQuantumTaskCommand = async (
     cancellationStatus: undefined,
     quantumTaskArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cancellationStatus !== undefined && data.cancellationStatus !== null) {
     contents.cancellationStatus = __expectString(data.cancellationStatus);
   }
@@ -427,7 +429,7 @@ export const deserializeAws_restJson1CreateQuantumTaskCommand = async (
     $metadata: deserializeMetadata(output),
     quantumTaskArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.quantumTaskArn !== undefined && data.quantumTaskArn !== null) {
     contents.quantumTaskArn = __expectString(data.quantumTaskArn);
   }
@@ -527,7 +529,7 @@ export const deserializeAws_restJson1GetDeviceCommand = async (
     deviceType: undefined,
     providerName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceArn !== undefined && data.deviceArn !== null) {
     contents.deviceArn = __expectString(data.deviceArn);
   }
@@ -655,7 +657,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
@@ -772,7 +774,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -844,7 +846,7 @@ export const deserializeAws_restJson1SearchDevicesCommand = async (
     devices: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.devices = deserializeAws_restJson1DeviceSummaryList(data.devices, context);
   }
@@ -927,7 +929,7 @@ export const deserializeAws_restJson1SearchQuantumTasksCommand = async (
     nextToken: undefined,
     quantumTasks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-chime-sdk-identity/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-identity/protocols/Aws_restJson1.ts
@@ -73,6 +73,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -609,7 +611,7 @@ export const deserializeAws_restJson1CreateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -721,7 +723,7 @@ export const deserializeAws_restJson1CreateAppInstanceAdminCommand = async (
     AppInstanceAdmin: undefined,
     AppInstanceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1Identity(data.AppInstanceAdmin, context);
   }
@@ -835,7 +837,7 @@ export const deserializeAws_restJson1CreateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -1259,7 +1261,7 @@ export const deserializeAws_restJson1DescribeAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstance: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstance !== undefined && data.AppInstance !== null) {
     contents.AppInstance = deserializeAws_restJson1AppInstance(data.AppInstance, context);
   }
@@ -1354,7 +1356,7 @@ export const deserializeAws_restJson1DescribeAppInstanceAdminCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceAdmin: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1AppInstanceAdmin(data.AppInstanceAdmin, context);
   }
@@ -1449,7 +1451,7 @@ export const deserializeAws_restJson1DescribeAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUser: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUser !== undefined && data.AppInstanceUser !== null) {
     contents.AppInstanceUser = deserializeAws_restJson1AppInstanceUser(data.AppInstanceUser, context);
   }
@@ -1545,7 +1547,7 @@ export const deserializeAws_restJson1GetAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -1648,7 +1650,7 @@ export const deserializeAws_restJson1ListAppInstanceAdminsCommand = async (
     AppInstanceArn: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmins !== undefined && data.AppInstanceAdmins !== null) {
     contents.AppInstanceAdmins = deserializeAws_restJson1AppInstanceAdminList(data.AppInstanceAdmins, context);
   }
@@ -1758,7 +1760,7 @@ export const deserializeAws_restJson1ListAppInstancesCommand = async (
     AppInstances: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstances !== undefined && data.AppInstances !== null) {
     contents.AppInstances = deserializeAws_restJson1AppInstanceList(data.AppInstances, context);
   }
@@ -1858,7 +1860,7 @@ export const deserializeAws_restJson1ListAppInstanceUsersCommand = async (
     AppInstanceUsers: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -1960,7 +1962,7 @@ export const deserializeAws_restJson1PutAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -2061,7 +2063,7 @@ export const deserializeAws_restJson1UpdateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -2164,7 +2166,7 @@ export const deserializeAws_restJson1UpdateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }

--- a/clients/client-chime-sdk-messaging/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-messaging/protocols/Aws_restJson1.ts
@@ -117,6 +117,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1232,7 +1234,7 @@ export const deserializeAws_restJson1BatchCreateChannelMembershipCommand = async
     BatchChannelMemberships: undefined,
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchChannelMemberships !== undefined && data.BatchChannelMemberships !== null) {
     contents.BatchChannelMemberships = deserializeAws_restJson1BatchChannelMemberships(
       data.BatchChannelMemberships,
@@ -1333,7 +1335,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -1445,7 +1447,7 @@ export const deserializeAws_restJson1CreateChannelBanCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -1560,7 +1562,7 @@ export const deserializeAws_restJson1CreateChannelMembershipCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -1675,7 +1677,7 @@ export const deserializeAws_restJson1CreateChannelModeratorCommand = async (
     ChannelArn: undefined,
     ChannelModerator: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -2252,7 +2254,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.Channel, context);
   }
@@ -2347,7 +2349,7 @@ export const deserializeAws_restJson1DescribeChannelBanCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelBan: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelBan !== undefined && data.ChannelBan !== null) {
     contents.ChannelBan = deserializeAws_restJson1ChannelBan(data.ChannelBan, context);
   }
@@ -2450,7 +2452,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembership(data.ChannelMembership, context);
   }
@@ -2553,7 +2555,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipForAppInstanceUser
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummary(
       data.ChannelMembership,
@@ -2651,7 +2653,7 @@ export const deserializeAws_restJson1DescribeChannelModeratedByAppInstanceUserCo
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummary(data.Channel, context);
   }
@@ -2746,7 +2748,7 @@ export const deserializeAws_restJson1DescribeChannelModeratorCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelModerator: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelModerator !== undefined && data.ChannelModerator !== null) {
     contents.ChannelModerator = deserializeAws_restJson1ChannelModerator(data.ChannelModerator, context);
   }
@@ -2849,7 +2851,7 @@ export const deserializeAws_restJson1GetChannelMessageCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMessage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMessage !== undefined && data.ChannelMessage !== null) {
     contents.ChannelMessage = deserializeAws_restJson1ChannelMessage(data.ChannelMessage, context);
   }
@@ -2952,7 +2954,7 @@ export const deserializeAws_restJson1GetMessagingSessionEndpointCommand = async 
     $metadata: deserializeMetadata(output),
     Endpoint: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Endpoint !== undefined && data.Endpoint !== null) {
     contents.Endpoint = deserializeAws_restJson1MessagingSessionEndpoint(data.Endpoint, context);
   }
@@ -3041,7 +3043,7 @@ export const deserializeAws_restJson1ListChannelBansCommand = async (
     ChannelBans: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3144,7 +3146,7 @@ export const deserializeAws_restJson1ListChannelMembershipsCommand = async (
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3249,7 +3251,7 @@ export const deserializeAws_restJson1ListChannelMembershipsForAppInstanceUserCom
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMemberships !== undefined && data.ChannelMemberships !== null) {
     contents.ChannelMemberships = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummaryList(
       data.ChannelMemberships,
@@ -3352,7 +3354,7 @@ export const deserializeAws_restJson1ListChannelMessagesCommand = async (
     ChannelMessages: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3455,7 +3457,7 @@ export const deserializeAws_restJson1ListChannelModeratorsCommand = async (
     ChannelModerators: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3557,7 +3559,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelSummaryList(data.Channels, context);
   }
@@ -3656,7 +3658,7 @@ export const deserializeAws_restJson1ListChannelsModeratedByAppInstanceUserComma
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummaryList(data.Channels, context);
   }
@@ -3755,7 +3757,7 @@ export const deserializeAws_restJson1RedactChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3854,7 +3856,7 @@ export const deserializeAws_restJson1SendChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3960,7 +3962,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -4064,7 +4066,7 @@ export const deserializeAws_restJson1UpdateChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -4170,7 +4172,7 @@ export const deserializeAws_restJson1UpdateChannelReadMarkerCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }

--- a/clients/client-chime/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1.ts
@@ -646,6 +646,8 @@ import {
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -7677,7 +7679,7 @@ export const deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorComm
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -7788,7 +7790,7 @@ export const deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorGrou
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -8106,7 +8108,7 @@ export const deserializeAws_restJson1BatchCreateAttendeeCommand = async (
     Attendees: undefined,
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -8221,7 +8223,7 @@ export const deserializeAws_restJson1BatchCreateChannelMembershipCommand = async
     BatchChannelMemberships: undefined,
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchChannelMemberships !== undefined && data.BatchChannelMemberships !== null) {
     contents.BatchChannelMemberships = deserializeAws_restJson1BatchChannelMemberships(
       data.BatchChannelMemberships,
@@ -8322,7 +8324,7 @@ export const deserializeAws_restJson1BatchCreateRoomMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1MemberErrorList(data.Errors, context);
   }
@@ -8425,7 +8427,7 @@ export const deserializeAws_restJson1BatchDeletePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -8528,7 +8530,7 @@ export const deserializeAws_restJson1BatchSuspendUserCommand = async (
     $metadata: deserializeMetadata(output),
     UserErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserErrors !== undefined && data.UserErrors !== null) {
     contents.UserErrors = deserializeAws_restJson1UserErrorList(data.UserErrors, context);
   }
@@ -8631,7 +8633,7 @@ export const deserializeAws_restJson1BatchUnsuspendUserCommand = async (
     $metadata: deserializeMetadata(output),
     UserErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserErrors !== undefined && data.UserErrors !== null) {
     contents.UserErrors = deserializeAws_restJson1UserErrorList(data.UserErrors, context);
   }
@@ -8734,7 +8736,7 @@ export const deserializeAws_restJson1BatchUpdatePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -8837,7 +8839,7 @@ export const deserializeAws_restJson1BatchUpdateUserCommand = async (
     $metadata: deserializeMetadata(output),
     UserErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserErrors !== undefined && data.UserErrors !== null) {
     contents.UserErrors = deserializeAws_restJson1UserErrorList(data.UserErrors, context);
   }
@@ -8940,7 +8942,7 @@ export const deserializeAws_restJson1CreateAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Account: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Account !== undefined && data.Account !== null) {
     contents.Account = deserializeAws_restJson1Account(data.Account, context);
   }
@@ -9043,7 +9045,7 @@ export const deserializeAws_restJson1CreateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -9155,7 +9157,7 @@ export const deserializeAws_restJson1CreateAppInstanceAdminCommand = async (
     AppInstanceAdmin: undefined,
     AppInstanceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1Identity(data.AppInstanceAdmin, context);
   }
@@ -9269,7 +9271,7 @@ export const deserializeAws_restJson1CreateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -9380,7 +9382,7 @@ export const deserializeAws_restJson1CreateAttendeeCommand = async (
     $metadata: deserializeMetadata(output),
     Attendee: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendee !== undefined && data.Attendee !== null) {
     contents.Attendee = deserializeAws_restJson1Attendee(data.Attendee, context);
   }
@@ -9491,7 +9493,7 @@ export const deserializeAws_restJson1CreateBotCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -9602,7 +9604,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -9714,7 +9716,7 @@ export const deserializeAws_restJson1CreateChannelBanCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -9829,7 +9831,7 @@ export const deserializeAws_restJson1CreateChannelMembershipCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -9944,7 +9946,7 @@ export const deserializeAws_restJson1CreateChannelModeratorCommand = async (
     ChannelArn: undefined,
     ChannelModerator: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -10058,7 +10060,7 @@ export const deserializeAws_restJson1CreateMediaCapturePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     MediaCapturePipeline: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipeline !== undefined && data.MediaCapturePipeline !== null) {
     contents.MediaCapturePipeline = deserializeAws_restJson1MediaCapturePipeline(data.MediaCapturePipeline, context);
   }
@@ -10161,7 +10163,7 @@ export const deserializeAws_restJson1CreateMeetingCommand = async (
     $metadata: deserializeMetadata(output),
     Meeting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meeting !== undefined && data.Meeting !== null) {
     contents.Meeting = deserializeAws_restJson1Meeting(data.Meeting, context);
   }
@@ -10264,7 +10266,7 @@ export const deserializeAws_restJson1CreateMeetingDialOutCommand = async (
     $metadata: deserializeMetadata(output),
     TransactionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransactionId !== undefined && data.TransactionId !== null) {
     contents.TransactionId = __expectString(data.TransactionId);
   }
@@ -10369,7 +10371,7 @@ export const deserializeAws_restJson1CreateMeetingWithAttendeesCommand = async (
     Errors: undefined,
     Meeting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -10478,7 +10480,7 @@ export const deserializeAws_restJson1CreatePhoneNumberOrderCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberOrder: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberOrder !== undefined && data.PhoneNumberOrder !== null) {
     contents.PhoneNumberOrder = deserializeAws_restJson1PhoneNumberOrder(data.PhoneNumberOrder, context);
   }
@@ -10589,7 +10591,7 @@ export const deserializeAws_restJson1CreateProxySessionCommand = async (
     $metadata: deserializeMetadata(output),
     ProxySession: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProxySession !== undefined && data.ProxySession !== null) {
     contents.ProxySession = deserializeAws_restJson1ProxySession(data.ProxySession, context);
   }
@@ -10692,7 +10694,7 @@ export const deserializeAws_restJson1CreateRoomCommand = async (
     $metadata: deserializeMetadata(output),
     Room: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Room !== undefined && data.Room !== null) {
     contents.Room = deserializeAws_restJson1Room(data.Room, context);
   }
@@ -10803,7 +10805,7 @@ export const deserializeAws_restJson1CreateRoomMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     RoomMembership: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoomMembership !== undefined && data.RoomMembership !== null) {
     contents.RoomMembership = deserializeAws_restJson1RoomMembership(data.RoomMembership, context);
   }
@@ -10922,7 +10924,7 @@ export const deserializeAws_restJson1CreateSipMediaApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     SipMediaApplication: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplication !== undefined && data.SipMediaApplication !== null) {
     contents.SipMediaApplication = deserializeAws_restJson1SipMediaApplication(data.SipMediaApplication, context);
   }
@@ -11041,7 +11043,7 @@ export const deserializeAws_restJson1CreateSipMediaApplicationCallCommand = asyn
     $metadata: deserializeMetadata(output),
     SipMediaApplicationCall: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplicationCall !== undefined && data.SipMediaApplicationCall !== null) {
     contents.SipMediaApplicationCall = deserializeAws_restJson1SipMediaApplicationCall(
       data.SipMediaApplicationCall,
@@ -11147,7 +11149,7 @@ export const deserializeAws_restJson1CreateSipRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SipRule: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipRule !== undefined && data.SipRule !== null) {
     contents.SipRule = deserializeAws_restJson1SipRule(data.SipRule, context);
   }
@@ -11266,7 +11268,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -11377,7 +11379,7 @@ export const deserializeAws_restJson1CreateVoiceConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnector: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnector !== undefined && data.VoiceConnector !== null) {
     contents.VoiceConnector = deserializeAws_restJson1VoiceConnector(data.VoiceConnector, context);
   }
@@ -11488,7 +11490,7 @@ export const deserializeAws_restJson1CreateVoiceConnectorGroupCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnectorGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnectorGroup !== undefined && data.VoiceConnectorGroup !== null) {
     contents.VoiceConnectorGroup = deserializeAws_restJson1VoiceConnectorGroup(data.VoiceConnectorGroup, context);
   }
@@ -14355,7 +14357,7 @@ export const deserializeAws_restJson1DescribeAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstance: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstance !== undefined && data.AppInstance !== null) {
     contents.AppInstance = deserializeAws_restJson1AppInstance(data.AppInstance, context);
   }
@@ -14450,7 +14452,7 @@ export const deserializeAws_restJson1DescribeAppInstanceAdminCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceAdmin: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1AppInstanceAdmin(data.AppInstanceAdmin, context);
   }
@@ -14545,7 +14547,7 @@ export const deserializeAws_restJson1DescribeAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUser: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUser !== undefined && data.AppInstanceUser !== null) {
     contents.AppInstanceUser = deserializeAws_restJson1AppInstanceUser(data.AppInstanceUser, context);
   }
@@ -14640,7 +14642,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.Channel, context);
   }
@@ -14735,7 +14737,7 @@ export const deserializeAws_restJson1DescribeChannelBanCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelBan: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelBan !== undefined && data.ChannelBan !== null) {
     contents.ChannelBan = deserializeAws_restJson1ChannelBan(data.ChannelBan, context);
   }
@@ -14838,7 +14840,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembership(data.ChannelMembership, context);
   }
@@ -14941,7 +14943,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipForAppInstanceUser
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummary(
       data.ChannelMembership,
@@ -15039,7 +15041,7 @@ export const deserializeAws_restJson1DescribeChannelModeratedByAppInstanceUserCo
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummary(data.Channel, context);
   }
@@ -15134,7 +15136,7 @@ export const deserializeAws_restJson1DescribeChannelModeratorCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelModerator: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelModerator !== undefined && data.ChannelModerator !== null) {
     contents.ChannelModerator = deserializeAws_restJson1ChannelModerator(data.ChannelModerator, context);
   }
@@ -15336,7 +15338,7 @@ export const deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorC
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -15439,7 +15441,7 @@ export const deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorG
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -15641,7 +15643,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Account: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Account !== undefined && data.Account !== null) {
     contents.Account = deserializeAws_restJson1Account(data.Account, context);
   }
@@ -15744,7 +15746,7 @@ export const deserializeAws_restJson1GetAccountSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     AccountSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountSettings !== undefined && data.AccountSettings !== null) {
     contents.AccountSettings = deserializeAws_restJson1AccountSettings(data.AccountSettings, context);
   }
@@ -15848,7 +15850,7 @@ export const deserializeAws_restJson1GetAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -15957,7 +15959,7 @@ export const deserializeAws_restJson1GetAppInstanceStreamingConfigurationsComman
     $metadata: deserializeMetadata(output),
     AppInstanceStreamingConfigurations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceStreamingConfigurations !== undefined && data.AppInstanceStreamingConfigurations !== null) {
     contents.AppInstanceStreamingConfigurations = deserializeAws_restJson1AppInstanceStreamingConfigurationList(
       data.AppInstanceStreamingConfigurations,
@@ -16063,7 +16065,7 @@ export const deserializeAws_restJson1GetAttendeeCommand = async (
     $metadata: deserializeMetadata(output),
     Attendee: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendee !== undefined && data.Attendee !== null) {
     contents.Attendee = deserializeAws_restJson1Attendee(data.Attendee, context);
   }
@@ -16166,7 +16168,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -16269,7 +16271,7 @@ export const deserializeAws_restJson1GetChannelMessageCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMessage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMessage !== undefined && data.ChannelMessage !== null) {
     contents.ChannelMessage = deserializeAws_restJson1ChannelMessage(data.ChannelMessage, context);
   }
@@ -16372,7 +16374,7 @@ export const deserializeAws_restJson1GetEventsConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     EventsConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventsConfiguration !== undefined && data.EventsConfiguration !== null) {
     contents.EventsConfiguration = deserializeAws_restJson1EventsConfiguration(data.EventsConfiguration, context);
   }
@@ -16476,7 +16478,7 @@ export const deserializeAws_restJson1GetGlobalSettingsCommand = async (
     BusinessCalling: undefined,
     VoiceConnector: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BusinessCalling !== undefined && data.BusinessCalling !== null) {
     contents.BusinessCalling = deserializeAws_restJson1BusinessCallingSettings(data.BusinessCalling, context);
   }
@@ -16574,7 +16576,7 @@ export const deserializeAws_restJson1GetMediaCapturePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     MediaCapturePipeline: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipeline !== undefined && data.MediaCapturePipeline !== null) {
     contents.MediaCapturePipeline = deserializeAws_restJson1MediaCapturePipeline(data.MediaCapturePipeline, context);
   }
@@ -16677,7 +16679,7 @@ export const deserializeAws_restJson1GetMeetingCommand = async (
     $metadata: deserializeMetadata(output),
     Meeting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meeting !== undefined && data.Meeting !== null) {
     contents.Meeting = deserializeAws_restJson1Meeting(data.Meeting, context);
   }
@@ -16780,7 +16782,7 @@ export const deserializeAws_restJson1GetMessagingSessionEndpointCommand = async 
     $metadata: deserializeMetadata(output),
     Endpoint: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Endpoint !== undefined && data.Endpoint !== null) {
     contents.Endpoint = deserializeAws_restJson1MessagingSessionEndpoint(data.Endpoint, context);
   }
@@ -16867,7 +16869,7 @@ export const deserializeAws_restJson1GetPhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumber: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumber !== undefined && data.PhoneNumber !== null) {
     contents.PhoneNumber = deserializeAws_restJson1PhoneNumber(data.PhoneNumber, context);
   }
@@ -16970,7 +16972,7 @@ export const deserializeAws_restJson1GetPhoneNumberOrderCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberOrder: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberOrder !== undefined && data.PhoneNumberOrder !== null) {
     contents.PhoneNumberOrder = deserializeAws_restJson1PhoneNumberOrder(data.PhoneNumberOrder, context);
   }
@@ -17074,7 +17076,7 @@ export const deserializeAws_restJson1GetPhoneNumberSettingsCommand = async (
     CallingName: undefined,
     CallingNameUpdatedTimestamp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CallingName !== undefined && data.CallingName !== null) {
     contents.CallingName = __expectString(data.CallingName);
   }
@@ -17172,7 +17174,7 @@ export const deserializeAws_restJson1GetProxySessionCommand = async (
     $metadata: deserializeMetadata(output),
     ProxySession: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProxySession !== undefined && data.ProxySession !== null) {
     contents.ProxySession = deserializeAws_restJson1ProxySession(data.ProxySession, context);
   }
@@ -17276,7 +17278,7 @@ export const deserializeAws_restJson1GetRetentionSettingsCommand = async (
     InitiateDeletionTimestamp: undefined,
     RetentionSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
     contents.InitiateDeletionTimestamp = new Date(data.InitiateDeletionTimestamp);
   }
@@ -17382,7 +17384,7 @@ export const deserializeAws_restJson1GetRoomCommand = async (
     $metadata: deserializeMetadata(output),
     Room: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Room !== undefined && data.Room !== null) {
     contents.Room = deserializeAws_restJson1Room(data.Room, context);
   }
@@ -17485,7 +17487,7 @@ export const deserializeAws_restJson1GetSipMediaApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     SipMediaApplication: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplication !== undefined && data.SipMediaApplication !== null) {
     contents.SipMediaApplication = deserializeAws_restJson1SipMediaApplication(data.SipMediaApplication, context);
   }
@@ -17588,7 +17590,7 @@ export const deserializeAws_restJson1GetSipMediaApplicationLoggingConfigurationC
     $metadata: deserializeMetadata(output),
     SipMediaApplicationLoggingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.SipMediaApplicationLoggingConfiguration !== undefined &&
     data.SipMediaApplicationLoggingConfiguration !== null
@@ -17697,7 +17699,7 @@ export const deserializeAws_restJson1GetSipRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SipRule: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipRule !== undefined && data.SipRule !== null) {
     contents.SipRule = deserializeAws_restJson1SipRule(data.SipRule, context);
   }
@@ -17800,7 +17802,7 @@ export const deserializeAws_restJson1GetUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -17903,7 +17905,7 @@ export const deserializeAws_restJson1GetUserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     UserSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserSettings !== undefined && data.UserSettings !== null) {
     contents.UserSettings = deserializeAws_restJson1UserSettings(data.UserSettings, context);
   }
@@ -18006,7 +18008,7 @@ export const deserializeAws_restJson1GetVoiceConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnector: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnector !== undefined && data.VoiceConnector !== null) {
     contents.VoiceConnector = deserializeAws_restJson1VoiceConnector(data.VoiceConnector, context);
   }
@@ -18109,7 +18111,7 @@ export const deserializeAws_restJson1GetVoiceConnectorEmergencyCallingConfigurat
     $metadata: deserializeMetadata(output),
     EmergencyCallingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmergencyCallingConfiguration !== undefined && data.EmergencyCallingConfiguration !== null) {
     contents.EmergencyCallingConfiguration = deserializeAws_restJson1EmergencyCallingConfiguration(
       data.EmergencyCallingConfiguration,
@@ -18215,7 +18217,7 @@ export const deserializeAws_restJson1GetVoiceConnectorGroupCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnectorGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnectorGroup !== undefined && data.VoiceConnectorGroup !== null) {
     contents.VoiceConnectorGroup = deserializeAws_restJson1VoiceConnectorGroup(data.VoiceConnectorGroup, context);
   }
@@ -18318,7 +18320,7 @@ export const deserializeAws_restJson1GetVoiceConnectorLoggingConfigurationComman
     $metadata: deserializeMetadata(output),
     LoggingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LoggingConfiguration !== undefined && data.LoggingConfiguration !== null) {
     contents.LoggingConfiguration = deserializeAws_restJson1LoggingConfiguration(data.LoggingConfiguration, context);
   }
@@ -18421,7 +18423,7 @@ export const deserializeAws_restJson1GetVoiceConnectorOriginationCommand = async
     $metadata: deserializeMetadata(output),
     Origination: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Origination !== undefined && data.Origination !== null) {
     contents.Origination = deserializeAws_restJson1Origination(data.Origination, context);
   }
@@ -18524,7 +18526,7 @@ export const deserializeAws_restJson1GetVoiceConnectorProxyCommand = async (
     $metadata: deserializeMetadata(output),
     Proxy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proxy !== undefined && data.Proxy !== null) {
     contents.Proxy = deserializeAws_restJson1Proxy(data.Proxy, context);
   }
@@ -18627,7 +18629,7 @@ export const deserializeAws_restJson1GetVoiceConnectorStreamingConfigurationComm
     $metadata: deserializeMetadata(output),
     StreamingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamingConfiguration !== undefined && data.StreamingConfiguration !== null) {
     contents.StreamingConfiguration = deserializeAws_restJson1StreamingConfiguration(
       data.StreamingConfiguration,
@@ -18733,7 +18735,7 @@ export const deserializeAws_restJson1GetVoiceConnectorTerminationCommand = async
     $metadata: deserializeMetadata(output),
     Termination: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Termination !== undefined && data.Termination !== null) {
     contents.Termination = deserializeAws_restJson1Termination(data.Termination, context);
   }
@@ -18836,7 +18838,7 @@ export const deserializeAws_restJson1GetVoiceConnectorTerminationHealthCommand =
     $metadata: deserializeMetadata(output),
     TerminationHealth: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TerminationHealth !== undefined && data.TerminationHealth !== null) {
     contents.TerminationHealth = deserializeAws_restJson1TerminationHealth(data.TerminationHealth, context);
   }
@@ -18939,7 +18941,7 @@ export const deserializeAws_restJson1InviteUsersCommand = async (
     $metadata: deserializeMetadata(output),
     Invites: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invites !== undefined && data.Invites !== null) {
     contents.Invites = deserializeAws_restJson1InviteList(data.Invites, context);
   }
@@ -19043,7 +19045,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
     Accounts: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Accounts !== undefined && data.Accounts !== null) {
     contents.Accounts = deserializeAws_restJson1AccountList(data.Accounts, context);
   }
@@ -19151,7 +19153,7 @@ export const deserializeAws_restJson1ListAppInstanceAdminsCommand = async (
     AppInstanceArn: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmins !== undefined && data.AppInstanceAdmins !== null) {
     contents.AppInstanceAdmins = deserializeAws_restJson1AppInstanceAdminList(data.AppInstanceAdmins, context);
   }
@@ -19253,7 +19255,7 @@ export const deserializeAws_restJson1ListAppInstancesCommand = async (
     AppInstances: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstances !== undefined && data.AppInstances !== null) {
     contents.AppInstances = deserializeAws_restJson1AppInstanceList(data.AppInstances, context);
   }
@@ -19353,7 +19355,7 @@ export const deserializeAws_restJson1ListAppInstanceUsersCommand = async (
     AppInstanceUsers: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -19455,7 +19457,7 @@ export const deserializeAws_restJson1ListAttendeesCommand = async (
     Attendees: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -19561,7 +19563,7 @@ export const deserializeAws_restJson1ListAttendeeTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -19665,7 +19667,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     Bots: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bots !== undefined && data.Bots !== null) {
     contents.Bots = deserializeAws_restJson1BotList(data.Bots, context);
   }
@@ -19773,7 +19775,7 @@ export const deserializeAws_restJson1ListChannelBansCommand = async (
     ChannelBans: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -19876,7 +19878,7 @@ export const deserializeAws_restJson1ListChannelMembershipsCommand = async (
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -19981,7 +19983,7 @@ export const deserializeAws_restJson1ListChannelMembershipsForAppInstanceUserCom
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMemberships !== undefined && data.ChannelMemberships !== null) {
     contents.ChannelMemberships = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummaryList(
       data.ChannelMemberships,
@@ -20084,7 +20086,7 @@ export const deserializeAws_restJson1ListChannelMessagesCommand = async (
     ChannelMessages: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -20187,7 +20189,7 @@ export const deserializeAws_restJson1ListChannelModeratorsCommand = async (
     ChannelModerators: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -20289,7 +20291,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelSummaryList(data.Channels, context);
   }
@@ -20388,7 +20390,7 @@ export const deserializeAws_restJson1ListChannelsModeratedByAppInstanceUserComma
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummaryList(data.Channels, context);
   }
@@ -20487,7 +20489,7 @@ export const deserializeAws_restJson1ListMediaCapturePipelinesCommand = async (
     MediaCapturePipelines: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipelines !== undefined && data.MediaCapturePipelines !== null) {
     contents.MediaCapturePipelines = deserializeAws_restJson1MediaCapturePipelineList(
       data.MediaCapturePipelines,
@@ -20589,7 +20591,7 @@ export const deserializeAws_restJson1ListMeetingsCommand = async (
     Meetings: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meetings !== undefined && data.Meetings !== null) {
     contents.Meetings = deserializeAws_restJson1MeetingList(data.Meetings, context);
   }
@@ -20687,7 +20689,7 @@ export const deserializeAws_restJson1ListMeetingTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -20791,7 +20793,7 @@ export const deserializeAws_restJson1ListPhoneNumberOrdersCommand = async (
     NextToken: undefined,
     PhoneNumberOrders: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -20890,7 +20892,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
     NextToken: undefined,
     PhoneNumbers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -20997,7 +20999,7 @@ export const deserializeAws_restJson1ListProxySessionsCommand = async (
     NextToken: undefined,
     ProxySessions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -21104,7 +21106,7 @@ export const deserializeAws_restJson1ListRoomMembershipsCommand = async (
     NextToken: undefined,
     RoomMemberships: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -21211,7 +21213,7 @@ export const deserializeAws_restJson1ListRoomsCommand = async (
     NextToken: undefined,
     Rooms: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -21318,7 +21320,7 @@ export const deserializeAws_restJson1ListSipMediaApplicationsCommand = async (
     NextToken: undefined,
     SipMediaApplications: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -21417,7 +21419,7 @@ export const deserializeAws_restJson1ListSipRulesCommand = async (
     NextToken: undefined,
     SipRules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -21515,7 +21517,7 @@ export const deserializeAws_restJson1ListSupportedPhoneNumberCountriesCommand = 
     $metadata: deserializeMetadata(output),
     PhoneNumberCountries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberCountries !== undefined && data.PhoneNumberCountries !== null) {
     contents.PhoneNumberCountries = deserializeAws_restJson1PhoneNumberCountriesList(
       data.PhoneNumberCountries,
@@ -21621,7 +21623,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -21717,7 +21719,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     NextToken: undefined,
     Users: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -21824,7 +21826,7 @@ export const deserializeAws_restJson1ListVoiceConnectorGroupsCommand = async (
     NextToken: undefined,
     VoiceConnectorGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -21923,7 +21925,7 @@ export const deserializeAws_restJson1ListVoiceConnectorsCommand = async (
     NextToken: undefined,
     VoiceConnectors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -22021,7 +22023,7 @@ export const deserializeAws_restJson1ListVoiceConnectorTerminationCredentialsCom
     $metadata: deserializeMetadata(output),
     Usernames: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Usernames !== undefined && data.Usernames !== null) {
     contents.Usernames = deserializeAws_restJson1SensitiveStringList(data.Usernames, context);
   }
@@ -22224,7 +22226,7 @@ export const deserializeAws_restJson1PutAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -22341,7 +22343,7 @@ export const deserializeAws_restJson1PutAppInstanceStreamingConfigurationsComman
     $metadata: deserializeMetadata(output),
     AppInstanceStreamingConfigurations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceStreamingConfigurations !== undefined && data.AppInstanceStreamingConfigurations !== null) {
     contents.AppInstanceStreamingConfigurations = deserializeAws_restJson1AppInstanceStreamingConfigurationList(
       data.AppInstanceStreamingConfigurations,
@@ -22447,7 +22449,7 @@ export const deserializeAws_restJson1PutEventsConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     EventsConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventsConfiguration !== undefined && data.EventsConfiguration !== null) {
     contents.EventsConfiguration = deserializeAws_restJson1EventsConfiguration(data.EventsConfiguration, context);
   }
@@ -22551,7 +22553,7 @@ export const deserializeAws_restJson1PutRetentionSettingsCommand = async (
     InitiateDeletionTimestamp: undefined,
     RetentionSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
     contents.InitiateDeletionTimestamp = new Date(data.InitiateDeletionTimestamp);
   }
@@ -22665,7 +22667,7 @@ export const deserializeAws_restJson1PutSipMediaApplicationLoggingConfigurationC
     $metadata: deserializeMetadata(output),
     SipMediaApplicationLoggingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.SipMediaApplicationLoggingConfiguration !== undefined &&
     data.SipMediaApplicationLoggingConfiguration !== null
@@ -22774,7 +22776,7 @@ export const deserializeAws_restJson1PutVoiceConnectorEmergencyCallingConfigurat
     $metadata: deserializeMetadata(output),
     EmergencyCallingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmergencyCallingConfiguration !== undefined && data.EmergencyCallingConfiguration !== null) {
     contents.EmergencyCallingConfiguration = deserializeAws_restJson1EmergencyCallingConfiguration(
       data.EmergencyCallingConfiguration,
@@ -22880,7 +22882,7 @@ export const deserializeAws_restJson1PutVoiceConnectorLoggingConfigurationComman
     $metadata: deserializeMetadata(output),
     LoggingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LoggingConfiguration !== undefined && data.LoggingConfiguration !== null) {
     contents.LoggingConfiguration = deserializeAws_restJson1LoggingConfiguration(data.LoggingConfiguration, context);
   }
@@ -22983,7 +22985,7 @@ export const deserializeAws_restJson1PutVoiceConnectorOriginationCommand = async
     $metadata: deserializeMetadata(output),
     Origination: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Origination !== undefined && data.Origination !== null) {
     contents.Origination = deserializeAws_restJson1Origination(data.Origination, context);
   }
@@ -23086,7 +23088,7 @@ export const deserializeAws_restJson1PutVoiceConnectorProxyCommand = async (
     $metadata: deserializeMetadata(output),
     Proxy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proxy !== undefined && data.Proxy !== null) {
     contents.Proxy = deserializeAws_restJson1Proxy(data.Proxy, context);
   }
@@ -23197,7 +23199,7 @@ export const deserializeAws_restJson1PutVoiceConnectorStreamingConfigurationComm
     $metadata: deserializeMetadata(output),
     StreamingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamingConfiguration !== undefined && data.StreamingConfiguration !== null) {
     contents.StreamingConfiguration = deserializeAws_restJson1StreamingConfiguration(
       data.StreamingConfiguration,
@@ -23303,7 +23305,7 @@ export const deserializeAws_restJson1PutVoiceConnectorTerminationCommand = async
     $metadata: deserializeMetadata(output),
     Termination: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Termination !== undefined && data.Termination !== null) {
     contents.Termination = deserializeAws_restJson1Termination(data.Termination, context);
   }
@@ -23514,7 +23516,7 @@ export const deserializeAws_restJson1RedactChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -23810,7 +23812,7 @@ export const deserializeAws_restJson1RegenerateSecurityTokenCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -23913,7 +23915,7 @@ export const deserializeAws_restJson1ResetPersonalPINCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -24016,7 +24018,7 @@ export const deserializeAws_restJson1RestorePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumber: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumber !== undefined && data.PhoneNumber !== null) {
     contents.PhoneNumber = deserializeAws_restJson1PhoneNumber(data.PhoneNumber, context);
   }
@@ -24128,7 +24130,7 @@ export const deserializeAws_restJson1SearchAvailablePhoneNumbersCommand = async 
     E164PhoneNumbers: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.E164PhoneNumbers !== undefined && data.E164PhoneNumbers !== null) {
     contents.E164PhoneNumbers = deserializeAws_restJson1E164PhoneNumberList(data.E164PhoneNumbers, context);
   }
@@ -24235,7 +24237,7 @@ export const deserializeAws_restJson1SendChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -25157,7 +25159,7 @@ export const deserializeAws_restJson1UpdateAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Account: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Account !== undefined && data.Account !== null) {
     contents.Account = deserializeAws_restJson1Account(data.Account, context);
   }
@@ -25367,7 +25369,7 @@ export const deserializeAws_restJson1UpdateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -25470,7 +25472,7 @@ export const deserializeAws_restJson1UpdateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -25573,7 +25575,7 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -25676,7 +25678,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -25780,7 +25782,7 @@ export const deserializeAws_restJson1UpdateChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -25886,7 +25888,7 @@ export const deserializeAws_restJson1UpdateChannelReadMarkerCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -26080,7 +26082,7 @@ export const deserializeAws_restJson1UpdatePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumber: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumber !== undefined && data.PhoneNumber !== null) {
     contents.PhoneNumber = deserializeAws_restJson1PhoneNumber(data.PhoneNumber, context);
   }
@@ -26274,7 +26276,7 @@ export const deserializeAws_restJson1UpdateProxySessionCommand = async (
     $metadata: deserializeMetadata(output),
     ProxySession: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProxySession !== undefined && data.ProxySession !== null) {
     contents.ProxySession = deserializeAws_restJson1ProxySession(data.ProxySession, context);
   }
@@ -26377,7 +26379,7 @@ export const deserializeAws_restJson1UpdateRoomCommand = async (
     $metadata: deserializeMetadata(output),
     Room: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Room !== undefined && data.Room !== null) {
     contents.Room = deserializeAws_restJson1Room(data.Room, context);
   }
@@ -26480,7 +26482,7 @@ export const deserializeAws_restJson1UpdateRoomMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     RoomMembership: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoomMembership !== undefined && data.RoomMembership !== null) {
     contents.RoomMembership = deserializeAws_restJson1RoomMembership(data.RoomMembership, context);
   }
@@ -26583,7 +26585,7 @@ export const deserializeAws_restJson1UpdateSipMediaApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     SipMediaApplication: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplication !== undefined && data.SipMediaApplication !== null) {
     contents.SipMediaApplication = deserializeAws_restJson1SipMediaApplication(data.SipMediaApplication, context);
   }
@@ -26694,7 +26696,7 @@ export const deserializeAws_restJson1UpdateSipMediaApplicationCallCommand = asyn
     $metadata: deserializeMetadata(output),
     SipMediaApplicationCall: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplicationCall !== undefined && data.SipMediaApplicationCall !== null) {
     contents.SipMediaApplicationCall = deserializeAws_restJson1SipMediaApplicationCall(
       data.SipMediaApplicationCall,
@@ -26808,7 +26810,7 @@ export const deserializeAws_restJson1UpdateSipRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SipRule: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipRule !== undefined && data.SipRule !== null) {
     contents.SipRule = deserializeAws_restJson1SipRule(data.SipRule, context);
   }
@@ -26927,7 +26929,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -27129,7 +27131,7 @@ export const deserializeAws_restJson1UpdateVoiceConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnector: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnector !== undefined && data.VoiceConnector !== null) {
     contents.VoiceConnector = deserializeAws_restJson1VoiceConnector(data.VoiceConnector, context);
   }
@@ -27232,7 +27234,7 @@ export const deserializeAws_restJson1UpdateVoiceConnectorGroupCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnectorGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnectorGroup !== undefined && data.VoiceConnectorGroup !== null) {
     contents.VoiceConnectorGroup = deserializeAws_restJson1VoiceConnectorGroup(data.VoiceConnectorGroup, context);
   }

--- a/clients/client-clouddirectory/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1.ts
@@ -278,6 +278,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2437,7 +2439,7 @@ export const deserializeAws_restJson1ApplySchemaCommand = async (
     AppliedSchemaArn: undefined,
     DirectoryArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
     contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
@@ -2559,7 +2561,7 @@ export const deserializeAws_restJson1AttachObjectCommand = async (
     $metadata: deserializeMetadata(output),
     AttachedObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachedObjectIdentifier !== undefined && data.AttachedObjectIdentifier !== null) {
     contents.AttachedObjectIdentifier = __expectString(data.AttachedObjectIdentifier);
   }
@@ -2809,7 +2811,7 @@ export const deserializeAws_restJson1AttachToIndexCommand = async (
     $metadata: deserializeMetadata(output),
     AttachedObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachedObjectIdentifier !== undefined && data.AttachedObjectIdentifier !== null) {
     contents.AttachedObjectIdentifier = __expectString(data.AttachedObjectIdentifier);
   }
@@ -2952,7 +2954,7 @@ export const deserializeAws_restJson1AttachTypedLinkCommand = async (
     $metadata: deserializeMetadata(output),
     TypedLinkSpecifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TypedLinkSpecifier !== undefined && data.TypedLinkSpecifier !== null) {
     contents.TypedLinkSpecifier = deserializeAws_restJson1TypedLinkSpecifier(data.TypedLinkSpecifier, context);
   }
@@ -3079,7 +3081,7 @@ export const deserializeAws_restJson1BatchReadCommand = async (
     $metadata: deserializeMetadata(output),
     Responses: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Responses !== undefined && data.Responses !== null) {
     contents.Responses = deserializeAws_restJson1BatchReadOperationResponseList(data.Responses, context);
   }
@@ -3182,7 +3184,7 @@ export const deserializeAws_restJson1BatchWriteCommand = async (
     $metadata: deserializeMetadata(output),
     Responses: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Responses !== undefined && data.Responses !== null) {
     contents.Responses = deserializeAws_restJson1BatchWriteOperationResponseList(data.Responses, context);
   }
@@ -3296,7 +3298,7 @@ export const deserializeAws_restJson1CreateDirectoryCommand = async (
     Name: undefined,
     ObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
     contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
@@ -3539,7 +3541,7 @@ export const deserializeAws_restJson1CreateIndexCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -3674,7 +3676,7 @@ export const deserializeAws_restJson1CreateObjectCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -3809,7 +3811,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     SchemaArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
   }
@@ -4035,7 +4037,7 @@ export const deserializeAws_restJson1DeleteDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     DirectoryArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -4384,7 +4386,7 @@ export const deserializeAws_restJson1DeleteSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     SchemaArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
   }
@@ -4602,7 +4604,7 @@ export const deserializeAws_restJson1DetachFromIndexCommand = async (
     $metadata: deserializeMetadata(output),
     DetachedObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DetachedObjectIdentifier !== undefined && data.DetachedObjectIdentifier !== null) {
     contents.DetachedObjectIdentifier = __expectString(data.DetachedObjectIdentifier);
   }
@@ -4729,7 +4731,7 @@ export const deserializeAws_restJson1DetachObjectCommand = async (
     $metadata: deserializeMetadata(output),
     DetachedObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DetachedObjectIdentifier !== undefined && data.DetachedObjectIdentifier !== null) {
     contents.DetachedObjectIdentifier = __expectString(data.DetachedObjectIdentifier);
   }
@@ -5078,7 +5080,7 @@ export const deserializeAws_restJson1DisableDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     DirectoryArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -5189,7 +5191,7 @@ export const deserializeAws_restJson1EnableDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     DirectoryArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -5300,7 +5302,7 @@ export const deserializeAws_restJson1GetAppliedSchemaVersionCommand = async (
     $metadata: deserializeMetadata(output),
     AppliedSchemaArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
     contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
@@ -5403,7 +5405,7 @@ export const deserializeAws_restJson1GetDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     Directory: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Directory !== undefined && data.Directory !== null) {
     contents.Directory = deserializeAws_restJson1Directory(data.Directory, context);
   }
@@ -5498,7 +5500,7 @@ export const deserializeAws_restJson1GetFacetCommand = async (
     $metadata: deserializeMetadata(output),
     Facet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Facet !== undefined && data.Facet !== null) {
     contents.Facet = deserializeAws_restJson1Facet(data.Facet, context);
   }
@@ -5609,7 +5611,7 @@ export const deserializeAws_restJson1GetLinkAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     Attributes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributeKeyAndValueList(data.Attributes, context);
   }
@@ -5728,7 +5730,7 @@ export const deserializeAws_restJson1GetObjectAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     Attributes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributeKeyAndValueList(data.Attributes, context);
   }
@@ -5848,7 +5850,7 @@ export const deserializeAws_restJson1GetObjectInformationCommand = async (
     ObjectIdentifier: undefined,
     SchemaFacets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -5963,7 +5965,7 @@ export const deserializeAws_restJson1GetSchemaAsJsonCommand = async (
     Document: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Document !== undefined && data.Document !== null) {
     contents.Document = __expectString(data.Document);
   }
@@ -6069,7 +6071,7 @@ export const deserializeAws_restJson1GetTypedLinkFacetInformationCommand = async
     $metadata: deserializeMetadata(output),
     IdentityAttributeOrder: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityAttributeOrder !== undefined && data.IdentityAttributeOrder !== null) {
     contents.IdentityAttributeOrder = deserializeAws_restJson1AttributeNameList(data.IdentityAttributeOrder, context);
   }
@@ -6189,7 +6191,7 @@ export const deserializeAws_restJson1ListAppliedSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6304,7 +6306,7 @@ export const deserializeAws_restJson1ListAttachedIndicesCommand = async (
     IndexAttachments: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IndexAttachments !== undefined && data.IndexAttachments !== null) {
     contents.IndexAttachments = deserializeAws_restJson1IndexAttachmentList(data.IndexAttachments, context);
   }
@@ -6419,7 +6421,7 @@ export const deserializeAws_restJson1ListDevelopmentSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6534,7 +6536,7 @@ export const deserializeAws_restJson1ListDirectoriesCommand = async (
     Directories: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Directories !== undefined && data.Directories !== null) {
     contents.Directories = deserializeAws_restJson1DirectoryList(data.Directories, context);
   }
@@ -6641,7 +6643,7 @@ export const deserializeAws_restJson1ListFacetAttributesCommand = async (
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1FacetAttributeList(data.Attributes, context);
   }
@@ -6764,7 +6766,7 @@ export const deserializeAws_restJson1ListFacetNamesCommand = async (
     FacetNames: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FacetNames !== undefined && data.FacetNames !== null) {
     contents.FacetNames = deserializeAws_restJson1FacetNameList(data.FacetNames, context);
   }
@@ -6879,7 +6881,7 @@ export const deserializeAws_restJson1ListIncomingTypedLinksCommand = async (
     LinkSpecifiers: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkSpecifiers !== undefined && data.LinkSpecifiers !== null) {
     contents.LinkSpecifiers = deserializeAws_restJson1TypedLinkSpecifierList(data.LinkSpecifiers, context);
   }
@@ -7010,7 +7012,7 @@ export const deserializeAws_restJson1ListIndexCommand = async (
     IndexAttachments: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IndexAttachments !== undefined && data.IndexAttachments !== null) {
     contents.IndexAttachments = deserializeAws_restJson1IndexAttachmentList(data.IndexAttachments, context);
   }
@@ -7149,7 +7151,7 @@ export const deserializeAws_restJson1ListManagedSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7248,7 +7250,7 @@ export const deserializeAws_restJson1ListObjectAttributesCommand = async (
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributeKeyAndValueList(data.Attributes, context);
   }
@@ -7379,7 +7381,7 @@ export const deserializeAws_restJson1ListObjectChildrenCommand = async (
     Children: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Children !== undefined && data.Children !== null) {
     contents.Children = deserializeAws_restJson1LinkNameToObjectIdentifierMap(data.Children, context);
   }
@@ -7510,7 +7512,7 @@ export const deserializeAws_restJson1ListObjectParentPathsCommand = async (
     NextToken: undefined,
     PathToObjectIdentifiersList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7637,7 +7639,7 @@ export const deserializeAws_restJson1ListObjectParentsCommand = async (
     ParentLinks: undefined,
     Parents: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7771,7 +7773,7 @@ export const deserializeAws_restJson1ListObjectPoliciesCommand = async (
     AttachedPolicyIds: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachedPolicyIds !== undefined && data.AttachedPolicyIds !== null) {
     contents.AttachedPolicyIds = deserializeAws_restJson1ObjectIdentifierList(data.AttachedPolicyIds, context);
   }
@@ -7894,7 +7896,7 @@ export const deserializeAws_restJson1ListOutgoingTypedLinksCommand = async (
     NextToken: undefined,
     TypedLinkSpecifiers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8025,7 +8027,7 @@ export const deserializeAws_restJson1ListPolicyAttachmentsCommand = async (
     NextToken: undefined,
     ObjectIdentifiers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8156,7 +8158,7 @@ export const deserializeAws_restJson1ListPublishedSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8271,7 +8273,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8386,7 +8388,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetAttributesCommand = async
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1TypedLinkAttributeDefinitionList(data.Attributes, context);
   }
@@ -8509,7 +8511,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetNamesCommand = async (
     FacetNames: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FacetNames !== undefined && data.FacetNames !== null) {
     contents.FacetNames = deserializeAws_restJson1TypedLinkNameList(data.FacetNames, context);
   }
@@ -8624,7 +8626,7 @@ export const deserializeAws_restJson1LookupPolicyCommand = async (
     NextToken: undefined,
     PolicyToPathList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8746,7 +8748,7 @@ export const deserializeAws_restJson1PublishSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     PublishedSchemaArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PublishedSchemaArn !== undefined && data.PublishedSchemaArn !== null) {
     contents.PublishedSchemaArn = __expectString(data.PublishedSchemaArn);
   }
@@ -8857,7 +8859,7 @@ export const deserializeAws_restJson1PutSchemaFromJsonCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -9543,7 +9545,7 @@ export const deserializeAws_restJson1UpdateObjectAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectIdentifier: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -9670,7 +9672,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     SchemaArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
   }
@@ -9905,7 +9907,7 @@ export const deserializeAws_restJson1UpgradeAppliedSchemaCommand = async (
     DirectoryArn: undefined,
     UpgradedSchemaArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -10027,7 +10029,7 @@ export const deserializeAws_restJson1UpgradePublishedSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     UpgradedSchemaArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UpgradedSchemaArn !== undefined && data.UpgradedSchemaArn !== null) {
     contents.UpgradedSchemaArn = __expectString(data.UpgradedSchemaArn);
   }

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -481,6 +481,8 @@ import {
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
@@ -3433,7 +3435,7 @@ export const deserializeAws_restXmlCreateCachePolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicy = deserializeAws_restXmlCachePolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -3550,7 +3552,7 @@ export const deserializeAws_restXmlCreateCloudFrontOriginAccessIdentityCommand =
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentity = deserializeAws_restXmlCloudFrontOriginAccessIdentity(data, context);
   return Promise.resolve(contents);
 };
@@ -3643,7 +3645,7 @@ export const deserializeAws_restXmlCreateDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -4161,7 +4163,7 @@ export const deserializeAws_restXmlCreateDistributionWithTagsCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -4687,7 +4689,7 @@ export const deserializeAws_restXmlCreateFieldLevelEncryptionConfigCommand = asy
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryption = deserializeAws_restXmlFieldLevelEncryption(data, context);
   return Promise.resolve(contents);
 };
@@ -4804,7 +4806,7 @@ export const deserializeAws_restXmlCreateFieldLevelEncryptionProfileCommand = as
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfile = deserializeAws_restXmlFieldLevelEncryptionProfile(data, context);
   return Promise.resolve(contents);
 };
@@ -4921,7 +4923,7 @@ export const deserializeAws_restXmlCreateFunctionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -5010,7 +5012,7 @@ export const deserializeAws_restXmlCreateInvalidationCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Invalidation = deserializeAws_restXmlInvalidation(data, context);
   return Promise.resolve(contents);
 };
@@ -5119,7 +5121,7 @@ export const deserializeAws_restXmlCreateKeyGroupCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroup = deserializeAws_restXmlKeyGroup(data, context);
   return Promise.resolve(contents);
 };
@@ -5196,7 +5198,7 @@ export const deserializeAws_restXmlCreateMonitoringSubscriptionCommand = async (
     $metadata: deserializeMetadata(output),
     MonitoringSubscription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MonitoringSubscription = deserializeAws_restXmlMonitoringSubscription(data, context);
   return Promise.resolve(contents);
 };
@@ -5273,7 +5275,7 @@ export const deserializeAws_restXmlCreateOriginRequestPolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicy = deserializeAws_restXmlOriginRequestPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -5390,7 +5392,7 @@ export const deserializeAws_restXmlCreatePublicKeyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKey = deserializeAws_restXmlPublicKey(data, context);
   return Promise.resolve(contents);
 };
@@ -5459,7 +5461,7 @@ export const deserializeAws_restXmlCreateRealtimeLogConfigCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RealtimeLogConfig"] !== undefined) {
     contents.RealtimeLogConfig = deserializeAws_restXmlRealtimeLogConfig(data["RealtimeLogConfig"], context);
   }
@@ -5546,7 +5548,7 @@ export const deserializeAws_restXmlCreateStreamingDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -5695,7 +5697,7 @@ export const deserializeAws_restXmlCreateStreamingDistributionWithTagsCommand = 
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -6828,7 +6830,7 @@ export const deserializeAws_restXmlDescribeFunctionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -6893,7 +6895,7 @@ export const deserializeAws_restXmlGetCachePolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicy = deserializeAws_restXmlCachePolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -6958,7 +6960,7 @@ export const deserializeAws_restXmlGetCachePolicyConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicyConfig = deserializeAws_restXmlCachePolicyConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7023,7 +7025,7 @@ export const deserializeAws_restXmlGetCloudFrontOriginAccessIdentityCommand = as
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentity = deserializeAws_restXmlCloudFrontOriginAccessIdentity(data, context);
   return Promise.resolve(contents);
 };
@@ -7088,7 +7090,7 @@ export const deserializeAws_restXmlGetCloudFrontOriginAccessIdentityConfigComman
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentityConfig = deserializeAws_restXmlCloudFrontOriginAccessIdentityConfig(
     data,
     context
@@ -7156,7 +7158,7 @@ export const deserializeAws_restXmlGetDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -7221,7 +7223,7 @@ export const deserializeAws_restXmlGetDistributionConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionConfig = deserializeAws_restXmlDistributionConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7286,7 +7288,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryption = deserializeAws_restXmlFieldLevelEncryption(data, context);
   return Promise.resolve(contents);
 };
@@ -7351,7 +7353,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionConfigCommand = async 
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionConfig = deserializeAws_restXmlFieldLevelEncryptionConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7416,7 +7418,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionProfileCommand = async
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfile = deserializeAws_restXmlFieldLevelEncryptionProfile(data, context);
   return Promise.resolve(contents);
 };
@@ -7481,7 +7483,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionProfileConfigCommand =
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfileConfig = deserializeAws_restXmlFieldLevelEncryptionProfileConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7611,7 +7613,7 @@ export const deserializeAws_restXmlGetInvalidationCommand = async (
     $metadata: deserializeMetadata(output),
     Invalidation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Invalidation = deserializeAws_restXmlInvalidation(data, context);
   return Promise.resolve(contents);
 };
@@ -7684,7 +7686,7 @@ export const deserializeAws_restXmlGetKeyGroupCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroup = deserializeAws_restXmlKeyGroup(data, context);
   return Promise.resolve(contents);
 };
@@ -7741,7 +7743,7 @@ export const deserializeAws_restXmlGetKeyGroupConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroupConfig = deserializeAws_restXmlKeyGroupConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7794,7 +7796,7 @@ export const deserializeAws_restXmlGetMonitoringSubscriptionCommand = async (
     $metadata: deserializeMetadata(output),
     MonitoringSubscription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MonitoringSubscription = deserializeAws_restXmlMonitoringSubscription(data, context);
   return Promise.resolve(contents);
 };
@@ -7867,7 +7869,7 @@ export const deserializeAws_restXmlGetOriginRequestPolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicy = deserializeAws_restXmlOriginRequestPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -7932,7 +7934,7 @@ export const deserializeAws_restXmlGetOriginRequestPolicyConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicyConfig = deserializeAws_restXmlOriginRequestPolicyConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7997,7 +7999,7 @@ export const deserializeAws_restXmlGetPublicKeyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKey = deserializeAws_restXmlPublicKey(data, context);
   return Promise.resolve(contents);
 };
@@ -8062,7 +8064,7 @@ export const deserializeAws_restXmlGetPublicKeyConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKeyConfig = deserializeAws_restXmlPublicKeyConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -8123,7 +8125,7 @@ export const deserializeAws_restXmlGetRealtimeLogConfigCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RealtimeLogConfig"] !== undefined) {
     contents.RealtimeLogConfig = deserializeAws_restXmlRealtimeLogConfig(data["RealtimeLogConfig"], context);
   }
@@ -8198,7 +8200,7 @@ export const deserializeAws_restXmlGetStreamingDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -8263,7 +8265,7 @@ export const deserializeAws_restXmlGetStreamingDistributionConfigCommand = async
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistributionConfig = deserializeAws_restXmlStreamingDistributionConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -8324,7 +8326,7 @@ export const deserializeAws_restXmlListCachePoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     CachePolicyList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicyList = deserializeAws_restXmlCachePolicyList(data, context);
   return Promise.resolve(contents);
 };
@@ -8393,7 +8395,7 @@ export const deserializeAws_restXmlListCloudFrontOriginAccessIdentitiesCommand =
     $metadata: deserializeMetadata(output),
     CloudFrontOriginAccessIdentityList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentityList = deserializeAws_restXmlCloudFrontOriginAccessIdentityList(data, context);
   return Promise.resolve(contents);
 };
@@ -8446,7 +8448,7 @@ export const deserializeAws_restXmlListConflictingAliasesCommand = async (
     $metadata: deserializeMetadata(output),
     ConflictingAliasesList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ConflictingAliasesList = deserializeAws_restXmlConflictingAliasesList(data, context);
   return Promise.resolve(contents);
 };
@@ -8507,7 +8509,7 @@ export const deserializeAws_restXmlListDistributionsCommand = async (
     $metadata: deserializeMetadata(output),
     DistributionList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionList = deserializeAws_restXmlDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8560,7 +8562,7 @@ export const deserializeAws_restXmlListDistributionsByCachePolicyIdCommand = asy
     $metadata: deserializeMetadata(output),
     DistributionIdList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionIdList = deserializeAws_restXmlDistributionIdList(data, context);
   return Promise.resolve(contents);
 };
@@ -8629,7 +8631,7 @@ export const deserializeAws_restXmlListDistributionsByKeyGroupCommand = async (
     $metadata: deserializeMetadata(output),
     DistributionIdList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionIdList = deserializeAws_restXmlDistributionIdList(data, context);
   return Promise.resolve(contents);
 };
@@ -8690,7 +8692,7 @@ export const deserializeAws_restXmlListDistributionsByOriginRequestPolicyIdComma
     $metadata: deserializeMetadata(output),
     DistributionIdList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionIdList = deserializeAws_restXmlDistributionIdList(data, context);
   return Promise.resolve(contents);
 };
@@ -8759,7 +8761,7 @@ export const deserializeAws_restXmlListDistributionsByRealtimeLogConfigCommand =
     $metadata: deserializeMetadata(output),
     DistributionList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionList = deserializeAws_restXmlDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8812,7 +8814,7 @@ export const deserializeAws_restXmlListDistributionsByWebACLIdCommand = async (
     $metadata: deserializeMetadata(output),
     DistributionList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionList = deserializeAws_restXmlDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8873,7 +8875,7 @@ export const deserializeAws_restXmlListFieldLevelEncryptionConfigsCommand = asyn
     $metadata: deserializeMetadata(output),
     FieldLevelEncryptionList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionList = deserializeAws_restXmlFieldLevelEncryptionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8926,7 +8928,7 @@ export const deserializeAws_restXmlListFieldLevelEncryptionProfilesCommand = asy
     $metadata: deserializeMetadata(output),
     FieldLevelEncryptionProfileList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfileList = deserializeAws_restXmlFieldLevelEncryptionProfileList(data, context);
   return Promise.resolve(contents);
 };
@@ -8979,7 +8981,7 @@ export const deserializeAws_restXmlListFunctionsCommand = async (
     $metadata: deserializeMetadata(output),
     FunctionList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionList = deserializeAws_restXmlFunctionList(data, context);
   return Promise.resolve(contents);
 };
@@ -9040,7 +9042,7 @@ export const deserializeAws_restXmlListInvalidationsCommand = async (
     $metadata: deserializeMetadata(output),
     InvalidationList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.InvalidationList = deserializeAws_restXmlInvalidationList(data, context);
   return Promise.resolve(contents);
 };
@@ -9109,7 +9111,7 @@ export const deserializeAws_restXmlListKeyGroupsCommand = async (
     $metadata: deserializeMetadata(output),
     KeyGroupList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroupList = deserializeAws_restXmlKeyGroupList(data, context);
   return Promise.resolve(contents);
 };
@@ -9162,7 +9164,7 @@ export const deserializeAws_restXmlListOriginRequestPoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     OriginRequestPolicyList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicyList = deserializeAws_restXmlOriginRequestPolicyList(data, context);
   return Promise.resolve(contents);
 };
@@ -9231,7 +9233,7 @@ export const deserializeAws_restXmlListPublicKeysCommand = async (
     $metadata: deserializeMetadata(output),
     PublicKeyList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKeyList = deserializeAws_restXmlPublicKeyList(data, context);
   return Promise.resolve(contents);
 };
@@ -9284,7 +9286,7 @@ export const deserializeAws_restXmlListRealtimeLogConfigsCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfigs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.RealtimeLogConfigs = deserializeAws_restXmlRealtimeLogConfigs(data, context);
   return Promise.resolve(contents);
 };
@@ -9353,7 +9355,7 @@ export const deserializeAws_restXmlListStreamingDistributionsCommand = async (
     $metadata: deserializeMetadata(output),
     StreamingDistributionList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistributionList = deserializeAws_restXmlStreamingDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -9406,7 +9408,7 @@ export const deserializeAws_restXmlListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Tags = deserializeAws_restXmlTags(data, context);
   return Promise.resolve(contents);
 };
@@ -9483,7 +9485,7 @@ export const deserializeAws_restXmlPublishFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     FunctionSummary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -9643,7 +9645,7 @@ export const deserializeAws_restXmlTestFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     TestResult: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.TestResult = deserializeAws_restXmlTestResult(data, context);
   return Promise.resolve(contents);
 };
@@ -9807,7 +9809,7 @@ export const deserializeAws_restXmlUpdateCachePolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicy = deserializeAws_restXmlCachePolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -9944,7 +9946,7 @@ export const deserializeAws_restXmlUpdateCloudFrontOriginAccessIdentityCommand =
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentity = deserializeAws_restXmlCloudFrontOriginAccessIdentity(data, context);
   return Promise.resolve(contents);
 };
@@ -10057,7 +10059,7 @@ export const deserializeAws_restXmlUpdateDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -10571,7 +10573,7 @@ export const deserializeAws_restXmlUpdateFieldLevelEncryptionConfigCommand = asy
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryption = deserializeAws_restXmlFieldLevelEncryption(data, context);
   return Promise.resolve(contents);
 };
@@ -10708,7 +10710,7 @@ export const deserializeAws_restXmlUpdateFieldLevelEncryptionProfileCommand = as
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfile = deserializeAws_restXmlFieldLevelEncryptionProfile(data, context);
   return Promise.resolve(contents);
 };
@@ -10853,7 +10855,7 @@ export const deserializeAws_restXmlUpdateFunctionCommand = async (
   if (output.headers["ettag"] !== undefined) {
     contents.ETag = output.headers["ettag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -10950,7 +10952,7 @@ export const deserializeAws_restXmlUpdateKeyGroupCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroup = deserializeAws_restXmlKeyGroup(data, context);
   return Promise.resolve(contents);
 };
@@ -11047,7 +11049,7 @@ export const deserializeAws_restXmlUpdateOriginRequestPolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicy = deserializeAws_restXmlOriginRequestPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -11184,7 +11186,7 @@ export const deserializeAws_restXmlUpdatePublicKeyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKey = deserializeAws_restXmlPublicKey(data, context);
   return Promise.resolve(contents);
 };
@@ -11285,7 +11287,7 @@ export const deserializeAws_restXmlUpdateRealtimeLogConfigCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RealtimeLogConfig"] !== undefined) {
     contents.RealtimeLogConfig = deserializeAws_restXmlRealtimeLogConfig(data["RealtimeLogConfig"], context);
   }
@@ -11360,7 +11362,7 @@ export const deserializeAws_restXmlUpdateStreamingDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
@@ -18,6 +18,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -139,7 +141,7 @@ export const deserializeAws_restJson1SearchCommand = async (
     stats: undefined,
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.facets !== undefined && data.facets !== null) {
     contents.facets = deserializeAws_restJson1Facets(data.facets, context);
   }
@@ -204,7 +206,7 @@ export const deserializeAws_restJson1SuggestCommand = async (
     status: undefined,
     suggest: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = deserializeAws_restJson1SuggestStatus(data.status, context);
   }
@@ -265,7 +267,7 @@ export const deserializeAws_restJson1UploadDocumentsCommand = async (
     status: undefined,
     warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adds !== undefined && data.adds !== null) {
     contents.adds = __expectLong(data.adds);
   }

--- a/clients/client-codeartifact/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/protocols/Aws_restJson1.ts
@@ -129,6 +129,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseInt32 as __strictParseInt32,
@@ -1162,7 +1164,7 @@ export const deserializeAws_restJson1AssociateExternalConnectionCommand = async 
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1266,7 +1268,7 @@ export const deserializeAws_restJson1CopyPackageVersionsCommand = async (
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -1375,7 +1377,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
     $metadata: deserializeMetadata(output),
     domain: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domain !== undefined && data.domain !== null) {
     contents.domain = deserializeAws_restJson1DomainDescription(data.domain, context);
   }
@@ -1478,7 +1480,7 @@ export const deserializeAws_restJson1CreateRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1581,7 +1583,7 @@ export const deserializeAws_restJson1DeleteDomainCommand = async (
     $metadata: deserializeMetadata(output),
     domain: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domain !== undefined && data.domain !== null) {
     contents.domain = deserializeAws_restJson1DomainDescription(data.domain, context);
   }
@@ -1668,7 +1670,7 @@ export const deserializeAws_restJson1DeleteDomainPermissionsPolicyCommand = asyn
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -1764,7 +1766,7 @@ export const deserializeAws_restJson1DeletePackageVersionsCommand = async (
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -1865,7 +1867,7 @@ export const deserializeAws_restJson1DeleteRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1960,7 +1962,7 @@ export const deserializeAws_restJson1DeleteRepositoryPermissionsPolicyCommand = 
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -2055,7 +2057,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
     $metadata: deserializeMetadata(output),
     domain: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domain !== undefined && data.domain !== null) {
     contents.domain = deserializeAws_restJson1DomainDescription(data.domain, context);
   }
@@ -2142,7 +2144,7 @@ export const deserializeAws_restJson1DescribePackageVersionCommand = async (
     $metadata: deserializeMetadata(output),
     packageVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.packageVersion !== undefined && data.packageVersion !== null) {
     contents.packageVersion = deserializeAws_restJson1PackageVersionDescription(data.packageVersion, context);
   }
@@ -2237,7 +2239,7 @@ export const deserializeAws_restJson1DescribeRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -2324,7 +2326,7 @@ export const deserializeAws_restJson1DisassociateExternalConnectionCommand = asy
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -2428,7 +2430,7 @@ export const deserializeAws_restJson1DisposePackageVersionsCommand = async (
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -2530,7 +2532,7 @@ export const deserializeAws_restJson1GetAuthorizationTokenCommand = async (
     authorizationToken: undefined,
     expiration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizationToken !== undefined && data.authorizationToken !== null) {
     contents.authorizationToken = __expectString(data.authorizationToken);
   }
@@ -2620,7 +2622,7 @@ export const deserializeAws_restJson1GetDomainPermissionsPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -2817,7 +2819,7 @@ export const deserializeAws_restJson1GetPackageVersionReadmeCommand = async (
     version: undefined,
     versionRevision: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.format !== undefined && data.format !== null) {
     contents.format = __expectString(data.format);
   }
@@ -2919,7 +2921,7 @@ export const deserializeAws_restJson1GetRepositoryEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     repositoryEndpoint: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repositoryEndpoint !== undefined && data.repositoryEndpoint !== null) {
     contents.repositoryEndpoint = __expectString(data.repositoryEndpoint);
   }
@@ -3006,7 +3008,7 @@ export const deserializeAws_restJson1GetRepositoryPermissionsPolicyCommand = asy
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -3094,7 +3096,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     domains: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domains !== undefined && data.domains !== null) {
     contents.domains = deserializeAws_restJson1DomainSummaryList(data.domains, context);
   }
@@ -3177,7 +3179,7 @@ export const deserializeAws_restJson1ListPackagesCommand = async (
     nextToken: undefined,
     packages: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3273,7 +3275,7 @@ export const deserializeAws_restJson1ListPackageVersionAssetsCommand = async (
     version: undefined,
     versionRevision: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assets !== undefined && data.assets !== null) {
     contents.assets = deserializeAws_restJson1AssetSummaryList(data.assets, context);
   }
@@ -3384,7 +3386,7 @@ export const deserializeAws_restJson1ListPackageVersionDependenciesCommand = asy
     version: undefined,
     versionRevision: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dependencies !== undefined && data.dependencies !== null) {
     contents.dependencies = deserializeAws_restJson1PackageDependencyList(data.dependencies, context);
   }
@@ -3494,7 +3496,7 @@ export const deserializeAws_restJson1ListPackageVersionsCommand = async (
     package: undefined,
     versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultDisplayVersion !== undefined && data.defaultDisplayVersion !== null) {
     contents.defaultDisplayVersion = __expectString(data.defaultDisplayVersion);
   }
@@ -3597,7 +3599,7 @@ export const deserializeAws_restJson1ListRepositoriesCommand = async (
     nextToken: undefined,
     repositories: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3680,7 +3682,7 @@ export const deserializeAws_restJson1ListRepositoriesInDomainCommand = async (
     nextToken: undefined,
     repositories: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3770,7 +3772,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
@@ -3849,7 +3851,7 @@ export const deserializeAws_restJson1PutDomainPermissionsPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -3952,7 +3954,7 @@ export const deserializeAws_restJson1PutRepositoryPermissionsPolicyCommand = asy
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -4214,7 +4216,7 @@ export const deserializeAws_restJson1UpdatePackageVersionsStatusCommand = async 
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -4315,7 +4317,7 @@ export const deserializeAws_restJson1UpdateRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
@@ -79,6 +79,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -541,7 +543,7 @@ export const deserializeAws_restJson1AssociateRepositoryCommand = async (
     RepositoryAssociation: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RepositoryAssociation !== undefined && data.RepositoryAssociation !== null) {
     contents.RepositoryAssociation = deserializeAws_restJson1RepositoryAssociation(data.RepositoryAssociation, context);
   }
@@ -631,7 +633,7 @@ export const deserializeAws_restJson1CreateCodeReviewCommand = async (
     $metadata: deserializeMetadata(output),
     CodeReview: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeReview !== undefined && data.CodeReview !== null) {
     contents.CodeReview = deserializeAws_restJson1CodeReview(data.CodeReview, context);
   }
@@ -726,7 +728,7 @@ export const deserializeAws_restJson1DescribeCodeReviewCommand = async (
     $metadata: deserializeMetadata(output),
     CodeReview: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeReview !== undefined && data.CodeReview !== null) {
     contents.CodeReview = deserializeAws_restJson1CodeReview(data.CodeReview, context);
   }
@@ -813,7 +815,7 @@ export const deserializeAws_restJson1DescribeRecommendationFeedbackCommand = asy
     $metadata: deserializeMetadata(output),
     RecommendationFeedback: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RecommendationFeedback !== undefined && data.RecommendationFeedback !== null) {
     contents.RecommendationFeedback = deserializeAws_restJson1RecommendationFeedback(
       data.RecommendationFeedback,
@@ -904,7 +906,7 @@ export const deserializeAws_restJson1DescribeRepositoryAssociationCommand = asyn
     RepositoryAssociation: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RepositoryAssociation !== undefined && data.RepositoryAssociation !== null) {
     contents.RepositoryAssociation = deserializeAws_restJson1RepositoryAssociation(data.RepositoryAssociation, context);
   }
@@ -995,7 +997,7 @@ export const deserializeAws_restJson1DisassociateRepositoryCommand = async (
     RepositoryAssociation: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RepositoryAssociation !== undefined && data.RepositoryAssociation !== null) {
     contents.RepositoryAssociation = deserializeAws_restJson1RepositoryAssociation(data.RepositoryAssociation, context);
   }
@@ -1094,7 +1096,7 @@ export const deserializeAws_restJson1ListCodeReviewsCommand = async (
     CodeReviewSummaries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeReviewSummaries !== undefined && data.CodeReviewSummaries !== null) {
     contents.CodeReviewSummaries = deserializeAws_restJson1CodeReviewSummaries(data.CodeReviewSummaries, context);
   }
@@ -1177,7 +1179,7 @@ export const deserializeAws_restJson1ListRecommendationFeedbackCommand = async (
     NextToken: undefined,
     RecommendationFeedbackSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1271,7 +1273,7 @@ export const deserializeAws_restJson1ListRecommendationsCommand = async (
     NextToken: undefined,
     RecommendationSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1365,7 +1367,7 @@ export const deserializeAws_restJson1ListRepositoryAssociationsCommand = async (
     NextToken: undefined,
     RepositoryAssociationSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1442,7 +1444,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -91,6 +91,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -940,7 +942,7 @@ export const deserializeAws_restJson1AddNotificationChannelsCommand = async (
     $metadata: deserializeMetadata(output),
     notificationConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.notificationConfiguration !== undefined && data.notificationConfiguration !== null) {
     contents.notificationConfiguration = deserializeAws_restJson1NotificationConfiguration(
       data.notificationConfiguration,
@@ -1043,7 +1045,7 @@ export const deserializeAws_restJson1BatchGetFrameMetricDataCommand = async (
     startTime: undefined,
     unprocessedEndTimes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endTime !== undefined && data.endTime !== null) {
     contents.endTime = new Date(data.endTime);
   }
@@ -1137,7 +1139,7 @@ export const deserializeAws_restJson1ConfigureAgentCommand = async (
     $metadata: deserializeMetadata(output),
     configuration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.configuration = deserializeAws_restJson1AgentConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -1214,7 +1216,7 @@ export const deserializeAws_restJson1CreateProfilingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     profilingGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.profilingGroup = deserializeAws_restJson1ProfilingGroupDescription(data, context);
   return Promise.resolve(contents);
 };
@@ -1382,7 +1384,7 @@ export const deserializeAws_restJson1DescribeProfilingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     profilingGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.profilingGroup = deserializeAws_restJson1ProfilingGroupDescription(data, context);
   return Promise.resolve(contents);
 };
@@ -1460,7 +1462,7 @@ export const deserializeAws_restJson1GetFindingsReportAccountSummaryCommand = as
     nextToken: undefined,
     reportSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1534,7 +1536,7 @@ export const deserializeAws_restJson1GetNotificationConfigurationCommand = async
     $metadata: deserializeMetadata(output),
     notificationConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.notificationConfiguration !== undefined && data.notificationConfiguration !== null) {
     contents.notificationConfiguration = deserializeAws_restJson1NotificationConfiguration(
       data.notificationConfiguration,
@@ -1617,7 +1619,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     policy: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -1780,7 +1782,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     profilingGroupName: undefined,
     recommendations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.anomalies !== undefined && data.anomalies !== null) {
     contents.anomalies = deserializeAws_restJson1Anomalies(data.anomalies, context);
   }
@@ -1872,7 +1874,7 @@ export const deserializeAws_restJson1ListFindingsReportsCommand = async (
     findingsReportSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingsReportSummaries !== undefined && data.findingsReportSummaries !== null) {
     contents.findingsReportSummaries = deserializeAws_restJson1FindingsReportSummaries(
       data.findingsReportSummaries,
@@ -1958,7 +1960,7 @@ export const deserializeAws_restJson1ListProfileTimesCommand = async (
     nextToken: undefined,
     profileTimes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2042,7 +2044,7 @@ export const deserializeAws_restJson1ListProfilingGroupsCommand = async (
     profilingGroupNames: undefined,
     profilingGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2111,7 +2113,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2258,7 +2260,7 @@ export const deserializeAws_restJson1PutPermissionCommand = async (
     policy: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -2348,7 +2350,7 @@ export const deserializeAws_restJson1RemoveNotificationChannelCommand = async (
     $metadata: deserializeMetadata(output),
     notificationConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.notificationConfiguration !== undefined && data.notificationConfiguration !== null) {
     contents.notificationConfiguration = deserializeAws_restJson1NotificationConfiguration(
       data.notificationConfiguration,
@@ -2431,7 +2433,7 @@ export const deserializeAws_restJson1RemovePermissionCommand = async (
     policy: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -2730,7 +2732,7 @@ export const deserializeAws_restJson1UpdateProfilingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     profilingGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.profilingGroup = deserializeAws_restJson1ProfilingGroupDescription(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
@@ -47,7 +47,11 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -418,7 +422,7 @@ export const deserializeAws_restJson1CreateNotificationRuleCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -513,7 +517,7 @@ export const deserializeAws_restJson1DeleteNotificationRuleCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -645,7 +649,7 @@ export const deserializeAws_restJson1DescribeNotificationRuleCommand = async (
     Tags: undefined,
     Targets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -739,7 +743,7 @@ export const deserializeAws_restJson1ListEventTypesCommand = async (
     EventTypes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventTypes !== undefined && data.EventTypes !== null) {
     contents.EventTypes = deserializeAws_restJson1EventTypeBatch(data.EventTypes, context);
   }
@@ -806,7 +810,7 @@ export const deserializeAws_restJson1ListNotificationRulesCommand = async (
     NextToken: undefined,
     NotificationRules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -872,7 +876,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -936,7 +940,7 @@ export const deserializeAws_restJson1ListTargetsCommand = async (
     NextToken: undefined,
     Targets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1002,7 +1006,7 @@ export const deserializeAws_restJson1SubscribeCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1065,7 +1069,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -1136,7 +1140,7 @@ export const deserializeAws_restJson1UnsubscribeCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-cognito-sync/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1.ts
@@ -63,6 +63,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -785,7 +787,7 @@ export const deserializeAws_restJson1BulkPublishCommand = async (
     $metadata: deserializeMetadata(output),
     IdentityPoolId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityPoolId !== undefined && data.IdentityPoolId !== null) {
     contents.IdentityPoolId = __expectString(data.IdentityPoolId);
   }
@@ -880,7 +882,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Dataset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Dataset !== undefined && data.Dataset !== null) {
     contents.Dataset = deserializeAws_restJson1Dataset(data.Dataset, context);
   }
@@ -975,7 +977,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Dataset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Dataset !== undefined && data.Dataset !== null) {
     contents.Dataset = deserializeAws_restJson1Dataset(data.Dataset, context);
   }
@@ -1062,7 +1064,7 @@ export const deserializeAws_restJson1DescribeIdentityPoolUsageCommand = async (
     $metadata: deserializeMetadata(output),
     IdentityPoolUsage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityPoolUsage !== undefined && data.IdentityPoolUsage !== null) {
     contents.IdentityPoolUsage = deserializeAws_restJson1IdentityPoolUsage(data.IdentityPoolUsage, context);
   }
@@ -1149,7 +1151,7 @@ export const deserializeAws_restJson1DescribeIdentityUsageCommand = async (
     $metadata: deserializeMetadata(output),
     IdentityUsage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityUsage !== undefined && data.IdentityUsage !== null) {
     contents.IdentityUsage = deserializeAws_restJson1IdentityUsage(data.IdentityUsage, context);
   }
@@ -1240,7 +1242,7 @@ export const deserializeAws_restJson1GetBulkPublishDetailsCommand = async (
     FailureMessage: undefined,
     IdentityPoolId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkPublishCompleteTime !== undefined && data.BulkPublishCompleteTime !== null) {
     contents.BulkPublishCompleteTime = new Date(Math.round(data.BulkPublishCompleteTime * 1000));
   }
@@ -1331,7 +1333,7 @@ export const deserializeAws_restJson1GetCognitoEventsCommand = async (
     $metadata: deserializeMetadata(output),
     Events: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Events !== undefined && data.Events !== null) {
     contents.Events = deserializeAws_restJson1Events(data.Events, context);
   }
@@ -1420,7 +1422,7 @@ export const deserializeAws_restJson1GetIdentityPoolConfigurationCommand = async
     IdentityPoolId: undefined,
     PushSync: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CognitoStreams !== undefined && data.CognitoStreams !== null) {
     contents.CognitoStreams = deserializeAws_restJson1CognitoStreams(data.CognitoStreams, context);
   }
@@ -1515,7 +1517,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     Datasets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Count !== undefined && data.Count !== null) {
     contents.Count = __expectInt32(data.Count);
   }
@@ -1603,7 +1605,7 @@ export const deserializeAws_restJson1ListIdentityPoolUsageCommand = async (
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Count !== undefined && data.Count !== null) {
     contents.Count = __expectInt32(data.Count);
   }
@@ -1699,7 +1701,7 @@ export const deserializeAws_restJson1ListRecordsCommand = async (
     Records: undefined,
     SyncSessionToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Count !== undefined && data.Count !== null) {
     contents.Count = __expectInt32(data.Count);
   }
@@ -1802,7 +1804,7 @@ export const deserializeAws_restJson1RegisterDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceId !== undefined && data.DeviceId !== null) {
     contents.DeviceId = __expectString(data.DeviceId);
   }
@@ -1982,7 +1984,7 @@ export const deserializeAws_restJson1SetIdentityPoolConfigurationCommand = async
     IdentityPoolId: undefined,
     PushSync: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CognitoStreams !== undefined && data.CognitoStreams !== null) {
     contents.CognitoStreams = deserializeAws_restJson1CognitoStreams(data.CognitoStreams, context);
   }
@@ -2265,7 +2267,7 @@ export const deserializeAws_restJson1UpdateRecordsCommand = async (
     $metadata: deserializeMetadata(output),
     Records: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Records !== undefined && data.Records !== null) {
     contents.Records = deserializeAws_restJson1RecordList(data.Records, context);
   }

--- a/clients/client-connect-contact-lens/protocols/Aws_restJson1.ts
+++ b/clients/client-connect-contact-lens/protocols/Aws_restJson1.ts
@@ -17,7 +17,12 @@ import {
   Transcript,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -67,7 +72,7 @@ export const deserializeAws_restJson1ListRealtimeContactAnalysisSegmentsCommand 
     NextToken: undefined,
     Segments: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-connect/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1.ts
@@ -407,6 +407,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -4856,7 +4858,7 @@ export const deserializeAws_restJson1AssociateInstanceStorageConfigCommand = asy
     $metadata: deserializeMetadata(output),
     AssociationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociationId !== undefined && data.AssociationId !== null) {
     contents.AssociationId = __expectString(data.AssociationId);
   }
@@ -5323,7 +5325,7 @@ export const deserializeAws_restJson1AssociateSecurityKeyCommand = async (
     $metadata: deserializeMetadata(output),
     AssociationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociationId !== undefined && data.AssociationId !== null) {
     contents.AssociationId = __expectString(data.AssociationId);
   }
@@ -5427,7 +5429,7 @@ export const deserializeAws_restJson1CreateAgentStatusCommand = async (
     AgentStatusARN: undefined,
     AgentStatusId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AgentStatusARN !== undefined && data.AgentStatusARN !== null) {
     contents.AgentStatusARN = __expectString(data.AgentStatusARN);
   }
@@ -5534,7 +5536,7 @@ export const deserializeAws_restJson1CreateContactFlowCommand = async (
     ContactFlowArn: undefined,
     ContactFlowId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlowArn !== undefined && data.ContactFlowArn !== null) {
     contents.ContactFlowArn = __expectString(data.ContactFlowArn);
   }
@@ -5649,7 +5651,7 @@ export const deserializeAws_restJson1CreateHoursOfOperationCommand = async (
     HoursOfOperationArn: undefined,
     HoursOfOperationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HoursOfOperationArn !== undefined && data.HoursOfOperationArn !== null) {
     contents.HoursOfOperationArn = __expectString(data.HoursOfOperationArn);
   }
@@ -5756,7 +5758,7 @@ export const deserializeAws_restJson1CreateInstanceCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5847,7 +5849,7 @@ export const deserializeAws_restJson1CreateIntegrationAssociationCommand = async
     IntegrationAssociationArn: undefined,
     IntegrationAssociationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IntegrationAssociationArn !== undefined && data.IntegrationAssociationArn !== null) {
     contents.IntegrationAssociationArn = __expectString(data.IntegrationAssociationArn);
   }
@@ -5938,7 +5940,7 @@ export const deserializeAws_restJson1CreateQueueCommand = async (
     QueueArn: undefined,
     QueueId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.QueueArn !== undefined && data.QueueArn !== null) {
     contents.QueueArn = __expectString(data.QueueArn);
   }
@@ -6045,7 +6047,7 @@ export const deserializeAws_restJson1CreateQuickConnectCommand = async (
     QuickConnectARN: undefined,
     QuickConnectId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.QuickConnectARN !== undefined && data.QuickConnectARN !== null) {
     contents.QuickConnectARN = __expectString(data.QuickConnectARN);
   }
@@ -6152,7 +6154,7 @@ export const deserializeAws_restJson1CreateRoutingProfileCommand = async (
     RoutingProfileArn: undefined,
     RoutingProfileId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingProfileArn !== undefined && data.RoutingProfileArn !== null) {
     contents.RoutingProfileArn = __expectString(data.RoutingProfileArn);
   }
@@ -6259,7 +6261,7 @@ export const deserializeAws_restJson1CreateUseCaseCommand = async (
     UseCaseArn: undefined,
     UseCaseId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UseCaseArn !== undefined && data.UseCaseArn !== null) {
     contents.UseCaseArn = __expectString(data.UseCaseArn);
   }
@@ -6350,7 +6352,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
     UserArn: undefined,
     UserId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserArn !== undefined && data.UserArn !== null) {
     contents.UserArn = __expectString(data.UserArn);
   }
@@ -6457,7 +6459,7 @@ export const deserializeAws_restJson1CreateUserHierarchyGroupCommand = async (
     HierarchyGroupArn: undefined,
     HierarchyGroupId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HierarchyGroupArn !== undefined && data.HierarchyGroupArn !== null) {
     contents.HierarchyGroupArn = __expectString(data.HierarchyGroupArn);
   }
@@ -7120,7 +7122,7 @@ export const deserializeAws_restJson1DescribeAgentStatusCommand = async (
     $metadata: deserializeMetadata(output),
     AgentStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AgentStatus !== undefined && data.AgentStatus !== null) {
     contents.AgentStatus = deserializeAws_restJson1AgentStatus(data.AgentStatus, context);
   }
@@ -7207,7 +7209,7 @@ export const deserializeAws_restJson1DescribeContactFlowCommand = async (
     $metadata: deserializeMetadata(output),
     ContactFlow: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlow !== undefined && data.ContactFlow !== null) {
     contents.ContactFlow = deserializeAws_restJson1ContactFlow(data.ContactFlow, context);
   }
@@ -7302,7 +7304,7 @@ export const deserializeAws_restJson1DescribeHoursOfOperationCommand = async (
     $metadata: deserializeMetadata(output),
     HoursOfOperation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HoursOfOperation !== undefined && data.HoursOfOperation !== null) {
     contents.HoursOfOperation = deserializeAws_restJson1HoursOfOperation(data.HoursOfOperation, context);
   }
@@ -7389,7 +7391,7 @@ export const deserializeAws_restJson1DescribeInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     Instance: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Instance !== undefined && data.Instance !== null) {
     contents.Instance = deserializeAws_restJson1Instance(data.Instance, context);
   }
@@ -7460,7 +7462,7 @@ export const deserializeAws_restJson1DescribeInstanceAttributeCommand = async (
     $metadata: deserializeMetadata(output),
     Attribute: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attribute !== undefined && data.Attribute !== null) {
     contents.Attribute = deserializeAws_restJson1Attribute(data.Attribute, context);
   }
@@ -7547,7 +7549,7 @@ export const deserializeAws_restJson1DescribeInstanceStorageConfigCommand = asyn
     $metadata: deserializeMetadata(output),
     StorageConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StorageConfig !== undefined && data.StorageConfig !== null) {
     contents.StorageConfig = deserializeAws_restJson1InstanceStorageConfig(data.StorageConfig, context);
   }
@@ -7634,7 +7636,7 @@ export const deserializeAws_restJson1DescribeQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Queue !== undefined && data.Queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.Queue, context);
   }
@@ -7721,7 +7723,7 @@ export const deserializeAws_restJson1DescribeQuickConnectCommand = async (
     $metadata: deserializeMetadata(output),
     QuickConnect: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.QuickConnect !== undefined && data.QuickConnect !== null) {
     contents.QuickConnect = deserializeAws_restJson1QuickConnect(data.QuickConnect, context);
   }
@@ -7808,7 +7810,7 @@ export const deserializeAws_restJson1DescribeRoutingProfileCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingProfile !== undefined && data.RoutingProfile !== null) {
     contents.RoutingProfile = deserializeAws_restJson1RoutingProfile(data.RoutingProfile, context);
   }
@@ -7895,7 +7897,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -7982,7 +7984,7 @@ export const deserializeAws_restJson1DescribeUserHierarchyGroupCommand = async (
     $metadata: deserializeMetadata(output),
     HierarchyGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HierarchyGroup !== undefined && data.HierarchyGroup !== null) {
     contents.HierarchyGroup = deserializeAws_restJson1HierarchyGroup(data.HierarchyGroup, context);
   }
@@ -8069,7 +8071,7 @@ export const deserializeAws_restJson1DescribeUserHierarchyStructureCommand = asy
     $metadata: deserializeMetadata(output),
     HierarchyStructure: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HierarchyStructure !== undefined && data.HierarchyStructure !== null) {
     contents.HierarchyStructure = deserializeAws_restJson1HierarchyStructure(data.HierarchyStructure, context);
   }
@@ -8812,7 +8814,7 @@ export const deserializeAws_restJson1GetContactAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     Attributes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1Attributes(data.Attributes, context);
   }
@@ -8885,7 +8887,7 @@ export const deserializeAws_restJson1GetCurrentMetricDataCommand = async (
     MetricResults: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSnapshotTime !== undefined && data.DataSnapshotTime !== null) {
     contents.DataSnapshotTime = new Date(Math.round(data.DataSnapshotTime * 1000));
   }
@@ -8978,7 +8980,7 @@ export const deserializeAws_restJson1GetFederationTokenCommand = async (
     $metadata: deserializeMetadata(output),
     Credentials: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Credentials !== undefined && data.Credentials !== null) {
     contents.Credentials = deserializeAws_restJson1Credentials(data.Credentials, context);
   }
@@ -9074,7 +9076,7 @@ export const deserializeAws_restJson1GetMetricDataCommand = async (
     MetricResults: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricResults !== undefined && data.MetricResults !== null) {
     contents.MetricResults = deserializeAws_restJson1HistoricalMetricResults(data.MetricResults, context);
   }
@@ -9165,7 +9167,7 @@ export const deserializeAws_restJson1ListAgentStatusesCommand = async (
     AgentStatusSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AgentStatusSummaryList !== undefined && data.AgentStatusSummaryList !== null) {
     contents.AgentStatusSummaryList = deserializeAws_restJson1AgentStatusSummaryList(
       data.AgentStatusSummaryList,
@@ -9259,7 +9261,7 @@ export const deserializeAws_restJson1ListApprovedOriginsCommand = async (
     NextToken: undefined,
     Origins: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -9350,7 +9352,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     LexBots: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LexBots !== undefined && data.LexBots !== null) {
     contents.LexBots = deserializeAws_restJson1LexBotConfigList(data.LexBots, context);
   }
@@ -9433,7 +9435,7 @@ export const deserializeAws_restJson1ListContactFlowsCommand = async (
     ContactFlowSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlowSummaryList !== undefined && data.ContactFlowSummaryList !== null) {
     contents.ContactFlowSummaryList = deserializeAws_restJson1ContactFlowSummaryList(
       data.ContactFlowSummaryList,
@@ -9527,7 +9529,7 @@ export const deserializeAws_restJson1ListHoursOfOperationsCommand = async (
     HoursOfOperationSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HoursOfOperationSummaryList !== undefined && data.HoursOfOperationSummaryList !== null) {
     contents.HoursOfOperationSummaryList = deserializeAws_restJson1HoursOfOperationSummaryList(
       data.HoursOfOperationSummaryList,
@@ -9621,7 +9623,7 @@ export const deserializeAws_restJson1ListInstanceAttributesCommand = async (
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributesList(data.Attributes, context);
   }
@@ -9712,7 +9714,7 @@ export const deserializeAws_restJson1ListInstancesCommand = async (
     InstanceSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InstanceSummaryList !== undefined && data.InstanceSummaryList !== null) {
     contents.InstanceSummaryList = deserializeAws_restJson1InstanceSummaryList(data.InstanceSummaryList, context);
   }
@@ -9779,7 +9781,7 @@ export const deserializeAws_restJson1ListInstanceStorageConfigsCommand = async (
     NextToken: undefined,
     StorageConfigs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -9870,7 +9872,7 @@ export const deserializeAws_restJson1ListIntegrationAssociationsCommand = async 
     IntegrationAssociationSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IntegrationAssociationSummaryList !== undefined && data.IntegrationAssociationSummaryList !== null) {
     contents.IntegrationAssociationSummaryList = deserializeAws_restJson1IntegrationAssociationSummaryList(
       data.IntegrationAssociationSummaryList,
@@ -9956,7 +9958,7 @@ export const deserializeAws_restJson1ListLambdaFunctionsCommand = async (
     LambdaFunctions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LambdaFunctions !== undefined && data.LambdaFunctions !== null) {
     contents.LambdaFunctions = deserializeAws_restJson1FunctionArnsList(data.LambdaFunctions, context);
   }
@@ -10047,7 +10049,7 @@ export const deserializeAws_restJson1ListLexBotsCommand = async (
     LexBots: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LexBots !== undefined && data.LexBots !== null) {
     contents.LexBots = deserializeAws_restJson1LexBotsList(data.LexBots, context);
   }
@@ -10138,7 +10140,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
     NextToken: undefined,
     PhoneNumberSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10232,7 +10234,7 @@ export const deserializeAws_restJson1ListPromptsCommand = async (
     NextToken: undefined,
     PromptSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10323,7 +10325,7 @@ export const deserializeAws_restJson1ListQueueQuickConnectsCommand = async (
     NextToken: undefined,
     QuickConnectSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10417,7 +10419,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
     NextToken: undefined,
     QueueSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10508,7 +10510,7 @@ export const deserializeAws_restJson1ListQuickConnectsCommand = async (
     NextToken: undefined,
     QuickConnectSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10602,7 +10604,7 @@ export const deserializeAws_restJson1ListRoutingProfileQueuesCommand = async (
     NextToken: undefined,
     RoutingProfileQueueConfigSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10696,7 +10698,7 @@ export const deserializeAws_restJson1ListRoutingProfilesCommand = async (
     NextToken: undefined,
     RoutingProfileSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10790,7 +10792,7 @@ export const deserializeAws_restJson1ListSecurityKeysCommand = async (
     NextToken: undefined,
     SecurityKeys: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10881,7 +10883,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
     NextToken: undefined,
     SecurityProfileSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10974,7 +10976,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -11062,7 +11064,7 @@ export const deserializeAws_restJson1ListUseCasesCommand = async (
     NextToken: undefined,
     UseCaseSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11145,7 +11147,7 @@ export const deserializeAws_restJson1ListUserHierarchyGroupsCommand = async (
     NextToken: undefined,
     UserHierarchyGroupSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11239,7 +11241,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     NextToken: undefined,
     UserSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11398,7 +11400,7 @@ export const deserializeAws_restJson1StartChatContactCommand = async (
     ParticipantId: undefined,
     ParticipantToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactId !== undefined && data.ContactId !== null) {
     contents.ContactId = __expectString(data.ContactId);
   }
@@ -11566,7 +11568,7 @@ export const deserializeAws_restJson1StartOutboundVoiceContactCommand = async (
     $metadata: deserializeMetadata(output),
     ContactId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactId !== undefined && data.ContactId !== null) {
     contents.ContactId = __expectString(data.ContactId);
   }
@@ -11669,7 +11671,7 @@ export const deserializeAws_restJson1StartTaskContactCommand = async (
     $metadata: deserializeMetadata(output),
     ContactId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactId !== undefined && data.ContactId !== null) {
     contents.ContactId = __expectString(data.ContactId);
   }

--- a/clients/client-connectparticipant/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1.ts
@@ -34,7 +34,11 @@ import {
   Websocket,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -371,7 +375,7 @@ export const deserializeAws_restJson1CreateParticipantConnectionCommand = async 
     ConnectionCredentials: undefined,
     Websocket: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionCredentials !== undefined && data.ConnectionCredentials !== null) {
     contents.ConnectionCredentials = deserializeAws_restJson1ConnectionCredentials(data.ConnectionCredentials, context);
   }
@@ -529,7 +533,7 @@ export const deserializeAws_restJson1GetAttachmentCommand = async (
     Url: undefined,
     UrlExpiry: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Url !== undefined && data.Url !== null) {
     contents.Url = __expectString(data.Url);
   }
@@ -613,7 +617,7 @@ export const deserializeAws_restJson1GetTranscriptCommand = async (
     NextToken: undefined,
     Transcript: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitialContactId !== undefined && data.InitialContactId !== null) {
     contents.InitialContactId = __expectString(data.InitialContactId);
   }
@@ -699,7 +703,7 @@ export const deserializeAws_restJson1SendEventCommand = async (
     AbsoluteTime: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AbsoluteTime !== undefined && data.AbsoluteTime !== null) {
     contents.AbsoluteTime = __expectString(data.AbsoluteTime);
   }
@@ -782,7 +786,7 @@ export const deserializeAws_restJson1SendMessageCommand = async (
     AbsoluteTime: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AbsoluteTime !== undefined && data.AbsoluteTime !== null) {
     contents.AbsoluteTime = __expectString(data.AbsoluteTime);
   }
@@ -865,7 +869,7 @@ export const deserializeAws_restJson1StartAttachmentUploadCommand = async (
     AttachmentId: undefined,
     UploadMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachmentId !== undefined && data.AttachmentId !== null) {
     contents.AttachmentId = __expectString(data.AttachmentId);
   }

--- a/clients/client-customer-profiles/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/protocols/Aws_restJson1.ts
@@ -99,6 +99,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1255,7 +1257,7 @@ export const deserializeAws_restJson1AddProfileKeyCommand = async (
     KeyName: undefined,
     Values: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KeyName !== undefined && data.KeyName !== null) {
     contents.KeyName = __expectString(data.KeyName);
   }
@@ -1352,7 +1354,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
     Matching: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
@@ -1460,7 +1462,7 @@ export const deserializeAws_restJson1CreateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     ProfileId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProfileId !== undefined && data.ProfileId !== null) {
     contents.ProfileId = __expectString(data.ProfileId);
   }
@@ -1547,7 +1549,7 @@ export const deserializeAws_restJson1DeleteDomainCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -1634,7 +1636,7 @@ export const deserializeAws_restJson1DeleteIntegrationCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -1721,7 +1723,7 @@ export const deserializeAws_restJson1DeleteProfileCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -1808,7 +1810,7 @@ export const deserializeAws_restJson1DeleteProfileKeyCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -1895,7 +1897,7 @@ export const deserializeAws_restJson1DeleteProfileObjectCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -1982,7 +1984,7 @@ export const deserializeAws_restJson1DeleteProfileObjectTypeCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -2077,7 +2079,7 @@ export const deserializeAws_restJson1GetDomainCommand = async (
     Stats: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
@@ -2193,7 +2195,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     Tags: undefined,
     Uri: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
@@ -2298,7 +2300,7 @@ export const deserializeAws_restJson1GetMatchesCommand = async (
     NextToken: undefined,
     PotentialMatches: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MatchGenerationDate !== undefined && data.MatchGenerationDate !== null) {
     contents.MatchGenerationDate = new Date(Math.round(data.MatchGenerationDate * 1000));
   }
@@ -2404,7 +2406,7 @@ export const deserializeAws_restJson1GetProfileObjectTypeCommand = async (
     Tags: undefined,
     TemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
@@ -2526,7 +2528,7 @@ export const deserializeAws_restJson1GetProfileObjectTypeTemplateCommand = async
     SourceObject: undefined,
     TemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
@@ -2629,7 +2631,7 @@ export const deserializeAws_restJson1ListAccountIntegrationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1IntegrationList(data.Items, context);
   }
@@ -2720,7 +2722,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1DomainList(data.Items, context);
   }
@@ -2811,7 +2813,7 @@ export const deserializeAws_restJson1ListIntegrationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1IntegrationList(data.Items, context);
   }
@@ -2902,7 +2904,7 @@ export const deserializeAws_restJson1ListProfileObjectsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileObjectList(data.Items, context);
   }
@@ -2993,7 +2995,7 @@ export const deserializeAws_restJson1ListProfileObjectTypesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileObjectTypeList(data.Items, context);
   }
@@ -3084,7 +3086,7 @@ export const deserializeAws_restJson1ListProfileObjectTypeTemplatesCommand = asy
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileObjectTypeTemplateList(data.Items, context);
   }
@@ -3174,7 +3176,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -3245,7 +3247,7 @@ export const deserializeAws_restJson1MergeProfilesCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -3329,7 +3331,7 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     Tags: undefined,
     Uri: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
@@ -3431,7 +3433,7 @@ export const deserializeAws_restJson1PutProfileObjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProfileObjectUniqueKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProfileObjectUniqueKey !== undefined && data.ProfileObjectUniqueKey !== null) {
     contents.ProfileObjectUniqueKey = __expectString(data.ProfileObjectUniqueKey);
   }
@@ -3528,7 +3530,7 @@ export const deserializeAws_restJson1PutProfileObjectTypeCommand = async (
     Tags: undefined,
     TemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
@@ -3646,7 +3648,7 @@ export const deserializeAws_restJson1SearchProfilesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileList(data.Items, context);
   }
@@ -3877,7 +3879,7 @@ export const deserializeAws_restJson1UpdateDomainCommand = async (
     Matching: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
   }
@@ -3985,7 +3987,7 @@ export const deserializeAws_restJson1UpdateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     ProfileId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProfileId !== undefined && data.ProfileId !== null) {
     contents.ProfileId = __expectString(data.ProfileId);
   }

--- a/clients/client-databrew/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/protocols/Aws_restJson1.ts
@@ -104,6 +104,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1416,7 +1418,7 @@ export const deserializeAws_restJson1BatchDeleteRecipeVersionCommand = async (
     Errors: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1RecipeErrorList(data.Errors, context);
   }
@@ -1490,7 +1492,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1569,7 +1571,7 @@ export const deserializeAws_restJson1CreateProfileJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1656,7 +1658,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1735,7 +1737,7 @@ export const deserializeAws_restJson1CreateRecipeCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1806,7 +1808,7 @@ export const deserializeAws_restJson1CreateRecipeJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1893,7 +1895,7 @@ export const deserializeAws_restJson1CreateScheduleCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1964,7 +1966,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2035,7 +2037,7 @@ export const deserializeAws_restJson1DeleteJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2106,7 +2108,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2178,7 +2180,7 @@ export const deserializeAws_restJson1DeleteRecipeVersionCommand = async (
     Name: undefined,
     RecipeVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2252,7 +2254,7 @@ export const deserializeAws_restJson1DeleteScheduleCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2326,7 +2328,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     Source: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
@@ -2444,7 +2446,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     Timeout: undefined,
     Type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
@@ -2590,7 +2592,7 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
     StartedOn: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attempt !== undefined && data.Attempt !== null) {
     contents.Attempt = __expectInt32(data.Attempt);
   }
@@ -2717,7 +2719,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     SessionStatus: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
@@ -2831,7 +2833,7 @@ export const deserializeAws_restJson1DescribeRecipeCommand = async (
     Steps: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
@@ -2938,7 +2940,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
     ResourceArn: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
   }
@@ -3026,7 +3028,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     Datasets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Datasets !== undefined && data.Datasets !== null) {
     contents.Datasets = deserializeAws_restJson1DatasetList(data.Datasets, context);
   }
@@ -3085,7 +3087,7 @@ export const deserializeAws_restJson1ListJobRunsCommand = async (
     JobRuns: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobRuns !== undefined && data.JobRuns !== null) {
     contents.JobRuns = deserializeAws_restJson1JobRunList(data.JobRuns, context);
   }
@@ -3152,7 +3154,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1JobList(data.Jobs, context);
   }
@@ -3211,7 +3213,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     NextToken: undefined,
     Projects: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3270,7 +3272,7 @@ export const deserializeAws_restJson1ListRecipesCommand = async (
     NextToken: undefined,
     Recipes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3329,7 +3331,7 @@ export const deserializeAws_restJson1ListRecipeVersionsCommand = async (
     NextToken: undefined,
     Recipes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3388,7 +3390,7 @@ export const deserializeAws_restJson1ListSchedulesCommand = async (
     NextToken: undefined,
     Schedules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3446,7 +3448,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3517,7 +3519,7 @@ export const deserializeAws_restJson1PublishRecipeCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -3590,7 +3592,7 @@ export const deserializeAws_restJson1SendProjectSessionActionCommand = async (
     Name: undefined,
     Result: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionId !== undefined && data.ActionId !== null) {
     contents.ActionId = __expectInt32(data.ActionId);
   }
@@ -3667,7 +3669,7 @@ export const deserializeAws_restJson1StartJobRunCommand = async (
     $metadata: deserializeMetadata(output),
     RunId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RunId !== undefined && data.RunId !== null) {
     contents.RunId = __expectString(data.RunId);
   }
@@ -3747,7 +3749,7 @@ export const deserializeAws_restJson1StartProjectSessionCommand = async (
     ClientSessionId: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ClientSessionId !== undefined && data.ClientSessionId !== null) {
     contents.ClientSessionId = __expectString(data.ClientSessionId);
   }
@@ -3829,7 +3831,7 @@ export const deserializeAws_restJson1StopJobRunCommand = async (
     $metadata: deserializeMetadata(output),
     RunId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RunId !== undefined && data.RunId !== null) {
     contents.RunId = __expectString(data.RunId);
   }
@@ -4026,7 +4028,7 @@ export const deserializeAws_restJson1UpdateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -4097,7 +4099,7 @@ export const deserializeAws_restJson1UpdateProfileJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -4169,7 +4171,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
     LastModifiedDate: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
     contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
   }
@@ -4235,7 +4237,7 @@ export const deserializeAws_restJson1UpdateRecipeCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -4298,7 +4300,7 @@ export const deserializeAws_restJson1UpdateRecipeJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -4369,7 +4371,7 @@ export const deserializeAws_restJson1UpdateScheduleCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }

--- a/clients/client-dataexchange/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1.ts
@@ -64,6 +64,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -942,7 +944,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1066,7 +1068,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     Type: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1182,7 +1184,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1575,7 +1577,7 @@ export const deserializeAws_restJson1GetAssetCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1691,7 +1693,7 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1807,7 +1809,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     Type: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1915,7 +1917,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2019,7 +2021,7 @@ export const deserializeAws_restJson1ListDataSetRevisionsCommand = async (
     NextToken: undefined,
     Revisions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2102,7 +2104,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
     DataSets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSets !== undefined && data.DataSets !== null) {
     contents.DataSets = deserializeAws_restJson1ListOfDataSetEntry(data.DataSets, context);
   }
@@ -2185,7 +2187,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1ListOfJobEntry(data.Jobs, context);
   }
@@ -2268,7 +2270,7 @@ export const deserializeAws_restJson1ListRevisionAssetsCommand = async (
     Assets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Assets !== undefined && data.Assets !== null) {
     contents.Assets = deserializeAws_restJson1ListOfAssetEntry(data.Assets, context);
   }
@@ -2350,7 +2352,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1MapOf__string(data.tags, context);
   }
@@ -2583,7 +2585,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2714,7 +2716,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2835,7 +2837,7 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-detective/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1.ts
@@ -36,6 +36,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -530,7 +532,7 @@ export const deserializeAws_restJson1CreateGraphCommand = async (
     $metadata: deserializeMetadata(output),
     GraphArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GraphArn !== undefined && data.GraphArn !== null) {
     contents.GraphArn = __expectString(data.GraphArn);
   }
@@ -602,7 +604,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
     Members: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberDetailList(data.Members, context);
   }
@@ -752,7 +754,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
     AccountIds: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountIds !== undefined && data.AccountIds !== null) {
     contents.AccountIds = deserializeAws_restJson1AccountIdList(data.AccountIds, context);
   }
@@ -910,7 +912,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
     MemberDetails: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberDetails !== undefined && data.MemberDetails !== null) {
     contents.MemberDetails = deserializeAws_restJson1MemberDetailList(data.MemberDetails, context);
   }
@@ -985,7 +987,7 @@ export const deserializeAws_restJson1ListGraphsCommand = async (
     GraphList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GraphList !== undefined && data.GraphList !== null) {
     contents.GraphList = deserializeAws_restJson1GraphList(data.GraphList, context);
   }
@@ -1052,7 +1054,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invitations !== undefined && data.Invitations !== null) {
     contents.Invitations = deserializeAws_restJson1MemberDetailList(data.Invitations, context);
   }
@@ -1119,7 +1121,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     MemberDetails: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberDetails !== undefined && data.MemberDetails !== null) {
     contents.MemberDetails = deserializeAws_restJson1MemberDetailList(data.MemberDetails, context);
   }
@@ -1193,7 +1195,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-devops-guru/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/protocols/Aws_restJson1.ts
@@ -131,6 +131,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -740,7 +742,7 @@ export const deserializeAws_restJson1AddNotificationChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Id !== undefined && data.Id !== null) {
     contents.Id = __expectString(data.Id);
   }
@@ -846,7 +848,7 @@ export const deserializeAws_restJson1DescribeAccountHealthCommand = async (
     OpenReactiveInsights: undefined,
     ResourceHours: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricsAnalyzed !== undefined && data.MetricsAnalyzed !== null) {
     contents.MetricsAnalyzed = __expectInt32(data.MetricsAnalyzed);
   }
@@ -936,7 +938,7 @@ export const deserializeAws_restJson1DescribeAccountOverviewCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MeanTimeToRecoverInMilliseconds !== undefined && data.MeanTimeToRecoverInMilliseconds !== null) {
     contents.MeanTimeToRecoverInMilliseconds = __expectLong(data.MeanTimeToRecoverInMilliseconds);
   }
@@ -1022,7 +1024,7 @@ export const deserializeAws_restJson1DescribeAnomalyCommand = async (
     ProactiveAnomaly: undefined,
     ReactiveAnomaly: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProactiveAnomaly !== undefined && data.ProactiveAnomaly !== null) {
     contents.ProactiveAnomaly = deserializeAws_restJson1ProactiveAnomaly(data.ProactiveAnomaly, context);
   }
@@ -1112,7 +1114,7 @@ export const deserializeAws_restJson1DescribeFeedbackCommand = async (
     $metadata: deserializeMetadata(output),
     InsightFeedback: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightFeedback !== undefined && data.InsightFeedback !== null) {
     contents.InsightFeedback = deserializeAws_restJson1InsightFeedback(data.InsightFeedback, context);
   }
@@ -1200,7 +1202,7 @@ export const deserializeAws_restJson1DescribeInsightCommand = async (
     ProactiveInsight: undefined,
     ReactiveInsight: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProactiveInsight !== undefined && data.ProactiveInsight !== null) {
     contents.ProactiveInsight = deserializeAws_restJson1ProactiveInsight(data.ProactiveInsight, context);
   }
@@ -1292,7 +1294,7 @@ export const deserializeAws_restJson1DescribeResourceCollectionHealthCommand = a
     NextToken: undefined,
     Service: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CloudFormation !== undefined && data.CloudFormation !== null) {
     contents.CloudFormation = deserializeAws_restJson1CloudFormationHealths(data.CloudFormation, context);
   }
@@ -1377,7 +1379,7 @@ export const deserializeAws_restJson1DescribeServiceIntegrationCommand = async (
     $metadata: deserializeMetadata(output),
     ServiceIntegration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceIntegration !== undefined && data.ServiceIntegration !== null) {
     contents.ServiceIntegration = deserializeAws_restJson1ServiceIntegrationConfig(data.ServiceIntegration, context);
   }
@@ -1461,7 +1463,7 @@ export const deserializeAws_restJson1GetCostEstimationCommand = async (
     TimeRange: undefined,
     TotalCost: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Costs !== undefined && data.Costs !== null) {
     contents.Costs = deserializeAws_restJson1ServiceResourceCosts(data.Costs, context);
   }
@@ -1567,7 +1569,7 @@ export const deserializeAws_restJson1GetResourceCollectionCommand = async (
     NextToken: undefined,
     ResourceCollection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1659,7 +1661,7 @@ export const deserializeAws_restJson1ListAnomaliesForInsightCommand = async (
     ProactiveAnomalies: undefined,
     ReactiveAnomalies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1753,7 +1755,7 @@ export const deserializeAws_restJson1ListEventsCommand = async (
     Events: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Events !== undefined && data.Events !== null) {
     contents.Events = deserializeAws_restJson1Events(data.Events, context);
   }
@@ -1845,7 +1847,7 @@ export const deserializeAws_restJson1ListInsightsCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1931,7 +1933,7 @@ export const deserializeAws_restJson1ListNotificationChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1Channels(data.Channels, context);
   }
@@ -2014,7 +2016,7 @@ export const deserializeAws_restJson1ListRecommendationsCommand = async (
     NextToken: undefined,
     Recommendations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2288,7 +2290,7 @@ export const deserializeAws_restJson1SearchInsightsCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-dlm/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1.ts
@@ -52,6 +52,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -324,7 +326,7 @@ export const deserializeAws_restJson1CreateLifecyclePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     PolicyId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PolicyId !== undefined && data.PolicyId !== null) {
     contents.PolicyId = __expectString(data.PolicyId);
   }
@@ -462,7 +464,7 @@ export const deserializeAws_restJson1GetLifecyclePoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     Policies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policies !== undefined && data.Policies !== null) {
     contents.Policies = deserializeAws_restJson1LifecyclePolicySummaryList(data.Policies, context);
   }
@@ -541,7 +543,7 @@ export const deserializeAws_restJson1GetLifecyclePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = deserializeAws_restJson1LifecyclePolicy(data.Policy, context);
   }
@@ -612,7 +614,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-ebs/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1.ts
@@ -21,6 +21,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseInt32 as __strictParseInt32,
@@ -279,7 +281,7 @@ export const deserializeAws_restJson1CompleteSnapshotCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -483,7 +485,7 @@ export const deserializeAws_restJson1ListChangedBlocksCommand = async (
     NextToken: undefined,
     VolumeSize: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
     contents.BlockSize = __expectInt32(data.BlockSize);
   }
@@ -594,7 +596,7 @@ export const deserializeAws_restJson1ListSnapshotBlocksCommand = async (
     NextToken: undefined,
     VolumeSize: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
     contents.BlockSize = __expectInt32(data.BlockSize);
   }
@@ -809,7 +811,7 @@ export const deserializeAws_restJson1StartSnapshotCommand = async (
     Tags: undefined,
     VolumeSize: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
     contents.BlockSize = __expectInt32(data.BlockSize);
   }

--- a/clients/client-efs/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1.ts
@@ -114,6 +114,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1014,7 +1016,7 @@ export const deserializeAws_restJson1CreateAccessPointCommand = async (
     RootDirectory: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPointArn !== undefined && data.AccessPointArn !== null) {
     contents.AccessPointArn = __expectString(data.AccessPointArn);
   }
@@ -1152,7 +1154,7 @@ export const deserializeAws_restJson1CreateFileSystemCommand = async (
     Tags: undefined,
     ThroughputMode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
     contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }
@@ -1312,7 +1314,7 @@ export const deserializeAws_restJson1CreateMountTargetCommand = async (
     SubnetId: undefined,
     VpcId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
     contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }
@@ -1909,7 +1911,7 @@ export const deserializeAws_restJson1DescribeAccessPointsCommand = async (
     AccessPoints: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPoints !== undefined && data.AccessPoints !== null) {
     contents.AccessPoints = deserializeAws_restJson1AccessPointDescriptions(data.AccessPoints, context);
   }
@@ -1992,7 +1994,7 @@ export const deserializeAws_restJson1DescribeAccountPreferencesCommand = async (
     NextToken: undefined,
     ResourceIdPreference: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2050,7 +2052,7 @@ export const deserializeAws_restJson1DescribeBackupPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPolicy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPolicy !== undefined && data.BackupPolicy !== null) {
     contents.BackupPolicy = deserializeAws_restJson1BackupPolicy(data.BackupPolicy, context);
   }
@@ -2138,7 +2140,7 @@ export const deserializeAws_restJson1DescribeFileSystemPolicyCommand = async (
     FileSystemId: undefined,
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
     contents.FileSystemId = __expectString(data.FileSystemId);
   }
@@ -2214,7 +2216,7 @@ export const deserializeAws_restJson1DescribeFileSystemsCommand = async (
     Marker: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FileSystems !== undefined && data.FileSystems !== null) {
     contents.FileSystems = deserializeAws_restJson1FileSystemDescriptions(data.FileSystems, context);
   }
@@ -2291,7 +2293,7 @@ export const deserializeAws_restJson1DescribeLifecycleConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     LifecyclePolicies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LifecyclePolicies !== undefined && data.LifecyclePolicies !== null) {
     contents.LifecyclePolicies = deserializeAws_restJson1LifecyclePolicies(data.LifecyclePolicies, context);
   }
@@ -2364,7 +2366,7 @@ export const deserializeAws_restJson1DescribeMountTargetsCommand = async (
     MountTargets: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -2457,7 +2459,7 @@ export const deserializeAws_restJson1DescribeMountTargetSecurityGroupsCommand = 
     $metadata: deserializeMetadata(output),
     SecurityGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SecurityGroups !== undefined && data.SecurityGroups !== null) {
     contents.SecurityGroups = deserializeAws_restJson1SecurityGroups(data.SecurityGroups, context);
   }
@@ -2538,7 +2540,7 @@ export const deserializeAws_restJson1DescribeTagsCommand = async (
     NextMarker: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -2616,7 +2618,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2789,7 +2791,7 @@ export const deserializeAws_restJson1PutAccountPreferencesCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceIdPreference: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceIdPreference !== undefined && data.ResourceIdPreference !== null) {
     contents.ResourceIdPreference = deserializeAws_restJson1ResourceIdPreference(data.ResourceIdPreference, context);
   }
@@ -2844,7 +2846,7 @@ export const deserializeAws_restJson1PutBackupPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPolicy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPolicy !== undefined && data.BackupPolicy !== null) {
     contents.BackupPolicy = deserializeAws_restJson1BackupPolicy(data.BackupPolicy, context);
   }
@@ -2932,7 +2934,7 @@ export const deserializeAws_restJson1PutFileSystemPolicyCommand = async (
     FileSystemId: undefined,
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
     contents.FileSystemId = __expectString(data.FileSystemId);
   }
@@ -3014,7 +3016,7 @@ export const deserializeAws_restJson1PutLifecycleConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     LifecyclePolicies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LifecyclePolicies !== undefined && data.LifecyclePolicies !== null) {
     contents.LifecyclePolicies = deserializeAws_restJson1LifecyclePolicies(data.LifecyclePolicies, context);
   }
@@ -3259,7 +3261,7 @@ export const deserializeAws_restJson1UpdateFileSystemCommand = async (
     Tags: undefined,
     ThroughputMode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
     contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }

--- a/clients/client-eks/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1.ts
@@ -132,6 +132,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1393,7 +1395,7 @@ export const deserializeAws_restJson1AssociateEncryptionConfigCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -1489,7 +1491,7 @@ export const deserializeAws_restJson1AssociateIdentityProviderConfigCommand = as
     tags: undefined,
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1587,7 +1589,7 @@ export const deserializeAws_restJson1CreateAddonCommand = async (
     $metadata: deserializeMetadata(output),
     addon: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addon !== undefined && data.addon !== null) {
     contents.addon = deserializeAws_restJson1Addon(data.addon, context);
   }
@@ -1682,7 +1684,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -1785,7 +1787,7 @@ export const deserializeAws_restJson1CreateFargateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     fargateProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfile !== undefined && data.fargateProfile !== null) {
     contents.fargateProfile = deserializeAws_restJson1FargateProfile(data.fargateProfile, context);
   }
@@ -1880,7 +1882,7 @@ export const deserializeAws_restJson1CreateNodegroupCommand = async (
     $metadata: deserializeMetadata(output),
     nodegroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nodegroup !== undefined && data.nodegroup !== null) {
     contents.nodegroup = deserializeAws_restJson1Nodegroup(data.nodegroup, context);
   }
@@ -1983,7 +1985,7 @@ export const deserializeAws_restJson1DeleteAddonCommand = async (
     $metadata: deserializeMetadata(output),
     addon: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addon !== undefined && data.addon !== null) {
     contents.addon = deserializeAws_restJson1Addon(data.addon, context);
   }
@@ -2070,7 +2072,7 @@ export const deserializeAws_restJson1DeleteClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -2157,7 +2159,7 @@ export const deserializeAws_restJson1DeleteFargateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     fargateProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfile !== undefined && data.fargateProfile !== null) {
     contents.fargateProfile = deserializeAws_restJson1FargateProfile(data.fargateProfile, context);
   }
@@ -2236,7 +2238,7 @@ export const deserializeAws_restJson1DeleteNodegroupCommand = async (
     $metadata: deserializeMetadata(output),
     nodegroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nodegroup !== undefined && data.nodegroup !== null) {
     contents.nodegroup = deserializeAws_restJson1Nodegroup(data.nodegroup, context);
   }
@@ -2331,7 +2333,7 @@ export const deserializeAws_restJson1DescribeAddonCommand = async (
     $metadata: deserializeMetadata(output),
     addon: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addon !== undefined && data.addon !== null) {
     contents.addon = deserializeAws_restJson1Addon(data.addon, context);
   }
@@ -2419,7 +2421,7 @@ export const deserializeAws_restJson1DescribeAddonVersionsCommand = async (
     addons: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addons !== undefined && data.addons !== null) {
     contents.addons = deserializeAws_restJson1Addons(data.addons, context);
   }
@@ -2493,7 +2495,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -2572,7 +2574,7 @@ export const deserializeAws_restJson1DescribeFargateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     fargateProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfile !== undefined && data.fargateProfile !== null) {
     contents.fargateProfile = deserializeAws_restJson1FargateProfile(data.fargateProfile, context);
   }
@@ -2651,7 +2653,7 @@ export const deserializeAws_restJson1DescribeIdentityProviderConfigCommand = asy
     $metadata: deserializeMetadata(output),
     identityProviderConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProviderConfig !== undefined && data.identityProviderConfig !== null) {
     contents.identityProviderConfig = deserializeAws_restJson1IdentityProviderConfigResponse(
       data.identityProviderConfig,
@@ -2741,7 +2743,7 @@ export const deserializeAws_restJson1DescribeNodegroupCommand = async (
     $metadata: deserializeMetadata(output),
     nodegroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nodegroup !== undefined && data.nodegroup !== null) {
     contents.nodegroup = deserializeAws_restJson1Nodegroup(data.nodegroup, context);
   }
@@ -2828,7 +2830,7 @@ export const deserializeAws_restJson1DescribeUpdateCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -2907,7 +2909,7 @@ export const deserializeAws_restJson1DisassociateIdentityProviderConfigCommand =
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3003,7 +3005,7 @@ export const deserializeAws_restJson1ListAddonsCommand = async (
     addons: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addons !== undefined && data.addons !== null) {
     contents.addons = deserializeAws_restJson1StringList(data.addons, context);
   }
@@ -3094,7 +3096,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     clusters: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusters !== undefined && data.clusters !== null) {
     contents.clusters = deserializeAws_restJson1StringList(data.clusters, context);
   }
@@ -3177,7 +3179,7 @@ export const deserializeAws_restJson1ListFargateProfilesCommand = async (
     fargateProfileNames: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfileNames !== undefined && data.fargateProfileNames !== null) {
     contents.fargateProfileNames = deserializeAws_restJson1StringList(data.fargateProfileNames, context);
   }
@@ -3260,7 +3262,7 @@ export const deserializeAws_restJson1ListIdentityProviderConfigsCommand = async 
     identityProviderConfigs: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProviderConfigs !== undefined && data.identityProviderConfigs !== null) {
     contents.identityProviderConfigs = deserializeAws_restJson1IdentityProviderConfigs(
       data.identityProviderConfigs,
@@ -3354,7 +3356,7 @@ export const deserializeAws_restJson1ListNodegroupsCommand = async (
     nextToken: undefined,
     nodegroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3444,7 +3446,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -3508,7 +3510,7 @@ export const deserializeAws_restJson1ListUpdatesCommand = async (
     nextToken: undefined,
     updateIds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3708,7 +3710,7 @@ export const deserializeAws_restJson1UpdateAddonCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3803,7 +3805,7 @@ export const deserializeAws_restJson1UpdateClusterConfigCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3898,7 +3900,7 @@ export const deserializeAws_restJson1UpdateClusterVersionCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3993,7 +3995,7 @@ export const deserializeAws_restJson1UpdateNodegroupConfigCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -4088,7 +4090,7 @@ export const deserializeAws_restJson1UpdateNodegroupVersionCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }

--- a/clients/client-elastic-inference/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1.ts
@@ -31,6 +31,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -229,7 +231,7 @@ export const deserializeAws_restJson1DescribeAcceleratorOfferingsCommand = async
     $metadata: deserializeMetadata(output),
     acceleratorTypeOfferings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.acceleratorTypeOfferings !== undefined && data.acceleratorTypeOfferings !== null) {
     contents.acceleratorTypeOfferings = deserializeAws_restJson1AcceleratorTypeOfferingList(
       data.acceleratorTypeOfferings,
@@ -304,7 +306,7 @@ export const deserializeAws_restJson1DescribeAcceleratorsCommand = async (
     acceleratorSet: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.acceleratorSet !== undefined && data.acceleratorSet !== null) {
     contents.acceleratorSet = deserializeAws_restJson1ElasticInferenceAcceleratorSet(data.acceleratorSet, context);
   }
@@ -378,7 +380,7 @@ export const deserializeAws_restJson1DescribeAcceleratorTypesCommand = async (
     $metadata: deserializeMetadata(output),
     acceleratorTypes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.acceleratorTypes !== undefined && data.acceleratorTypes !== null) {
     contents.acceleratorTypes = deserializeAws_restJson1AcceleratorTypeList(data.acceleratorTypes, context);
   }
@@ -433,7 +435,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
@@ -65,6 +65,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -722,7 +724,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Job !== undefined && data.Job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.Job, context);
   }
@@ -818,7 +820,7 @@ export const deserializeAws_restJson1CreatePipelineCommand = async (
     Pipeline: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -917,7 +919,7 @@ export const deserializeAws_restJson1CreatePresetCommand = async (
     Preset: undefined,
     Warning: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Preset !== undefined && data.Preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.Preset, context);
   }
@@ -1182,7 +1184,7 @@ export const deserializeAws_restJson1ListJobsByPipelineCommand = async (
     Jobs: undefined,
     NextPageToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1Jobs(data.Jobs, context);
   }
@@ -1273,7 +1275,7 @@ export const deserializeAws_restJson1ListJobsByStatusCommand = async (
     Jobs: undefined,
     NextPageToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1Jobs(data.Jobs, context);
   }
@@ -1364,7 +1366,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
     NextPageToken: undefined,
     Pipelines: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
     contents.NextPageToken = __expectString(data.NextPageToken);
   }
@@ -1447,7 +1449,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
     NextPageToken: undefined,
     Presets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
     contents.NextPageToken = __expectString(data.NextPageToken);
   }
@@ -1529,7 +1531,7 @@ export const deserializeAws_restJson1ReadJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Job !== undefined && data.Job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.Job, context);
   }
@@ -1617,7 +1619,7 @@ export const deserializeAws_restJson1ReadPipelineCommand = async (
     Pipeline: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -1707,7 +1709,7 @@ export const deserializeAws_restJson1ReadPresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Preset !== undefined && data.Preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.Preset, context);
   }
@@ -1795,7 +1797,7 @@ export const deserializeAws_restJson1TestRoleCommand = async (
     Messages: undefined,
     Success: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Messages !== undefined && data.Messages !== null) {
     contents.Messages = deserializeAws_restJson1ExceptionMessages(data.Messages, context);
   }
@@ -1886,7 +1888,7 @@ export const deserializeAws_restJson1UpdatePipelineCommand = async (
     Pipeline: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -1984,7 +1986,7 @@ export const deserializeAws_restJson1UpdatePipelineNotificationsCommand = async 
     $metadata: deserializeMetadata(output),
     Pipeline: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -2079,7 +2081,7 @@ export const deserializeAws_restJson1UpdatePipelineStatusCommand = async (
     $metadata: deserializeMetadata(output),
     Pipeline: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
@@ -213,6 +213,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1547,7 +1549,7 @@ export const deserializeAws_restJson1AcceptInboundCrossClusterSearchConnectionCo
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1InboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -1696,7 +1698,7 @@ export const deserializeAws_restJson1AssociatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     DomainPackageDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetails !== undefined && data.DomainPackageDetails !== null) {
     contents.DomainPackageDetails = deserializeAws_restJson1DomainPackageDetails(data.DomainPackageDetails, context);
   }
@@ -1791,7 +1793,7 @@ export const deserializeAws_restJson1CancelElasticsearchServiceSoftwareUpdateCom
     $metadata: deserializeMetadata(output),
     ServiceSoftwareOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceSoftwareOptions !== undefined && data.ServiceSoftwareOptions !== null) {
     contents.ServiceSoftwareOptions = deserializeAws_restJson1ServiceSoftwareOptions(
       data.ServiceSoftwareOptions,
@@ -1873,7 +1875,7 @@ export const deserializeAws_restJson1CreateElasticsearchDomainCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1ElasticsearchDomainStatus(data.DomainStatus, context);
   }
@@ -1980,7 +1982,7 @@ export const deserializeAws_restJson1CreateOutboundCrossClusterSearchConnectionC
     DestinationDomainInfo: undefined,
     SourceDomainInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionAlias !== undefined && data.ConnectionAlias !== null) {
     contents.ConnectionAlias = __expectString(data.ConnectionAlias);
   }
@@ -2074,7 +2076,7 @@ export const deserializeAws_restJson1CreatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -2177,7 +2179,7 @@ export const deserializeAws_restJson1DeleteElasticsearchDomainCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1ElasticsearchDomainStatus(data.DomainStatus, context);
   }
@@ -2323,7 +2325,7 @@ export const deserializeAws_restJson1DeleteInboundCrossClusterSearchConnectionCo
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1InboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -2389,7 +2391,7 @@ export const deserializeAws_restJson1DeleteOutboundCrossClusterSearchConnectionC
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1OutboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -2455,7 +2457,7 @@ export const deserializeAws_restJson1DeletePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -2551,7 +2553,7 @@ export const deserializeAws_restJson1DescribeDomainAutoTunesCommand = async (
     AutoTunes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoTunes !== undefined && data.AutoTunes !== null) {
     contents.AutoTunes = deserializeAws_restJson1AutoTuneList(data.AutoTunes, context);
   }
@@ -2633,7 +2635,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainCommand = async 
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1ElasticsearchDomainStatus(data.DomainStatus, context);
   }
@@ -2712,7 +2714,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainConfigCommand = 
     $metadata: deserializeMetadata(output),
     DomainConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainConfig !== undefined && data.DomainConfig !== null) {
     contents.DomainConfig = deserializeAws_restJson1ElasticsearchDomainConfig(data.DomainConfig, context);
   }
@@ -2791,7 +2793,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainsCommand = async
     $metadata: deserializeMetadata(output),
     DomainStatusList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatusList !== undefined && data.DomainStatusList !== null) {
     contents.DomainStatusList = deserializeAws_restJson1ElasticsearchDomainStatusList(data.DomainStatusList, context);
   }
@@ -2862,7 +2864,7 @@ export const deserializeAws_restJson1DescribeElasticsearchInstanceTypeLimitsComm
     $metadata: deserializeMetadata(output),
     LimitsByRole: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LimitsByRole !== undefined && data.LimitsByRole !== null) {
     contents.LimitsByRole = deserializeAws_restJson1LimitsByRole(data.LimitsByRole, context);
   }
@@ -2958,7 +2960,7 @@ export const deserializeAws_restJson1DescribeInboundCrossClusterSearchConnection
     CrossClusterSearchConnections: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnections !== undefined && data.CrossClusterSearchConnections !== null) {
     contents.CrossClusterSearchConnections = deserializeAws_restJson1InboundCrossClusterSearchConnections(
       data.CrossClusterSearchConnections,
@@ -3028,7 +3030,7 @@ export const deserializeAws_restJson1DescribeOutboundCrossClusterSearchConnectio
     CrossClusterSearchConnections: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnections !== undefined && data.CrossClusterSearchConnections !== null) {
     contents.CrossClusterSearchConnections = deserializeAws_restJson1OutboundCrossClusterSearchConnections(
       data.CrossClusterSearchConnections,
@@ -3098,7 +3100,7 @@ export const deserializeAws_restJson1DescribePackagesCommand = async (
     NextToken: undefined,
     PackageDetailsList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3189,7 +3191,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstanceOfferi
     NextToken: undefined,
     ReservedElasticsearchInstanceOfferings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3278,7 +3280,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstancesComma
     NextToken: undefined,
     ReservedElasticsearchInstances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3363,7 +3365,7 @@ export const deserializeAws_restJson1DissociatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     DomainPackageDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetails !== undefined && data.DomainPackageDetails !== null) {
     contents.DomainPackageDetails = deserializeAws_restJson1DomainPackageDetails(data.DomainPackageDetails, context);
   }
@@ -3458,7 +3460,7 @@ export const deserializeAws_restJson1GetCompatibleElasticsearchVersionsCommand =
     $metadata: deserializeMetadata(output),
     CompatibleElasticsearchVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleElasticsearchVersions !== undefined && data.CompatibleElasticsearchVersions !== null) {
     contents.CompatibleElasticsearchVersions = deserializeAws_restJson1CompatibleElasticsearchVersionsList(
       data.CompatibleElasticsearchVersions,
@@ -3550,7 +3552,7 @@ export const deserializeAws_restJson1GetPackageVersionHistoryCommand = async (
     PackageID: undefined,
     PackageVersionHistoryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3647,7 +3649,7 @@ export const deserializeAws_restJson1GetUpgradeHistoryCommand = async (
     NextToken: undefined,
     UpgradeHistories: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3739,7 +3741,7 @@ export const deserializeAws_restJson1GetUpgradeStatusCommand = async (
     UpgradeName: undefined,
     UpgradeStep: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StepStatus !== undefined && data.StepStatus !== null) {
     contents.StepStatus = __expectString(data.StepStatus);
   }
@@ -3832,7 +3834,7 @@ export const deserializeAws_restJson1ListDomainNamesCommand = async (
     $metadata: deserializeMetadata(output),
     DomainNames: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainNames !== undefined && data.DomainNames !== null) {
     contents.DomainNames = deserializeAws_restJson1DomainInfoList(data.DomainNames, context);
   }
@@ -3896,7 +3898,7 @@ export const deserializeAws_restJson1ListDomainsForPackageCommand = async (
     DomainPackageDetailsList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetailsList !== undefined && data.DomainPackageDetailsList !== null) {
     contents.DomainPackageDetailsList = deserializeAws_restJson1DomainPackageDetailsList(
       data.DomainPackageDetailsList,
@@ -3990,7 +3992,7 @@ export const deserializeAws_restJson1ListElasticsearchInstanceTypesCommand = asy
     ElasticsearchInstanceTypes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ElasticsearchInstanceTypes !== undefined && data.ElasticsearchInstanceTypes !== null) {
     contents.ElasticsearchInstanceTypes = deserializeAws_restJson1ElasticsearchInstanceTypeList(
       data.ElasticsearchInstanceTypes,
@@ -4076,7 +4078,7 @@ export const deserializeAws_restJson1ListElasticsearchVersionsCommand = async (
     ElasticsearchVersions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ElasticsearchVersions !== undefined && data.ElasticsearchVersions !== null) {
     contents.ElasticsearchVersions = deserializeAws_restJson1ElasticsearchVersionList(
       data.ElasticsearchVersions,
@@ -4162,7 +4164,7 @@ export const deserializeAws_restJson1ListPackagesForDomainCommand = async (
     DomainPackageDetailsList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetailsList !== undefined && data.DomainPackageDetailsList !== null) {
     contents.DomainPackageDetailsList = deserializeAws_restJson1DomainPackageDetailsList(
       data.DomainPackageDetailsList,
@@ -4255,7 +4257,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     $metadata: deserializeMetadata(output),
     TagList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagList !== undefined && data.TagList !== null) {
     contents.TagList = deserializeAws_restJson1TagList(data.TagList, context);
   }
@@ -4335,7 +4337,7 @@ export const deserializeAws_restJson1PurchaseReservedElasticsearchInstanceOfferi
     ReservationName: undefined,
     ReservedElasticsearchInstanceId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReservationName !== undefined && data.ReservationName !== null) {
     contents.ReservationName = __expectString(data.ReservationName);
   }
@@ -4433,7 +4435,7 @@ export const deserializeAws_restJson1RejectInboundCrossClusterSearchConnectionCo
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1InboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -4566,7 +4568,7 @@ export const deserializeAws_restJson1StartElasticsearchServiceSoftwareUpdateComm
     $metadata: deserializeMetadata(output),
     ServiceSoftwareOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceSoftwareOptions !== undefined && data.ServiceSoftwareOptions !== null) {
     contents.ServiceSoftwareOptions = deserializeAws_restJson1ServiceSoftwareOptions(
       data.ServiceSoftwareOptions,
@@ -4648,7 +4650,7 @@ export const deserializeAws_restJson1UpdateElasticsearchDomainConfigCommand = as
     $metadata: deserializeMetadata(output),
     DomainConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainConfig !== undefined && data.DomainConfig !== null) {
     contents.DomainConfig = deserializeAws_restJson1ElasticsearchDomainConfig(data.DomainConfig, context);
   }
@@ -4743,7 +4745,7 @@ export const deserializeAws_restJson1UpdatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -4840,7 +4842,7 @@ export const deserializeAws_restJson1UpgradeElasticsearchDomainCommand = async (
     PerformCheckOnly: undefined,
     TargetVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainName !== undefined && data.DomainName !== null) {
     contents.DomainName = __expectString(data.DomainName);
   }

--- a/clients/client-emr-containers/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/protocols/Aws_restJson1.ts
@@ -60,6 +60,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -631,7 +633,7 @@ export const deserializeAws_restJson1CancelJobRunCommand = async (
     id: undefined,
     virtualClusterId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -700,7 +702,7 @@ export const deserializeAws_restJson1CreateManagedEndpointCommand = async (
     name: undefined,
     virtualClusterId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -782,7 +784,7 @@ export const deserializeAws_restJson1CreateVirtualClusterCommand = async (
     id: undefined,
     name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -860,7 +862,7 @@ export const deserializeAws_restJson1DeleteManagedEndpointCommand = async (
     id: undefined,
     virtualClusterId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -926,7 +928,7 @@ export const deserializeAws_restJson1DeleteVirtualClusterCommand = async (
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -989,7 +991,7 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
     $metadata: deserializeMetadata(output),
     jobRun: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobRun !== undefined && data.jobRun !== null) {
     contents.jobRun = deserializeAws_restJson1JobRun(data.jobRun, context);
   }
@@ -1060,7 +1062,7 @@ export const deserializeAws_restJson1DescribeManagedEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     endpoint: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpoint !== undefined && data.endpoint !== null) {
     contents.endpoint = deserializeAws_restJson1Endpoint(data.endpoint, context);
   }
@@ -1131,7 +1133,7 @@ export const deserializeAws_restJson1DescribeVirtualClusterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualCluster: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.virtualCluster !== undefined && data.virtualCluster !== null) {
     contents.virtualCluster = deserializeAws_restJson1VirtualCluster(data.virtualCluster, context);
   }
@@ -1203,7 +1205,7 @@ export const deserializeAws_restJson1ListJobRunsCommand = async (
     jobRuns: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobRuns !== undefined && data.jobRuns !== null) {
     contents.jobRuns = deserializeAws_restJson1JobRuns(data.jobRuns, context);
   }
@@ -1270,7 +1272,7 @@ export const deserializeAws_restJson1ListManagedEndpointsCommand = async (
     endpoints: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpoints !== undefined && data.endpoints !== null) {
     contents.endpoints = deserializeAws_restJson1Endpoints(data.endpoints, context);
   }
@@ -1336,7 +1338,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1408,7 +1410,7 @@ export const deserializeAws_restJson1ListVirtualClustersCommand = async (
     nextToken: undefined,
     virtualClusters: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1477,7 +1479,7 @@ export const deserializeAws_restJson1StartJobRunCommand = async (
     name: undefined,
     virtualClusterId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-finspace-data/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/protocols/Aws_restJson1.ts
@@ -17,6 +17,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -130,7 +132,7 @@ export const deserializeAws_restJson1CreateChangesetCommand = async (
     $metadata: deserializeMetadata(output),
     changeset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.changeset !== undefined && data.changeset !== null) {
     contents.changeset = deserializeAws_restJson1ChangesetInfo(data.changeset, context);
   }
@@ -218,7 +220,7 @@ export const deserializeAws_restJson1GetProgrammaticAccessCredentialsCommand = a
     credentials: undefined,
     durationInMinutes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.credentials !== undefined && data.credentials !== null) {
     contents.credentials = deserializeAws_restJson1Credentials(data.credentials, context);
   }
@@ -294,7 +296,7 @@ export const deserializeAws_restJson1GetWorkingLocationCommand = async (
     s3Path: undefined,
     s3Uri: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.s3Bucket !== undefined && data.s3Bucket !== null) {
     contents.s3Bucket = __expectString(data.s3Bucket);
   }

--- a/clients/client-finspace/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace/protocols/Aws_restJson1.ts
@@ -23,6 +23,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -296,7 +298,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     environmentId: undefined,
     environmentUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environmentArn !== undefined && data.environmentArn !== null) {
     contents.environmentArn = __expectString(data.environmentArn);
   }
@@ -480,7 +482,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     environment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environment !== undefined && data.environment !== null) {
     contents.environment = deserializeAws_restJson1Environment(data.environment, context);
   }
@@ -560,7 +562,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     environments: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environments !== undefined && data.environments !== null) {
     contents.environments = deserializeAws_restJson1EnvironmentList(data.environments, context);
   }
@@ -626,7 +628,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -831,7 +833,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     environment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environment !== undefined && data.environment !== null) {
     contents.environment = deserializeAws_restJson1Environment(data.environment, context);
   }

--- a/clients/client-fis/protocols/Aws_restJson1.ts
+++ b/clients/client-fis/protocols/Aws_restJson1.ts
@@ -64,6 +64,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -513,7 +515,7 @@ export const deserializeAws_restJson1CreateExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }
@@ -592,7 +594,7 @@ export const deserializeAws_restJson1DeleteExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }
@@ -655,7 +657,7 @@ export const deserializeAws_restJson1GetActionCommand = async (
     $metadata: deserializeMetadata(output),
     action: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.action !== undefined && data.action !== null) {
     contents.action = deserializeAws_restJson1Action(data.action, context);
   }
@@ -718,7 +720,7 @@ export const deserializeAws_restJson1GetExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -781,7 +783,7 @@ export const deserializeAws_restJson1GetExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }
@@ -845,7 +847,7 @@ export const deserializeAws_restJson1ListActionsCommand = async (
     actions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actions !== undefined && data.actions !== null) {
     contents.actions = deserializeAws_restJson1ActionSummaryList(data.actions, context);
   }
@@ -904,7 +906,7 @@ export const deserializeAws_restJson1ListExperimentsCommand = async (
     experiments: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiments !== undefined && data.experiments !== null) {
     contents.experiments = deserializeAws_restJson1ExperimentSummaryList(data.experiments, context);
   }
@@ -963,7 +965,7 @@ export const deserializeAws_restJson1ListExperimentTemplatesCommand = async (
     experimentTemplates: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplates !== undefined && data.experimentTemplates !== null) {
     contents.experimentTemplates = deserializeAws_restJson1ExperimentTemplateSummaryList(
       data.experimentTemplates,
@@ -1024,7 +1026,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1071,7 +1073,7 @@ export const deserializeAws_restJson1StartExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -1150,7 +1152,7 @@ export const deserializeAws_restJson1StopExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -1299,7 +1301,7 @@ export const deserializeAws_restJson1UpdateExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }

--- a/clients/client-glacier/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1.ts
@@ -116,6 +116,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -2340,7 +2342,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     Tier: undefined,
     VaultARN: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Action !== undefined && data.Action !== null) {
     contents.Action = __expectString(data.Action);
   }
@@ -2487,7 +2489,7 @@ export const deserializeAws_restJson1DescribeVaultCommand = async (
     VaultARN: undefined,
     VaultName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = __expectString(data.CreationDate);
   }
@@ -2581,7 +2583,7 @@ export const deserializeAws_restJson1GetDataRetrievalPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = deserializeAws_restJson1DataRetrievalPolicy(data.Policy, context);
   }
@@ -2753,7 +2755,7 @@ export const deserializeAws_restJson1GetVaultAccessPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.policy = deserializeAws_restJson1VaultAccessPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -2833,7 +2835,7 @@ export const deserializeAws_restJson1GetVaultLockCommand = async (
     Policy: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = __expectString(data.CreationDate);
   }
@@ -2921,7 +2923,7 @@ export const deserializeAws_restJson1GetVaultNotificationsCommand = async (
     $metadata: deserializeMetadata(output),
     vaultNotificationConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.vaultNotificationConfig = deserializeAws_restJson1VaultNotificationConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -3264,7 +3266,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     JobList: undefined,
     Marker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobList !== undefined && data.JobList !== null) {
     contents.JobList = deserializeAws_restJson1JobList(data.JobList, context);
   }
@@ -3347,7 +3349,7 @@ export const deserializeAws_restJson1ListMultipartUploadsCommand = async (
     Marker: undefined,
     UploadsList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -3435,7 +3437,7 @@ export const deserializeAws_restJson1ListPartsCommand = async (
     Parts: undefined,
     VaultARN: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ArchiveDescription !== undefined && data.ArchiveDescription !== null) {
     contents.ArchiveDescription = __expectString(data.ArchiveDescription);
   }
@@ -3532,7 +3534,7 @@ export const deserializeAws_restJson1ListProvisionedCapacityCommand = async (
     $metadata: deserializeMetadata(output),
     ProvisionedCapacityList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProvisionedCapacityList !== undefined && data.ProvisionedCapacityList !== null) {
     contents.ProvisionedCapacityList = deserializeAws_restJson1ProvisionedCapacityList(
       data.ProvisionedCapacityList,
@@ -3606,7 +3608,7 @@ export const deserializeAws_restJson1ListTagsForVaultCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3686,7 +3688,7 @@ export const deserializeAws_restJson1ListVaultsCommand = async (
     Marker: undefined,
     VaultList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }

--- a/clients/client-greengrass/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1.ts
@@ -369,6 +369,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -3424,7 +3426,7 @@ export const deserializeAws_restJson1AssociateRoleToGroupCommand = async (
     $metadata: deserializeMetadata(output),
     AssociatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -3487,7 +3489,7 @@ export const deserializeAws_restJson1AssociateServiceRoleToAccountCommand = asyn
     $metadata: deserializeMetadata(output),
     AssociatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -3556,7 +3558,7 @@ export const deserializeAws_restJson1CreateConnectorDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3632,7 +3634,7 @@ export const deserializeAws_restJson1CreateConnectorDefinitionVersionCommand = a
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3702,7 +3704,7 @@ export const deserializeAws_restJson1CreateCoreDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3778,7 +3780,7 @@ export const deserializeAws_restJson1CreateCoreDefinitionVersionCommand = async 
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3843,7 +3845,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     DeploymentArn: undefined,
     DeploymentId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentArn !== undefined && data.DeploymentArn !== null) {
     contents.DeploymentArn = __expectString(data.DeploymentArn);
   }
@@ -3907,7 +3909,7 @@ export const deserializeAws_restJson1CreateDeviceDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3983,7 +3985,7 @@ export const deserializeAws_restJson1CreateDeviceDefinitionVersionCommand = asyn
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4053,7 +4055,7 @@ export const deserializeAws_restJson1CreateFunctionDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4129,7 +4131,7 @@ export const deserializeAws_restJson1CreateFunctionDefinitionVersionCommand = as
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4199,7 +4201,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4272,7 +4274,7 @@ export const deserializeAws_restJson1CreateGroupCertificateAuthorityCommand = as
     $metadata: deserializeMetadata(output),
     GroupCertificateAuthorityArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupCertificateAuthorityArn !== undefined && data.GroupCertificateAuthorityArn !== null) {
     contents.GroupCertificateAuthorityArn = __expectString(data.GroupCertificateAuthorityArn);
   }
@@ -4338,7 +4340,7 @@ export const deserializeAws_restJson1CreateGroupVersionCommand = async (
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4408,7 +4410,7 @@ export const deserializeAws_restJson1CreateLoggerDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4484,7 +4486,7 @@ export const deserializeAws_restJson1CreateLoggerDefinitionVersionCommand = asyn
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4554,7 +4556,7 @@ export const deserializeAws_restJson1CreateResourceDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4630,7 +4632,7 @@ export const deserializeAws_restJson1CreateResourceDefinitionVersionCommand = as
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4696,7 +4698,7 @@ export const deserializeAws_restJson1CreateSoftwareUpdateJobCommand = async (
     IotJobId: undefined,
     PlatformSoftwareVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IotJobArn !== undefined && data.IotJobArn !== null) {
     contents.IotJobArn = __expectString(data.IotJobArn);
   }
@@ -4771,7 +4773,7 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionCommand = async
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4847,7 +4849,7 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionVersionCommand 
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5319,7 +5321,7 @@ export const deserializeAws_restJson1DisassociateRoleFromGroupCommand = async (
     $metadata: deserializeMetadata(output),
     DisassociatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DisassociatedAt !== undefined && data.DisassociatedAt !== null) {
     contents.DisassociatedAt = __expectString(data.DisassociatedAt);
   }
@@ -5382,7 +5384,7 @@ export const deserializeAws_restJson1DisassociateServiceRoleFromAccountCommand =
     $metadata: deserializeMetadata(output),
     DisassociatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DisassociatedAt !== undefined && data.DisassociatedAt !== null) {
     contents.DisassociatedAt = __expectString(data.DisassociatedAt);
   }
@@ -5438,7 +5440,7 @@ export const deserializeAws_restJson1GetAssociatedRoleCommand = async (
     AssociatedAt: undefined,
     RoleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -5509,7 +5511,7 @@ export const deserializeAws_restJson1GetBulkDeploymentStatusCommand = async (
     ErrorMessage: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkDeploymentMetrics !== undefined && data.BulkDeploymentMetrics !== null) {
     contents.BulkDeploymentMetrics = deserializeAws_restJson1BulkDeploymentMetrics(data.BulkDeploymentMetrics, context);
   }
@@ -5580,7 +5582,7 @@ export const deserializeAws_restJson1GetConnectivityInfoCommand = async (
     ConnectivityInfo: undefined,
     Message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectivityInfo !== undefined && data.ConnectivityInfo !== null) {
     contents.ConnectivityInfo = deserializeAws_restJson1__listOfConnectivityInfo(data.ConnectivityInfo, context);
   }
@@ -5653,7 +5655,7 @@ export const deserializeAws_restJson1GetConnectorDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5734,7 +5736,7 @@ export const deserializeAws_restJson1GetConnectorDefinitionVersionCommand = asyn
     NextToken: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5811,7 +5813,7 @@ export const deserializeAws_restJson1GetCoreDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5892,7 +5894,7 @@ export const deserializeAws_restJson1GetCoreDefinitionVersionCommand = async (
     NextToken: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5966,7 +5968,7 @@ export const deserializeAws_restJson1GetDeploymentStatusCommand = async (
     ErrorMessage: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentStatus !== undefined && data.DeploymentStatus !== null) {
     contents.DeploymentStatus = __expectString(data.DeploymentStatus);
   }
@@ -6040,7 +6042,7 @@ export const deserializeAws_restJson1GetDeviceDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6121,7 +6123,7 @@ export const deserializeAws_restJson1GetDeviceDefinitionVersionCommand = async (
     NextToken: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6198,7 +6200,7 @@ export const deserializeAws_restJson1GetFunctionDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6279,7 +6281,7 @@ export const deserializeAws_restJson1GetFunctionDefinitionVersionCommand = async
     NextToken: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6356,7 +6358,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6434,7 +6436,7 @@ export const deserializeAws_restJson1GetGroupCertificateAuthorityCommand = async
     GroupCertificateAuthorityId: undefined,
     PemEncodedCertificate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupCertificateAuthorityArn !== undefined && data.GroupCertificateAuthorityArn !== null) {
     contents.GroupCertificateAuthorityArn = __expectString(data.GroupCertificateAuthorityArn);
   }
@@ -6505,7 +6507,7 @@ export const deserializeAws_restJson1GetGroupCertificateConfigurationCommand = a
     CertificateExpiryInMilliseconds: undefined,
     GroupId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.CertificateAuthorityExpiryInMilliseconds !== undefined &&
     data.CertificateAuthorityExpiryInMilliseconds !== null
@@ -6581,7 +6583,7 @@ export const deserializeAws_restJson1GetGroupVersionCommand = async (
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6655,7 +6657,7 @@ export const deserializeAws_restJson1GetLoggerDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6735,7 +6737,7 @@ export const deserializeAws_restJson1GetLoggerDefinitionVersionCommand = async (
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6809,7 +6811,7 @@ export const deserializeAws_restJson1GetResourceDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6889,7 +6891,7 @@ export const deserializeAws_restJson1GetResourceDefinitionVersionCommand = async
     Id: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6957,7 +6959,7 @@ export const deserializeAws_restJson1GetServiceRoleForAccountCommand = async (
     AssociatedAt: undefined,
     RoleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -7022,7 +7024,7 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7103,7 +7105,7 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionVersionCommand = a
     NextToken: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7173,7 +7175,7 @@ export const deserializeAws_restJson1GetThingRuntimeConfigurationCommand = async
     $metadata: deserializeMetadata(output),
     RuntimeConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RuntimeConfiguration !== undefined && data.RuntimeConfiguration !== null) {
     contents.RuntimeConfiguration = deserializeAws_restJson1RuntimeConfiguration(data.RuntimeConfiguration, context);
   }
@@ -7237,7 +7239,7 @@ export const deserializeAws_restJson1ListBulkDeploymentDetailedReportsCommand = 
     Deployments: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Deployments !== undefined && data.Deployments !== null) {
     contents.Deployments = deserializeAws_restJson1BulkDeploymentResults(data.Deployments, context);
   }
@@ -7296,7 +7298,7 @@ export const deserializeAws_restJson1ListBulkDeploymentsCommand = async (
     BulkDeployments: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkDeployments !== undefined && data.BulkDeployments !== null) {
     contents.BulkDeployments = deserializeAws_restJson1BulkDeployments(data.BulkDeployments, context);
   }
@@ -7355,7 +7357,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7406,7 +7408,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionVersionsCommand = as
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7465,7 +7467,7 @@ export const deserializeAws_restJson1ListCoreDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7516,7 +7518,7 @@ export const deserializeAws_restJson1ListCoreDefinitionVersionsCommand = async (
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7575,7 +7577,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     Deployments: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Deployments !== undefined && data.Deployments !== null) {
     contents.Deployments = deserializeAws_restJson1Deployments(data.Deployments, context);
   }
@@ -7634,7 +7636,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7685,7 +7687,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionVersionsCommand = async
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7744,7 +7746,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7795,7 +7797,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionVersionsCommand = asy
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7853,7 +7855,7 @@ export const deserializeAws_restJson1ListGroupCertificateAuthoritiesCommand = as
     $metadata: deserializeMetadata(output),
     GroupCertificateAuthorities: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupCertificateAuthorities !== undefined && data.GroupCertificateAuthorities !== null) {
     contents.GroupCertificateAuthorities = deserializeAws_restJson1__listOfGroupCertificateAuthorityProperties(
       data.GroupCertificateAuthorities,
@@ -7920,7 +7922,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     Groups: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Groups !== undefined && data.Groups !== null) {
     contents.Groups = deserializeAws_restJson1__listOfGroupInformation(data.Groups, context);
   }
@@ -7971,7 +7973,7 @@ export const deserializeAws_restJson1ListGroupVersionsCommand = async (
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8030,7 +8032,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -8081,7 +8083,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionVersionsCommand = async
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8140,7 +8142,7 @@ export const deserializeAws_restJson1ListResourceDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -8191,7 +8193,7 @@ export const deserializeAws_restJson1ListResourceDefinitionVersionsCommand = asy
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8250,7 +8252,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionsCommand = async 
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -8301,7 +8303,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionVersionsCommand =
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -8359,7 +8361,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -8415,7 +8417,7 @@ export const deserializeAws_restJson1ResetDeploymentsCommand = async (
     DeploymentArn: undefined,
     DeploymentId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentArn !== undefined && data.DeploymentArn !== null) {
     contents.DeploymentArn = __expectString(data.DeploymentArn);
   }
@@ -8474,7 +8476,7 @@ export const deserializeAws_restJson1StartBulkDeploymentCommand = async (
     BulkDeploymentArn: undefined,
     BulkDeploymentId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkDeploymentArn !== undefined && data.BulkDeploymentArn !== null) {
     contents.BulkDeploymentArn = __expectString(data.BulkDeploymentArn);
   }
@@ -8686,7 +8688,7 @@ export const deserializeAws_restJson1UpdateConnectivityInfoCommand = async (
     Message: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.message !== undefined && data.message !== null) {
     contents.Message = __expectString(data.message);
   }
@@ -9009,7 +9011,7 @@ export const deserializeAws_restJson1UpdateGroupCertificateConfigurationCommand 
     CertificateExpiryInMilliseconds: undefined,
     GroupId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.CertificateAuthorityExpiryInMilliseconds !== undefined &&
     data.CertificateAuthorityExpiryInMilliseconds !== null

--- a/clients/client-greengrassv2/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrassv2/protocols/Aws_restJson1.ts
@@ -105,6 +105,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -877,7 +879,7 @@ export const deserializeAws_restJson1BatchAssociateClientDeviceWithCoreDeviceCom
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1AssociateClientDeviceWithCoreDeviceErrorList(
       data.errorEntries,
@@ -967,7 +969,7 @@ export const deserializeAws_restJson1BatchDisassociateClientDeviceFromCoreDevice
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1DisassociateClientDeviceFromCoreDeviceErrorList(
       data.errorEntries,
@@ -1057,7 +1059,7 @@ export const deserializeAws_restJson1CancelDeploymentCommand = async (
     $metadata: deserializeMetadata(output),
     message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.message !== undefined && data.message !== null) {
     contents.message = __expectString(data.message);
   }
@@ -1156,7 +1158,7 @@ export const deserializeAws_restJson1CreateComponentVersionCommand = async (
     creationTimestamp: undefined,
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1273,7 +1275,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     iotJobArn: undefined,
     iotJobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.deploymentId = __expectString(data.deploymentId);
   }
@@ -1564,7 +1566,7 @@ export const deserializeAws_restJson1DescribeComponentCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1677,7 +1679,7 @@ export const deserializeAws_restJson1GetComponentCommand = async (
     recipeOutputFormat: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recipe !== undefined && data.recipe !== null) {
     contents.recipe = context.base64Decoder(data.recipe);
   }
@@ -1770,7 +1772,7 @@ export const deserializeAws_restJson1GetComponentVersionArtifactCommand = async 
     $metadata: deserializeMetadata(output),
     preSignedUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preSignedUrl !== undefined && data.preSignedUrl !== null) {
     contents.preSignedUrl = __expectString(data.preSignedUrl);
   }
@@ -1863,7 +1865,7 @@ export const deserializeAws_restJson1GetCoreDeviceCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.architecture !== undefined && data.architecture !== null) {
     contents.architecture = __expectString(data.architecture);
   }
@@ -1980,7 +1982,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     tags: undefined,
     targetArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.components !== undefined && data.components !== null) {
     contents.components = deserializeAws_restJson1ComponentDeploymentSpecifications(data.components, context);
   }
@@ -2107,7 +2109,7 @@ export const deserializeAws_restJson1ListClientDevicesAssociatedWithCoreDeviceCo
     associatedClientDevices: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associatedClientDevices !== undefined && data.associatedClientDevices !== null) {
     contents.associatedClientDevices = deserializeAws_restJson1AssociatedClientDeviceList(
       data.associatedClientDevices,
@@ -2201,7 +2203,7 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
     components: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.components !== undefined && data.components !== null) {
     contents.components = deserializeAws_restJson1ComponentList(data.components, context);
   }
@@ -2284,7 +2286,7 @@ export const deserializeAws_restJson1ListComponentVersionsCommand = async (
     componentVersions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentVersions !== undefined && data.componentVersions !== null) {
     contents.componentVersions = deserializeAws_restJson1ComponentVersionList(data.componentVersions, context);
   }
@@ -2375,7 +2377,7 @@ export const deserializeAws_restJson1ListCoreDevicesCommand = async (
     coreDevices: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.coreDevices !== undefined && data.coreDevices !== null) {
     contents.coreDevices = deserializeAws_restJson1CoreDevicesList(data.coreDevices, context);
   }
@@ -2458,7 +2460,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     deployments: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deployments !== undefined && data.deployments !== null) {
     contents.deployments = deserializeAws_restJson1DeploymentList(data.deployments, context);
   }
@@ -2541,7 +2543,7 @@ export const deserializeAws_restJson1ListEffectiveDeploymentsCommand = async (
     effectiveDeployments: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.effectiveDeployments !== undefined && data.effectiveDeployments !== null) {
     contents.effectiveDeployments = deserializeAws_restJson1EffectiveDeploymentsList(
       data.effectiveDeployments,
@@ -2635,7 +2637,7 @@ export const deserializeAws_restJson1ListInstalledComponentsCommand = async (
     installedComponents: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.installedComponents !== undefined && data.installedComponents !== null) {
     contents.installedComponents = deserializeAws_restJson1InstalledComponentList(data.installedComponents, context);
   }
@@ -2725,7 +2727,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -2796,7 +2798,7 @@ export const deserializeAws_restJson1ResolveComponentCandidatesCommand = async (
     $metadata: deserializeMetadata(output),
     resolvedComponentVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolvedComponentVersions !== undefined && data.resolvedComponentVersions !== null) {
     contents.resolvedComponentVersions = deserializeAws_restJson1ResolvedComponentVersionsList(
       data.resolvedComponentVersions,

--- a/clients/client-groundstation/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1.ts
@@ -93,6 +93,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -901,7 +903,7 @@ export const deserializeAws_restJson1CancelContactCommand = async (
     $metadata: deserializeMetadata(output),
     contactId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactId !== undefined && data.contactId !== null) {
     contents.contactId = __expectString(data.contactId);
   }
@@ -974,7 +976,7 @@ export const deserializeAws_restJson1CreateConfigCommand = async (
     configId: undefined,
     configType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -1059,7 +1061,7 @@ export const deserializeAws_restJson1CreateDataflowEndpointGroupCommand = async 
     $metadata: deserializeMetadata(output),
     dataflowEndpointGroupId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupId !== undefined && data.dataflowEndpointGroupId !== null) {
     contents.dataflowEndpointGroupId = __expectString(data.dataflowEndpointGroupId);
   }
@@ -1130,7 +1132,7 @@ export const deserializeAws_restJson1CreateMissionProfileCommand = async (
     $metadata: deserializeMetadata(output),
     missionProfileId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
     contents.missionProfileId = __expectString(data.missionProfileId);
   }
@@ -1203,7 +1205,7 @@ export const deserializeAws_restJson1DeleteConfigCommand = async (
     configId: undefined,
     configType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -1280,7 +1282,7 @@ export const deserializeAws_restJson1DeleteDataflowEndpointGroupCommand = async 
     $metadata: deserializeMetadata(output),
     dataflowEndpointGroupId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupId !== undefined && data.dataflowEndpointGroupId !== null) {
     contents.dataflowEndpointGroupId = __expectString(data.dataflowEndpointGroupId);
   }
@@ -1351,7 +1353,7 @@ export const deserializeAws_restJson1DeleteMissionProfileCommand = async (
     $metadata: deserializeMetadata(output),
     missionProfileId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
     contents.missionProfileId = __expectString(data.missionProfileId);
   }
@@ -1435,7 +1437,7 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     startTime: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactId !== undefined && data.contactId !== null) {
     contents.contactId = __expectString(data.contactId);
   }
@@ -1550,7 +1552,7 @@ export const deserializeAws_restJson1GetConfigCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -1639,7 +1641,7 @@ export const deserializeAws_restJson1GetDataflowEndpointGroupCommand = async (
     endpointsDetails: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupArn !== undefined && data.dataflowEndpointGroupArn !== null) {
     contents.dataflowEndpointGroupArn = __expectString(data.dataflowEndpointGroupArn);
   }
@@ -1723,7 +1725,7 @@ export const deserializeAws_restJson1GetMinuteUsageCommand = async (
     totalScheduledMinutes: undefined,
     upcomingMinutesScheduled: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.estimatedMinutesRemaining !== undefined && data.estimatedMinutesRemaining !== null) {
     contents.estimatedMinutesRemaining = __expectInt32(data.estimatedMinutesRemaining);
   }
@@ -1815,7 +1817,7 @@ export const deserializeAws_restJson1GetMissionProfileCommand = async (
     tags: undefined,
     trackingConfigArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactPostPassDurationSeconds !== undefined && data.contactPostPassDurationSeconds !== null) {
     contents.contactPostPassDurationSeconds = __expectInt32(data.contactPostPassDurationSeconds);
   }
@@ -1916,7 +1918,7 @@ export const deserializeAws_restJson1GetSatelliteCommand = async (
     satelliteArn: undefined,
     satelliteId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.groundStations !== undefined && data.groundStations !== null) {
     contents.groundStations = deserializeAws_restJson1GroundStationIdList(data.groundStations, context);
   }
@@ -1997,7 +1999,7 @@ export const deserializeAws_restJson1ListConfigsCommand = async (
     configList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configList !== undefined && data.configList !== null) {
     contents.configList = deserializeAws_restJson1ConfigList(data.configList, context);
   }
@@ -2072,7 +2074,7 @@ export const deserializeAws_restJson1ListContactsCommand = async (
     contactList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactList !== undefined && data.contactList !== null) {
     contents.contactList = deserializeAws_restJson1ContactList(data.contactList, context);
   }
@@ -2147,7 +2149,7 @@ export const deserializeAws_restJson1ListDataflowEndpointGroupsCommand = async (
     dataflowEndpointGroupList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupList !== undefined && data.dataflowEndpointGroupList !== null) {
     contents.dataflowEndpointGroupList = deserializeAws_restJson1DataflowEndpointGroupList(
       data.dataflowEndpointGroupList,
@@ -2225,7 +2227,7 @@ export const deserializeAws_restJson1ListGroundStationsCommand = async (
     groundStationList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.groundStationList !== undefined && data.groundStationList !== null) {
     contents.groundStationList = deserializeAws_restJson1GroundStationList(data.groundStationList, context);
   }
@@ -2300,7 +2302,7 @@ export const deserializeAws_restJson1ListMissionProfilesCommand = async (
     missionProfileList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileList !== undefined && data.missionProfileList !== null) {
     contents.missionProfileList = deserializeAws_restJson1MissionProfileList(data.missionProfileList, context);
   }
@@ -2375,7 +2377,7 @@ export const deserializeAws_restJson1ListSatellitesCommand = async (
     nextToken: undefined,
     satellites: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2449,7 +2451,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2520,7 +2522,7 @@ export const deserializeAws_restJson1ReserveContactCommand = async (
     $metadata: deserializeMetadata(output),
     contactId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactId !== undefined && data.contactId !== null) {
     contents.contactId = __expectString(data.contactId);
   }
@@ -2727,7 +2729,7 @@ export const deserializeAws_restJson1UpdateConfigCommand = async (
     configId: undefined,
     configType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -2804,7 +2806,7 @@ export const deserializeAws_restJson1UpdateMissionProfileCommand = async (
     $metadata: deserializeMetadata(output),
     missionProfileId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
     contents.missionProfileId = __expectString(data.missionProfileId);
   }

--- a/clients/client-guardduty/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1.ts
@@ -207,6 +207,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -2387,7 +2389,7 @@ export const deserializeAws_restJson1CreateDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     DetectorId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorId !== undefined && data.detectorId !== null) {
     contents.DetectorId = __expectString(data.detectorId);
   }
@@ -2450,7 +2452,7 @@ export const deserializeAws_restJson1CreateFilterCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.name !== undefined && data.name !== null) {
     contents.Name = __expectString(data.name);
   }
@@ -2513,7 +2515,7 @@ export const deserializeAws_restJson1CreateIPSetCommand = async (
     $metadata: deserializeMetadata(output),
     IpSetId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ipSetId !== undefined && data.ipSetId !== null) {
     contents.IpSetId = __expectString(data.ipSetId);
   }
@@ -2576,7 +2578,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -2639,7 +2641,7 @@ export const deserializeAws_restJson1CreatePublishingDestinationCommand = async 
     $metadata: deserializeMetadata(output),
     DestinationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinationId !== undefined && data.destinationId !== null) {
     contents.DestinationId = __expectString(data.destinationId);
   }
@@ -2761,7 +2763,7 @@ export const deserializeAws_restJson1CreateThreatIntelSetCommand = async (
     $metadata: deserializeMetadata(output),
     ThreatIntelSetId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.threatIntelSetId !== undefined && data.threatIntelSetId !== null) {
     contents.ThreatIntelSetId = __expectString(data.threatIntelSetId);
   }
@@ -2824,7 +2826,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -3005,7 +3007,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -3127,7 +3129,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -3310,7 +3312,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     DataSources: undefined,
     MemberAccountLimitReached: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
     contents.AutoEnable = __expectBoolean(data.autoEnable);
   }
@@ -3386,7 +3388,7 @@ export const deserializeAws_restJson1DescribePublishingDestinationCommand = asyn
     PublishingFailureStartTimestamp: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinationId !== undefined && data.destinationId !== null) {
     contents.DestinationId = __expectString(data.destinationId);
   }
@@ -3579,7 +3581,7 @@ export const deserializeAws_restJson1DisassociateMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -3707,7 +3709,7 @@ export const deserializeAws_restJson1GetDetectorCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.CreatedAt = __expectString(data.createdAt);
   }
@@ -3793,7 +3795,7 @@ export const deserializeAws_restJson1GetFilterCommand = async (
     Rank: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.action !== undefined && data.action !== null) {
     contents.Action = __expectString(data.action);
   }
@@ -3871,7 +3873,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
     $metadata: deserializeMetadata(output),
     Findings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.Findings = deserializeAws_restJson1Findings(data.findings, context);
   }
@@ -3934,7 +3936,7 @@ export const deserializeAws_restJson1GetFindingsStatisticsCommand = async (
     $metadata: deserializeMetadata(output),
     FindingStatistics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingStatistics !== undefined && data.findingStatistics !== null) {
     contents.FindingStatistics = deserializeAws_restJson1FindingStatistics(data.findingStatistics, context);
   }
@@ -3997,7 +3999,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
     $metadata: deserializeMetadata(output),
     InvitationsCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitationsCount !== undefined && data.invitationsCount !== null) {
     contents.InvitationsCount = __expectInt32(data.invitationsCount);
   }
@@ -4064,7 +4066,7 @@ export const deserializeAws_restJson1GetIPSetCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.format !== undefined && data.format !== null) {
     contents.Format = __expectString(data.format);
   }
@@ -4139,7 +4141,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Master: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.master !== undefined && data.master !== null) {
     contents.Master = deserializeAws_restJson1Master(data.master, context);
   }
@@ -4203,7 +4205,7 @@ export const deserializeAws_restJson1GetMemberDetectorsCommand = async (
     MemberDataSourceConfigurations: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.MemberDataSourceConfigurations = deserializeAws_restJson1MemberDataSourceConfigurations(
       data.members,
@@ -4273,7 +4275,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
     Members: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.Members = deserializeAws_restJson1Members(data.members, context);
   }
@@ -4343,7 +4345,7 @@ export const deserializeAws_restJson1GetThreatIntelSetCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.format !== undefined && data.format !== null) {
     contents.Format = __expectString(data.format);
   }
@@ -4419,7 +4421,7 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
     NextToken: undefined,
     UsageStatistics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -4485,7 +4487,7 @@ export const deserializeAws_restJson1InviteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -4549,7 +4551,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
     DetectorIds: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorIds !== undefined && data.detectorIds !== null) {
     contents.DetectorIds = deserializeAws_restJson1DetectorIds(data.detectorIds, context);
   }
@@ -4616,7 +4618,7 @@ export const deserializeAws_restJson1ListFiltersCommand = async (
     FilterNames: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.filterNames !== undefined && data.filterNames !== null) {
     contents.FilterNames = deserializeAws_restJson1FilterNames(data.filterNames, context);
   }
@@ -4683,7 +4685,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     FindingIds: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingIds !== undefined && data.findingIds !== null) {
     contents.FindingIds = deserializeAws_restJson1FindingIds(data.findingIds, context);
   }
@@ -4750,7 +4752,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitations !== undefined && data.invitations !== null) {
     contents.Invitations = deserializeAws_restJson1Invitations(data.invitations, context);
   }
@@ -4817,7 +4819,7 @@ export const deserializeAws_restJson1ListIPSetsCommand = async (
     IpSetIds: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ipSetIds !== undefined && data.ipSetIds !== null) {
     contents.IpSetIds = deserializeAws_restJson1IpSetIds(data.ipSetIds, context);
   }
@@ -4884,7 +4886,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     Members: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.Members = deserializeAws_restJson1Members(data.members, context);
   }
@@ -4951,7 +4953,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     AdminAccounts: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccounts !== undefined && data.adminAccounts !== null) {
     contents.AdminAccounts = deserializeAws_restJson1AdminAccounts(data.adminAccounts, context);
   }
@@ -5018,7 +5020,7 @@ export const deserializeAws_restJson1ListPublishingDestinationsCommand = async (
     Destinations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinations !== undefined && data.destinations !== null) {
     contents.Destinations = deserializeAws_restJson1Destinations(data.destinations, context);
   }
@@ -5084,7 +5086,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -5148,7 +5150,7 @@ export const deserializeAws_restJson1ListThreatIntelSetsCommand = async (
     NextToken: undefined,
     ThreatIntelSetIds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -5214,7 +5216,7 @@ export const deserializeAws_restJson1StartMonitoringMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -5277,7 +5279,7 @@ export const deserializeAws_restJson1StopMonitoringMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -5576,7 +5578,7 @@ export const deserializeAws_restJson1UpdateFilterCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.name !== undefined && data.name !== null) {
     contents.Name = __expectString(data.name);
   }
@@ -5757,7 +5759,7 @@ export const deserializeAws_restJson1UpdateMemberDetectorsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }

--- a/clients/client-honeycode/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/protocols/Aws_restJson1.ts
@@ -72,6 +72,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -657,7 +659,7 @@ export const deserializeAws_restJson1BatchCreateTableRowsCommand = async (
     failedBatchItems: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdRows !== undefined && data.createdRows !== null) {
     contents.createdRows = deserializeAws_restJson1CreatedRowsMap(data.createdRows, context);
   }
@@ -775,7 +777,7 @@ export const deserializeAws_restJson1BatchDeleteTableRowsCommand = async (
     failedBatchItems: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedBatchItems !== undefined && data.failedBatchItems !== null) {
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
@@ -882,7 +884,7 @@ export const deserializeAws_restJson1BatchUpdateTableRowsCommand = async (
     failedBatchItems: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedBatchItems !== undefined && data.failedBatchItems !== null) {
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
@@ -990,7 +992,7 @@ export const deserializeAws_restJson1BatchUpsertTableRowsCommand = async (
     rows: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedBatchItems !== undefined && data.failedBatchItems !== null) {
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
@@ -1109,7 +1111,7 @@ export const deserializeAws_restJson1DescribeTableDataImportJobCommand = async (
     jobStatus: undefined,
     message: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobMetadata !== undefined && data.jobMetadata !== null) {
     contents.jobMetadata = deserializeAws_restJson1TableDataImportJobMetadata(data.jobMetadata, context);
   }
@@ -1212,7 +1214,7 @@ export const deserializeAws_restJson1GetScreenDataCommand = async (
     results: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1321,7 +1323,7 @@ export const deserializeAws_restJson1InvokeScreenAutomationCommand = async (
     $metadata: deserializeMetadata(output),
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
     contents.workbookCursor = __expectLong(data.workbookCursor);
   }
@@ -1442,7 +1444,7 @@ export const deserializeAws_restJson1ListTableColumnsCommand = async (
     tableColumns: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1555,7 +1557,7 @@ export const deserializeAws_restJson1ListTableRowsCommand = async (
     rows: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.columnIds !== undefined && data.columnIds !== null) {
     contents.columnIds = deserializeAws_restJson1ResourceIds(data.columnIds, context);
   }
@@ -1672,7 +1674,7 @@ export const deserializeAws_restJson1ListTablesCommand = async (
     tables: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1784,7 +1786,7 @@ export const deserializeAws_restJson1QueryTableRowsCommand = async (
     rows: undefined,
     workbookCursor: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.columnIds !== undefined && data.columnIds !== null) {
     contents.columnIds = deserializeAws_restJson1ResourceIds(data.columnIds, context);
   }
@@ -1897,7 +1899,7 @@ export const deserializeAws_restJson1StartTableDataImportJobCommand = async (
     jobId: undefined,
     jobStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobId !== undefined && data.jobId !== null) {
     contents.jobId = __expectString(data.jobId);
   }

--- a/clients/client-imagebuilder/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1.ts
@@ -187,6 +187,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1688,7 +1690,7 @@ export const deserializeAws_restJson1CancelImageCreationCommand = async (
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1807,7 +1809,7 @@ export const deserializeAws_restJson1CreateComponentCommand = async (
     componentBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1950,7 +1952,7 @@ export const deserializeAws_restJson1CreateContainerRecipeCommand = async (
     containerRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2093,7 +2095,7 @@ export const deserializeAws_restJson1CreateDistributionConfigurationCommand = as
     distributionConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2236,7 +2238,7 @@ export const deserializeAws_restJson1CreateImageCommand = async (
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2363,7 +2365,7 @@ export const deserializeAws_restJson1CreateImagePipelineCommand = async (
     imagePipelineArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2498,7 +2500,7 @@ export const deserializeAws_restJson1CreateImageRecipeCommand = async (
     imageRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2641,7 +2643,7 @@ export const deserializeAws_restJson1CreateInfrastructureConfigurationCommand = 
     infrastructureConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2775,7 +2777,7 @@ export const deserializeAws_restJson1DeleteComponentCommand = async (
     componentBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentBuildVersionArn !== undefined && data.componentBuildVersionArn !== null) {
     contents.componentBuildVersionArn = __expectString(data.componentBuildVersionArn);
   }
@@ -2882,7 +2884,7 @@ export const deserializeAws_restJson1DeleteContainerRecipeCommand = async (
     containerRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipeArn !== undefined && data.containerRecipeArn !== null) {
     contents.containerRecipeArn = __expectString(data.containerRecipeArn);
   }
@@ -2989,7 +2991,7 @@ export const deserializeAws_restJson1DeleteDistributionConfigurationCommand = as
     distributionConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.distributionConfigurationArn !== undefined && data.distributionConfigurationArn !== null) {
     contents.distributionConfigurationArn = __expectString(data.distributionConfigurationArn);
   }
@@ -3096,7 +3098,7 @@ export const deserializeAws_restJson1DeleteImageCommand = async (
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageBuildVersionArn !== undefined && data.imageBuildVersionArn !== null) {
     contents.imageBuildVersionArn = __expectString(data.imageBuildVersionArn);
   }
@@ -3203,7 +3205,7 @@ export const deserializeAws_restJson1DeleteImagePipelineCommand = async (
     imagePipelineArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePipelineArn !== undefined && data.imagePipelineArn !== null) {
     contents.imagePipelineArn = __expectString(data.imagePipelineArn);
   }
@@ -3310,7 +3312,7 @@ export const deserializeAws_restJson1DeleteImageRecipeCommand = async (
     imageRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipeArn !== undefined && data.imageRecipeArn !== null) {
     contents.imageRecipeArn = __expectString(data.imageRecipeArn);
   }
@@ -3417,7 +3419,7 @@ export const deserializeAws_restJson1DeleteInfrastructureConfigurationCommand = 
     infrastructureConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.infrastructureConfigurationArn !== undefined && data.infrastructureConfigurationArn !== null) {
     contents.infrastructureConfigurationArn = __expectString(data.infrastructureConfigurationArn);
   }
@@ -3524,7 +3526,7 @@ export const deserializeAws_restJson1GetComponentCommand = async (
     component: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.component !== undefined && data.component !== null) {
     contents.component = deserializeAws_restJson1Component(data.component, context);
   }
@@ -3623,7 +3625,7 @@ export const deserializeAws_restJson1GetComponentPolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -3722,7 +3724,7 @@ export const deserializeAws_restJson1GetContainerRecipeCommand = async (
     containerRecipe: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipe !== undefined && data.containerRecipe !== null) {
     contents.containerRecipe = deserializeAws_restJson1ContainerRecipe(data.containerRecipe, context);
   }
@@ -3821,7 +3823,7 @@ export const deserializeAws_restJson1GetContainerRecipePolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -3920,7 +3922,7 @@ export const deserializeAws_restJson1GetDistributionConfigurationCommand = async
     distributionConfiguration: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.distributionConfiguration !== undefined && data.distributionConfiguration !== null) {
     contents.distributionConfiguration = deserializeAws_restJson1DistributionConfiguration(
       data.distributionConfiguration,
@@ -4022,7 +4024,7 @@ export const deserializeAws_restJson1GetImageCommand = async (
     image: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.image !== undefined && data.image !== null) {
     contents.image = deserializeAws_restJson1Image(data.image, context);
   }
@@ -4121,7 +4123,7 @@ export const deserializeAws_restJson1GetImagePipelineCommand = async (
     imagePipeline: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePipeline !== undefined && data.imagePipeline !== null) {
     contents.imagePipeline = deserializeAws_restJson1ImagePipeline(data.imagePipeline, context);
   }
@@ -4220,7 +4222,7 @@ export const deserializeAws_restJson1GetImagePolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -4319,7 +4321,7 @@ export const deserializeAws_restJson1GetImageRecipeCommand = async (
     imageRecipe: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipe !== undefined && data.imageRecipe !== null) {
     contents.imageRecipe = deserializeAws_restJson1ImageRecipe(data.imageRecipe, context);
   }
@@ -4418,7 +4420,7 @@ export const deserializeAws_restJson1GetImageRecipePolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -4517,7 +4519,7 @@ export const deserializeAws_restJson1GetInfrastructureConfigurationCommand = asy
     infrastructureConfiguration: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.infrastructureConfiguration !== undefined && data.infrastructureConfiguration !== null) {
     contents.infrastructureConfiguration = deserializeAws_restJson1InfrastructureConfiguration(
       data.infrastructureConfiguration,
@@ -4620,7 +4622,7 @@ export const deserializeAws_restJson1ImportComponentCommand = async (
     componentBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -4755,7 +4757,7 @@ export const deserializeAws_restJson1ListComponentBuildVersionsCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentSummaryList !== undefined && data.componentSummaryList !== null) {
     contents.componentSummaryList = deserializeAws_restJson1ComponentSummaryList(data.componentSummaryList, context);
   }
@@ -4866,7 +4868,7 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentVersionList !== undefined && data.componentVersionList !== null) {
     contents.componentVersionList = deserializeAws_restJson1ComponentVersionList(data.componentVersionList, context);
   }
@@ -4977,7 +4979,7 @@ export const deserializeAws_restJson1ListContainerRecipesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipeSummaryList !== undefined && data.containerRecipeSummaryList !== null) {
     contents.containerRecipeSummaryList = deserializeAws_restJson1ContainerRecipeSummaryList(
       data.containerRecipeSummaryList,
@@ -5091,7 +5093,7 @@ export const deserializeAws_restJson1ListDistributionConfigurationsCommand = asy
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.distributionConfigurationSummaryList !== undefined && data.distributionConfigurationSummaryList !== null) {
     contents.distributionConfigurationSummaryList = deserializeAws_restJson1DistributionConfigurationSummaryList(
       data.distributionConfigurationSummaryList,
@@ -5205,7 +5207,7 @@ export const deserializeAws_restJson1ListImageBuildVersionsCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageSummaryList !== undefined && data.imageSummaryList !== null) {
     contents.imageSummaryList = deserializeAws_restJson1ImageSummaryList(data.imageSummaryList, context);
   }
@@ -5316,7 +5318,7 @@ export const deserializeAws_restJson1ListImagePackagesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePackageList !== undefined && data.imagePackageList !== null) {
     contents.imagePackageList = deserializeAws_restJson1ImagePackageList(data.imagePackageList, context);
   }
@@ -5435,7 +5437,7 @@ export const deserializeAws_restJson1ListImagePipelineImagesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageSummaryList !== undefined && data.imageSummaryList !== null) {
     contents.imageSummaryList = deserializeAws_restJson1ImageSummaryList(data.imageSummaryList, context);
   }
@@ -5554,7 +5556,7 @@ export const deserializeAws_restJson1ListImagePipelinesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePipelineList !== undefined && data.imagePipelineList !== null) {
     contents.imagePipelineList = deserializeAws_restJson1ImagePipelineList(data.imagePipelineList, context);
   }
@@ -5665,7 +5667,7 @@ export const deserializeAws_restJson1ListImageRecipesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipeSummaryList !== undefined && data.imageRecipeSummaryList !== null) {
     contents.imageRecipeSummaryList = deserializeAws_restJson1ImageRecipeSummaryList(
       data.imageRecipeSummaryList,
@@ -5779,7 +5781,7 @@ export const deserializeAws_restJson1ListImagesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageVersionList !== undefined && data.imageVersionList !== null) {
     contents.imageVersionList = deserializeAws_restJson1ImageVersionList(data.imageVersionList, context);
   }
@@ -5890,7 +5892,7 @@ export const deserializeAws_restJson1ListInfrastructureConfigurationsCommand = a
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.infrastructureConfigurationSummaryList !== undefined &&
     data.infrastructureConfigurationSummaryList !== null
@@ -6005,7 +6007,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -6077,7 +6079,7 @@ export const deserializeAws_restJson1PutComponentPolicyCommand = async (
     componentArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentArn !== undefined && data.componentArn !== null) {
     contents.componentArn = __expectString(data.componentArn);
   }
@@ -6192,7 +6194,7 @@ export const deserializeAws_restJson1PutContainerRecipePolicyCommand = async (
     containerRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipeArn !== undefined && data.containerRecipeArn !== null) {
     contents.containerRecipeArn = __expectString(data.containerRecipeArn);
   }
@@ -6307,7 +6309,7 @@ export const deserializeAws_restJson1PutImagePolicyCommand = async (
     imageArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageArn !== undefined && data.imageArn !== null) {
     contents.imageArn = __expectString(data.imageArn);
   }
@@ -6422,7 +6424,7 @@ export const deserializeAws_restJson1PutImageRecipePolicyCommand = async (
     imageRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipeArn !== undefined && data.imageRecipeArn !== null) {
     contents.imageRecipeArn = __expectString(data.imageRecipeArn);
   }
@@ -6538,7 +6540,7 @@ export const deserializeAws_restJson1StartImagePipelineExecutionCommand = async 
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -6799,7 +6801,7 @@ export const deserializeAws_restJson1UpdateDistributionConfigurationCommand = as
     distributionConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -6926,7 +6928,7 @@ export const deserializeAws_restJson1UpdateImagePipelineCommand = async (
     imagePipelineArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -7045,7 +7047,7 @@ export const deserializeAws_restJson1UpdateInfrastructureConfigurationCommand = 
     infrastructureConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
@@ -41,6 +41,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -473,7 +475,7 @@ export const deserializeAws_restJson1ClaimDevicesByClaimCodeCommand = async (
     ClaimCode: undefined,
     Total: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.claimCode !== undefined && data.claimCode !== null) {
     contents.ClaimCode = __expectString(data.claimCode);
   }
@@ -547,7 +549,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceDescription !== undefined && data.deviceDescription !== null) {
     contents.DeviceDescription = deserializeAws_restJson1DeviceDescription(data.deviceDescription, context);
   }
@@ -618,7 +620,7 @@ export const deserializeAws_restJson1FinalizeDeviceClaimCommand = async (
     $metadata: deserializeMetadata(output),
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.State = __expectString(data.state);
   }
@@ -705,7 +707,7 @@ export const deserializeAws_restJson1GetDeviceMethodsCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceMethods: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceMethods !== undefined && data.deviceMethods !== null) {
     contents.DeviceMethods = deserializeAws_restJson1__listOfDeviceMethod(data.deviceMethods, context);
   }
@@ -776,7 +778,7 @@ export const deserializeAws_restJson1InitiateDeviceClaimCommand = async (
     $metadata: deserializeMetadata(output),
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.State = __expectString(data.state);
   }
@@ -855,7 +857,7 @@ export const deserializeAws_restJson1InvokeDeviceMethodCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceMethodResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceMethodResponse !== undefined && data.deviceMethodResponse !== null) {
     contents.DeviceMethodResponse = __expectString(data.deviceMethodResponse);
   }
@@ -951,7 +953,7 @@ export const deserializeAws_restJson1ListDeviceEventsCommand = async (
     Events: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.events !== undefined && data.events !== null) {
     contents.Events = deserializeAws_restJson1__listOfDeviceEvent(data.events, context);
   }
@@ -1034,7 +1036,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     Devices: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.Devices = deserializeAws_restJson1__listOfDeviceDescription(data.devices, context);
   }
@@ -1108,7 +1110,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -1238,7 +1240,7 @@ export const deserializeAws_restJson1UnclaimDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.State = __expectString(data.state);
   }

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
@@ -41,6 +41,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1007,7 +1009,7 @@ export const deserializeAws_restJson1DescribePlacementCommand = async (
     $metadata: deserializeMetadata(output),
     placement: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.placement !== undefined && data.placement !== null) {
     contents.placement = deserializeAws_restJson1PlacementDescription(data.placement, context);
   }
@@ -1078,7 +1080,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     $metadata: deserializeMetadata(output),
     project: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.project !== undefined && data.project !== null) {
     contents.project = deserializeAws_restJson1ProjectDescription(data.project, context);
   }
@@ -1224,7 +1226,7 @@ export const deserializeAws_restJson1GetDevicesInPlacementCommand = async (
     $metadata: deserializeMetadata(output),
     devices: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.devices = deserializeAws_restJson1DeviceMap(data.devices, context);
   }
@@ -1296,7 +1298,7 @@ export const deserializeAws_restJson1ListPlacementsCommand = async (
     nextToken: undefined,
     placements: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1371,7 +1373,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     nextToken: undefined,
     projects: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1437,7 +1439,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
@@ -28,6 +28,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -391,7 +393,7 @@ export const deserializeAws_restJson1GetRetainedMessageCommand = async (
     qos: undefined,
     topic: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.lastModifiedTime !== undefined && data.lastModifiedTime !== null) {
     contents.lastModifiedTime = __expectLong(data.lastModifiedTime);
   }
@@ -614,7 +616,7 @@ export const deserializeAws_restJson1ListNamedShadowsForThingCommand = async (
     results: undefined,
     timestamp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -724,7 +726,7 @@ export const deserializeAws_restJson1ListRetainedMessagesCommand = async (
     nextToken: undefined,
     retainedTopics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-iot-events-data/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1.ts
@@ -58,6 +58,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -404,7 +406,7 @@ export const deserializeAws_restJson1BatchAcknowledgeAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -483,7 +485,7 @@ export const deserializeAws_restJson1BatchDisableAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -562,7 +564,7 @@ export const deserializeAws_restJson1BatchEnableAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -641,7 +643,7 @@ export const deserializeAws_restJson1BatchPutMessageCommand = async (
     $metadata: deserializeMetadata(output),
     BatchPutMessageErrorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchPutMessageErrorEntries !== undefined && data.BatchPutMessageErrorEntries !== null) {
     contents.BatchPutMessageErrorEntries = deserializeAws_restJson1BatchPutMessageErrorEntries(
       data.BatchPutMessageErrorEntries,
@@ -723,7 +725,7 @@ export const deserializeAws_restJson1BatchResetAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -802,7 +804,7 @@ export const deserializeAws_restJson1BatchSnoozeAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -881,7 +883,7 @@ export const deserializeAws_restJson1BatchUpdateDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     batchUpdateDetectorErrorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.batchUpdateDetectorErrorEntries !== undefined && data.batchUpdateDetectorErrorEntries !== null) {
     contents.batchUpdateDetectorErrorEntries = deserializeAws_restJson1BatchUpdateDetectorErrorEntries(
       data.batchUpdateDetectorErrorEntries,
@@ -963,7 +965,7 @@ export const deserializeAws_restJson1DescribeAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     alarm: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarm !== undefined && data.alarm !== null) {
     contents.alarm = deserializeAws_restJson1Alarm(data.alarm, context);
   }
@@ -1050,7 +1052,7 @@ export const deserializeAws_restJson1DescribeDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     detector: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detector !== undefined && data.detector !== null) {
     contents.detector = deserializeAws_restJson1Detector(data.detector, context);
   }
@@ -1138,7 +1140,7 @@ export const deserializeAws_restJson1ListAlarmsCommand = async (
     alarmSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmSummaries !== undefined && data.alarmSummaries !== null) {
     contents.alarmSummaries = deserializeAws_restJson1AlarmSummaries(data.alarmSummaries, context);
   }
@@ -1229,7 +1231,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
     detectorSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorSummaries !== undefined && data.detectorSummaries !== null) {
     contents.detectorSummaries = deserializeAws_restJson1DetectorSummaries(data.detectorSummaries, context);
   }

--- a/clients/client-iot-events/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1.ts
@@ -134,6 +134,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -969,7 +971,7 @@ export const deserializeAws_restJson1CreateAlarmModelCommand = async (
     lastUpdateTime: undefined,
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelArn !== undefined && data.alarmModelArn !== null) {
     contents.alarmModelArn = __expectString(data.alarmModelArn);
   }
@@ -1084,7 +1086,7 @@ export const deserializeAws_restJson1CreateDetectorModelCommand = async (
     $metadata: deserializeMetadata(output),
     detectorModelConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelConfiguration !== undefined && data.detectorModelConfiguration !== null) {
     contents.detectorModelConfiguration = deserializeAws_restJson1DetectorModelConfiguration(
       data.detectorModelConfiguration,
@@ -1190,7 +1192,7 @@ export const deserializeAws_restJson1CreateInputCommand = async (
     $metadata: deserializeMetadata(output),
     inputConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputConfiguration !== undefined && data.inputConfiguration !== null) {
     contents.inputConfiguration = deserializeAws_restJson1InputConfiguration(data.inputConfiguration, context);
   }
@@ -1564,7 +1566,7 @@ export const deserializeAws_restJson1DescribeAlarmModelCommand = async (
     status: undefined,
     statusMessage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmCapabilities !== undefined && data.alarmCapabilities !== null) {
     contents.alarmCapabilities = deserializeAws_restJson1AlarmCapabilities(data.alarmCapabilities, context);
   }
@@ -1693,7 +1695,7 @@ export const deserializeAws_restJson1DescribeDetectorModelCommand = async (
     $metadata: deserializeMetadata(output),
     detectorModel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModel !== undefined && data.detectorModel !== null) {
     contents.detectorModel = deserializeAws_restJson1DetectorModel(data.detectorModel, context);
   }
@@ -1780,7 +1782,7 @@ export const deserializeAws_restJson1DescribeDetectorModelAnalysisCommand = asyn
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -1867,7 +1869,7 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
     $metadata: deserializeMetadata(output),
     input: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -1954,7 +1956,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
     $metadata: deserializeMetadata(output),
     loggingOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.loggingOptions !== undefined && data.loggingOptions !== null) {
     contents.loggingOptions = deserializeAws_restJson1LoggingOptions(data.loggingOptions, context);
   }
@@ -2050,7 +2052,7 @@ export const deserializeAws_restJson1GetDetectorModelAnalysisResultsCommand = as
     analysisResults: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analysisResults !== undefined && data.analysisResults !== null) {
     contents.analysisResults = deserializeAws_restJson1AnalysisResults(data.analysisResults, context);
   }
@@ -2141,7 +2143,7 @@ export const deserializeAws_restJson1ListAlarmModelsCommand = async (
     alarmModelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelSummaries !== undefined && data.alarmModelSummaries !== null) {
     contents.alarmModelSummaries = deserializeAws_restJson1AlarmModelSummaries(data.alarmModelSummaries, context);
   }
@@ -2224,7 +2226,7 @@ export const deserializeAws_restJson1ListAlarmModelVersionsCommand = async (
     alarmModelVersionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelVersionSummaries !== undefined && data.alarmModelVersionSummaries !== null) {
     contents.alarmModelVersionSummaries = deserializeAws_restJson1AlarmModelVersionSummaries(
       data.alarmModelVersionSummaries,
@@ -2318,7 +2320,7 @@ export const deserializeAws_restJson1ListDetectorModelsCommand = async (
     detectorModelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelSummaries !== undefined && data.detectorModelSummaries !== null) {
     contents.detectorModelSummaries = deserializeAws_restJson1DetectorModelSummaries(
       data.detectorModelSummaries,
@@ -2404,7 +2406,7 @@ export const deserializeAws_restJson1ListDetectorModelVersionsCommand = async (
     detectorModelVersionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelVersionSummaries !== undefined && data.detectorModelVersionSummaries !== null) {
     contents.detectorModelVersionSummaries = deserializeAws_restJson1DetectorModelVersionSummaries(
       data.detectorModelVersionSummaries,
@@ -2498,7 +2500,7 @@ export const deserializeAws_restJson1ListInputRoutingsCommand = async (
     nextToken: undefined,
     routedResources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2589,7 +2591,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
     inputSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputSummaries !== undefined && data.inputSummaries !== null) {
     contents.inputSummaries = deserializeAws_restJson1InputSummaries(data.inputSummaries, context);
   }
@@ -2671,7 +2673,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -2849,7 +2851,7 @@ export const deserializeAws_restJson1StartDetectorModelAnalysisCommand = async (
     $metadata: deserializeMetadata(output),
     analysisId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analysisId !== undefined && data.analysisId !== null) {
     contents.analysisId = __expectString(data.analysisId);
   }
@@ -3114,7 +3116,7 @@ export const deserializeAws_restJson1UpdateAlarmModelCommand = async (
     lastUpdateTime: undefined,
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelArn !== undefined && data.alarmModelArn !== null) {
     contents.alarmModelArn = __expectString(data.alarmModelArn);
   }
@@ -3221,7 +3223,7 @@ export const deserializeAws_restJson1UpdateDetectorModelCommand = async (
     $metadata: deserializeMetadata(output),
     detectorModelConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelConfiguration !== undefined && data.detectorModelConfiguration !== null) {
     contents.detectorModelConfiguration = deserializeAws_restJson1DetectorModelConfiguration(
       data.detectorModelConfiguration,
@@ -3319,7 +3321,7 @@ export const deserializeAws_restJson1UpdateInputCommand = async (
     $metadata: deserializeMetadata(output),
     inputConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputConfiguration !== undefined && data.inputConfiguration !== null) {
     contents.inputConfiguration = deserializeAws_restJson1InputConfiguration(data.inputConfiguration, context);
   }

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
@@ -26,6 +26,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -215,7 +217,7 @@ export const deserializeAws_restJson1DescribeJobExecutionCommand = async (
     $metadata: deserializeMetadata(output),
     execution: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.execution !== undefined && data.execution !== null) {
     contents.execution = deserializeAws_restJson1JobExecution(data.execution, context);
   }
@@ -311,7 +313,7 @@ export const deserializeAws_restJson1GetPendingJobExecutionsCommand = async (
     inProgressJobs: undefined,
     queuedJobs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inProgressJobs !== undefined && data.inProgressJobs !== null) {
     contents.inProgressJobs = deserializeAws_restJson1JobExecutionSummaryList(data.inProgressJobs, context);
   }
@@ -401,7 +403,7 @@ export const deserializeAws_restJson1StartNextPendingJobExecutionCommand = async
     $metadata: deserializeMetadata(output),
     execution: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.execution !== undefined && data.execution !== null) {
     contents.execution = deserializeAws_restJson1JobExecution(data.execution, context);
   }
@@ -489,7 +491,7 @@ export const deserializeAws_restJson1UpdateJobExecutionCommand = async (
     executionState: undefined,
     jobDocument: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionState !== undefined && data.executionState !== null) {
     contents.executionState = deserializeAws_restJson1JobExecutionState(data.executionState, context);
   }

--- a/clients/client-iot-wireless/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-wireless/protocols/Aws_restJson1.ts
@@ -236,6 +236,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1976,7 +1978,7 @@ export const deserializeAws_restJson1AssociateAwsAccountWithPartnerAccountComman
     Arn: undefined,
     Sidewalk: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2165,7 +2167,7 @@ export const deserializeAws_restJson1AssociateWirelessGatewayWithCertificateComm
     $metadata: deserializeMetadata(output),
     IotCertificateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IotCertificateId !== undefined && data.IotCertificateId !== null) {
     contents.IotCertificateId = __expectString(data.IotCertificateId);
   }
@@ -2352,7 +2354,7 @@ export const deserializeAws_restJson1CreateDestinationCommand = async (
     Arn: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2451,7 +2453,7 @@ export const deserializeAws_restJson1CreateDeviceProfileCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2542,7 +2544,7 @@ export const deserializeAws_restJson1CreateServiceProfileCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2633,7 +2635,7 @@ export const deserializeAws_restJson1CreateWirelessDeviceCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2732,7 +2734,7 @@ export const deserializeAws_restJson1CreateWirelessGatewayCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2823,7 +2825,7 @@ export const deserializeAws_restJson1CreateWirelessGatewayTaskCommand = async (
     Status: undefined,
     WirelessGatewayTaskDefinitionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -2922,7 +2924,7 @@ export const deserializeAws_restJson1CreateWirelessGatewayTaskDefinitionCommand 
     Arn: undefined,
     Id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3970,7 +3972,7 @@ export const deserializeAws_restJson1GetDestinationCommand = async (
     Name: undefined,
     RoleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4075,7 +4077,7 @@ export const deserializeAws_restJson1GetDeviceProfileCommand = async (
     LoRaWAN: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4173,7 +4175,7 @@ export const deserializeAws_restJson1GetLogLevelsByResourceTypesCommand = async 
     WirelessDeviceLogOptions: undefined,
     WirelessGatewayLogOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DefaultLogLevel !== undefined && data.DefaultLogLevel !== null) {
     contents.DefaultLogLevel = __expectString(data.DefaultLogLevel);
   }
@@ -4273,7 +4275,7 @@ export const deserializeAws_restJson1GetPartnerAccountCommand = async (
     AccountLinked: undefined,
     Sidewalk: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountLinked !== undefined && data.AccountLinked !== null) {
     contents.AccountLinked = __expectBoolean(data.AccountLinked);
   }
@@ -4355,7 +4357,7 @@ export const deserializeAws_restJson1GetResourceLogLevelCommand = async (
     $metadata: deserializeMetadata(output),
     LogLevel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LogLevel !== undefined && data.LogLevel !== null) {
     contents.LogLevel = __expectString(data.LogLevel);
   }
@@ -4444,7 +4446,7 @@ export const deserializeAws_restJson1GetServiceEndpointCommand = async (
     ServiceEndpoint: undefined,
     ServiceType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServerTrust !== undefined && data.ServerTrust !== null) {
     contents.ServerTrust = __expectString(data.ServerTrust);
   }
@@ -4532,7 +4534,7 @@ export const deserializeAws_restJson1GetServiceProfileCommand = async (
     LoRaWAN: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4637,7 +4639,7 @@ export const deserializeAws_restJson1GetWirelessDeviceCommand = async (
     ThingName: undefined,
     Type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4754,7 +4756,7 @@ export const deserializeAws_restJson1GetWirelessDeviceStatisticsCommand = async 
     Sidewalk: undefined,
     WirelessDeviceId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastUplinkReceivedAt !== undefined && data.LastUplinkReceivedAt !== null) {
     contents.LastUplinkReceivedAt = __expectString(data.LastUplinkReceivedAt);
   }
@@ -4856,7 +4858,7 @@ export const deserializeAws_restJson1GetWirelessGatewayCommand = async (
     ThingArn: undefined,
     ThingName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4962,7 +4964,7 @@ export const deserializeAws_restJson1GetWirelessGatewayCertificateCommand = asyn
     IotCertificateId: undefined,
     LoRaWANNetworkServerCertificateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IotCertificateId !== undefined && data.IotCertificateId !== null) {
     contents.IotCertificateId = __expectString(data.IotCertificateId);
   }
@@ -5052,7 +5054,7 @@ export const deserializeAws_restJson1GetWirelessGatewayFirmwareInformationComman
     $metadata: deserializeMetadata(output),
     LoRaWAN: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANGatewayCurrentVersion(data.LoRaWAN, context);
   }
@@ -5141,7 +5143,7 @@ export const deserializeAws_restJson1GetWirelessGatewayStatisticsCommand = async
     LastUplinkReceivedAt: undefined,
     WirelessGatewayId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionStatus !== undefined && data.ConnectionStatus !== null) {
     contents.ConnectionStatus = __expectString(data.ConnectionStatus);
   }
@@ -5238,7 +5240,7 @@ export const deserializeAws_restJson1GetWirelessGatewayTaskCommand = async (
     WirelessGatewayId: undefined,
     WirelessGatewayTaskDefinitionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastUplinkReceivedAt !== undefined && data.LastUplinkReceivedAt !== null) {
     contents.LastUplinkReceivedAt = __expectString(data.LastUplinkReceivedAt);
   }
@@ -5340,7 +5342,7 @@ export const deserializeAws_restJson1GetWirelessGatewayTaskDefinitionCommand = a
     Name: undefined,
     Update: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5437,7 +5439,7 @@ export const deserializeAws_restJson1ListDestinationsCommand = async (
     DestinationList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationList !== undefined && data.DestinationList !== null) {
     contents.DestinationList = deserializeAws_restJson1DestinationList(data.DestinationList, context);
   }
@@ -5520,7 +5522,7 @@ export const deserializeAws_restJson1ListDeviceProfilesCommand = async (
     DeviceProfileList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceProfileList !== undefined && data.DeviceProfileList !== null) {
     contents.DeviceProfileList = deserializeAws_restJson1DeviceProfileList(data.DeviceProfileList, context);
   }
@@ -5603,7 +5605,7 @@ export const deserializeAws_restJson1ListPartnerAccountsCommand = async (
     NextToken: undefined,
     Sidewalk: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5686,7 +5688,7 @@ export const deserializeAws_restJson1ListServiceProfilesCommand = async (
     NextToken: undefined,
     ServiceProfileList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5768,7 +5770,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -5856,7 +5858,7 @@ export const deserializeAws_restJson1ListWirelessDevicesCommand = async (
     NextToken: undefined,
     WirelessDeviceList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5942,7 +5944,7 @@ export const deserializeAws_restJson1ListWirelessGatewaysCommand = async (
     NextToken: undefined,
     WirelessGatewayList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6028,7 +6030,7 @@ export const deserializeAws_restJson1ListWirelessGatewayTaskDefinitionsCommand =
     NextToken: undefined,
     TaskDefinitions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6359,7 +6361,7 @@ export const deserializeAws_restJson1SendDataToWirelessDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }
@@ -6529,7 +6531,7 @@ export const deserializeAws_restJson1TestWirelessDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Result: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Result !== undefined && data.Result !== null) {
     contents.Result = __expectString(data.Result);
   }

--- a/clients/client-iot/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1.ts
@@ -847,6 +847,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -8441,7 +8443,7 @@ export const deserializeAws_restJson1AssociateTargetsWithJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -9240,7 +9242,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -9674,7 +9676,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
     authorizerArn: undefined,
     authorizerName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
     contents.authorizerArn = __expectString(data.authorizerArn);
   }
@@ -9782,7 +9784,7 @@ export const deserializeAws_restJson1CreateBillingGroupCommand = async (
     billingGroupId: undefined,
     billingGroupName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.billingGroupArn !== undefined && data.billingGroupArn !== null) {
     contents.billingGroupArn = __expectString(data.billingGroupArn);
   }
@@ -9869,7 +9871,7 @@ export const deserializeAws_restJson1CreateCertificateFromCsrCommand = async (
     certificateId: undefined,
     certificatePem: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -9963,7 +9965,7 @@ export const deserializeAws_restJson1CreateCustomMetricCommand = async (
     metricArn: undefined,
     metricName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.metricArn !== undefined && data.metricArn !== null) {
     contents.metricArn = __expectString(data.metricArn);
   }
@@ -10054,7 +10056,7 @@ export const deserializeAws_restJson1CreateDimensionCommand = async (
     arn: undefined,
     name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -10145,7 +10147,7 @@ export const deserializeAws_restJson1CreateDomainConfigurationCommand = async (
     domainConfigurationArn: undefined,
     domainConfigurationName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainConfigurationArn !== undefined && data.domainConfigurationArn !== null) {
     contents.domainConfigurationArn = __expectString(data.domainConfigurationArn);
   }
@@ -10264,7 +10266,7 @@ export const deserializeAws_restJson1CreateDynamicThingGroupCommand = async (
     thingGroupId: undefined,
     thingGroupName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexName !== undefined && data.indexName !== null) {
     contents.indexName = __expectString(data.indexName);
   }
@@ -10384,7 +10386,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -10486,7 +10488,7 @@ export const deserializeAws_restJson1CreateJobTemplateCommand = async (
     jobTemplateArn: undefined,
     jobTemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplateArn !== undefined && data.jobTemplateArn !== null) {
     contents.jobTemplateArn = __expectString(data.jobTemplateArn);
   }
@@ -10587,7 +10589,7 @@ export const deserializeAws_restJson1CreateKeysAndCertificateCommand = async (
     certificatePem: undefined,
     keyPair: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -10684,7 +10686,7 @@ export const deserializeAws_restJson1CreateMitigationActionCommand = async (
     actionArn: undefined,
     actionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionArn !== undefined && data.actionArn !== null) {
     contents.actionArn = __expectString(data.actionArn);
   }
@@ -10778,7 +10780,7 @@ export const deserializeAws_restJson1CreateOTAUpdateCommand = async (
     otaUpdateId: undefined,
     otaUpdateStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.awsIotJobArn !== undefined && data.awsIotJobArn !== null) {
     contents.awsIotJobArn = __expectString(data.awsIotJobArn);
   }
@@ -10904,7 +10906,7 @@ export const deserializeAws_restJson1CreatePolicyCommand = async (
     policyName: undefined,
     policyVersionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policyArn !== undefined && data.policyArn !== null) {
     contents.policyArn = __expectString(data.policyArn);
   }
@@ -11019,7 +11021,7 @@ export const deserializeAws_restJson1CreatePolicyVersionCommand = async (
     policyDocument: undefined,
     policyVersionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
     contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
@@ -11142,7 +11144,7 @@ export const deserializeAws_restJson1CreateProvisioningClaimCommand = async (
     expiration: undefined,
     keyPair: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateId !== undefined && data.certificateId !== null) {
     contents.certificateId = __expectString(data.certificateId);
   }
@@ -11248,7 +11250,7 @@ export const deserializeAws_restJson1CreateProvisioningTemplateCommand = async (
     templateArn: undefined,
     templateName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultVersionId !== undefined && data.defaultVersionId !== null) {
     contents.defaultVersionId = __expectInt32(data.defaultVersionId);
   }
@@ -11352,7 +11354,7 @@ export const deserializeAws_restJson1CreateProvisioningTemplateVersionCommand = 
     templateName: undefined,
     versionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
     contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
@@ -11465,7 +11467,7 @@ export const deserializeAws_restJson1CreateRoleAliasCommand = async (
     roleAlias: undefined,
     roleAliasArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleAlias !== undefined && data.roleAlias !== null) {
     contents.roleAlias = __expectString(data.roleAlias);
   }
@@ -11571,7 +11573,7 @@ export const deserializeAws_restJson1CreateScheduledAuditCommand = async (
     $metadata: deserializeMetadata(output),
     scheduledAuditArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.scheduledAuditArn !== undefined && data.scheduledAuditArn !== null) {
     contents.scheduledAuditArn = __expectString(data.scheduledAuditArn);
   }
@@ -11659,7 +11661,7 @@ export const deserializeAws_restJson1CreateSecurityProfileCommand = async (
     securityProfileArn: undefined,
     securityProfileName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityProfileArn !== undefined && data.securityProfileArn !== null) {
     contents.securityProfileArn = __expectString(data.securityProfileArn);
   }
@@ -11744,7 +11746,7 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
     streamId: undefined,
     streamVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -11866,7 +11868,7 @@ export const deserializeAws_restJson1CreateThingCommand = async (
     thingId: undefined,
     thingName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingArn !== undefined && data.thingArn !== null) {
     contents.thingArn = __expectString(data.thingArn);
   }
@@ -11977,7 +11979,7 @@ export const deserializeAws_restJson1CreateThingGroupCommand = async (
     thingGroupId: undefined,
     thingGroupName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingGroupArn !== undefined && data.thingGroupArn !== null) {
     contents.thingGroupArn = __expectString(data.thingGroupArn);
   }
@@ -12064,7 +12066,7 @@ export const deserializeAws_restJson1CreateThingTypeCommand = async (
     thingTypeId: undefined,
     thingTypeName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingTypeArn !== undefined && data.thingTypeArn !== null) {
     contents.thingTypeArn = __expectString(data.thingTypeArn);
   }
@@ -12256,7 +12258,7 @@ export const deserializeAws_restJson1CreateTopicRuleDestinationCommand = async (
     $metadata: deserializeMetadata(output),
     topicRuleDestination: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.topicRuleDestination !== undefined && data.topicRuleDestination !== null) {
     contents.topicRuleDestination = deserializeAws_restJson1TopicRuleDestination(data.topicRuleDestination, context);
   }
@@ -14998,7 +15000,7 @@ export const deserializeAws_restJson1DescribeAccountAuditConfigurationCommand = 
     auditNotificationTargetConfigurations: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.auditCheckConfigurations !== undefined && data.auditCheckConfigurations !== null) {
     contents.auditCheckConfigurations = deserializeAws_restJson1AuditCheckConfigurations(
       data.auditCheckConfigurations,
@@ -15073,7 +15075,7 @@ export const deserializeAws_restJson1DescribeAuditFindingCommand = async (
     $metadata: deserializeMetadata(output),
     finding: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.finding !== undefined && data.finding !== null) {
     contents.finding = deserializeAws_restJson1AuditFinding(data.finding, context);
   }
@@ -15158,7 +15160,7 @@ export const deserializeAws_restJson1DescribeAuditMitigationActionsTaskCommand =
     taskStatistics: undefined,
     taskStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionsDefinition !== undefined && data.actionsDefinition !== null) {
     contents.actionsDefinition = deserializeAws_restJson1MitigationActionList(data.actionsDefinition, context);
   }
@@ -15265,7 +15267,7 @@ export const deserializeAws_restJson1DescribeAuditSuppressionCommand = async (
     resourceIdentifier: undefined,
     suppressIndefinitely: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checkName !== undefined && data.checkName !== null) {
     contents.checkName = __expectString(data.checkName);
   }
@@ -15361,7 +15363,7 @@ export const deserializeAws_restJson1DescribeAuditTaskCommand = async (
     taskStatus: undefined,
     taskType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.auditDetails !== undefined && data.auditDetails !== null) {
     contents.auditDetails = deserializeAws_restJson1AuditDetails(data.auditDetails, context);
   }
@@ -15455,7 +15457,7 @@ export const deserializeAws_restJson1DescribeAuthorizerCommand = async (
     $metadata: deserializeMetadata(output),
     authorizerDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerDescription !== undefined && data.authorizerDescription !== null) {
     contents.authorizerDescription = deserializeAws_restJson1AuthorizerDescription(data.authorizerDescription, context);
   }
@@ -15555,7 +15557,7 @@ export const deserializeAws_restJson1DescribeBillingGroupCommand = async (
     billingGroupProperties: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.billingGroupArn !== undefined && data.billingGroupArn !== null) {
     contents.billingGroupArn = __expectString(data.billingGroupArn);
   }
@@ -15653,7 +15655,7 @@ export const deserializeAws_restJson1DescribeCACertificateCommand = async (
     certificateDescription: undefined,
     registrationConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateDescription !== undefined && data.certificateDescription !== null) {
     contents.certificateDescription = deserializeAws_restJson1CACertificateDescription(
       data.certificateDescription,
@@ -15754,7 +15756,7 @@ export const deserializeAws_restJson1DescribeCertificateCommand = async (
     $metadata: deserializeMetadata(output),
     certificateDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateDescription !== undefined && data.certificateDescription !== null) {
     contents.certificateDescription = deserializeAws_restJson1CertificateDescription(
       data.certificateDescription,
@@ -15857,7 +15859,7 @@ export const deserializeAws_restJson1DescribeCustomMetricCommand = async (
     metricName: undefined,
     metricType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -15951,7 +15953,7 @@ export const deserializeAws_restJson1DescribeDefaultAuthorizerCommand = async (
     $metadata: deserializeMetadata(output),
     authorizerDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerDescription !== undefined && data.authorizerDescription !== null) {
     contents.authorizerDescription = deserializeAws_restJson1AuthorizerDescription(data.authorizerDescription, context);
   }
@@ -16046,7 +16048,7 @@ export const deserializeAws_restJson1DescribeDetectMitigationActionsTaskCommand 
     $metadata: deserializeMetadata(output),
     taskSummary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskSummary !== undefined && data.taskSummary !== null) {
     contents.taskSummary = deserializeAws_restJson1DetectMitigationActionsTaskSummary(data.taskSummary, context);
   }
@@ -16130,7 +16132,7 @@ export const deserializeAws_restJson1DescribeDimensionCommand = async (
     stringValues: undefined,
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -16232,7 +16234,7 @@ export const deserializeAws_restJson1DescribeDomainConfigurationCommand = async 
     serverCertificates: undefined,
     serviceType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerConfig !== undefined && data.authorizerConfig !== null) {
     contents.authorizerConfig = deserializeAws_restJson1AuthorizerConfig(data.authorizerConfig, context);
   }
@@ -16351,7 +16353,7 @@ export const deserializeAws_restJson1DescribeEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     endpointAddress: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpointAddress !== undefined && data.endpointAddress !== null) {
     contents.endpointAddress = __expectString(data.endpointAddress);
   }
@@ -16432,7 +16434,7 @@ export const deserializeAws_restJson1DescribeEventConfigurationsCommand = async 
     eventConfigurations: undefined,
     lastModifiedDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -16503,7 +16505,7 @@ export const deserializeAws_restJson1DescribeIndexCommand = async (
     indexStatus: undefined,
     schema: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexName !== undefined && data.indexName !== null) {
     contents.indexName = __expectString(data.indexName);
   }
@@ -16605,7 +16607,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     documentSource: undefined,
     job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.documentSource !== undefined && data.documentSource !== null) {
     contents.documentSource = __expectString(data.documentSource);
   }
@@ -16687,7 +16689,7 @@ export const deserializeAws_restJson1DescribeJobExecutionCommand = async (
     $metadata: deserializeMetadata(output),
     execution: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.execution !== undefined && data.execution !== null) {
     contents.execution = deserializeAws_restJson1JobExecution(data.execution, context);
   }
@@ -16775,7 +16777,7 @@ export const deserializeAws_restJson1DescribeJobTemplateCommand = async (
     presignedUrlConfig: undefined,
     timeoutConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortConfig !== undefined && data.abortConfig !== null) {
     contents.abortConfig = deserializeAws_restJson1AbortConfig(data.abortConfig, context);
   }
@@ -16891,7 +16893,7 @@ export const deserializeAws_restJson1DescribeMitigationActionCommand = async (
     lastModifiedDate: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionArn !== undefined && data.actionArn !== null) {
     contents.actionArn = __expectString(data.actionArn);
   }
@@ -17000,7 +17002,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateCommand = async
     templateBody: undefined,
     templateName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -17117,7 +17119,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateVersionCommand 
     templateBody: undefined,
     versionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -17213,7 +17215,7 @@ export const deserializeAws_restJson1DescribeRoleAliasCommand = async (
     $metadata: deserializeMetadata(output),
     roleAliasDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleAliasDescription !== undefined && data.roleAliasDescription !== null) {
     contents.roleAliasDescription = deserializeAws_restJson1RoleAliasDescription(data.roleAliasDescription, context);
   }
@@ -17313,7 +17315,7 @@ export const deserializeAws_restJson1DescribeScheduledAuditCommand = async (
     scheduledAuditName: undefined,
     targetCheckNames: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dayOfMonth !== undefined && data.dayOfMonth !== null) {
     contents.dayOfMonth = __expectString(data.dayOfMonth);
   }
@@ -17416,7 +17418,7 @@ export const deserializeAws_restJson1DescribeSecurityProfileCommand = async (
     securityProfileName: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.additionalMetricsToRetain !== undefined && data.additionalMetricsToRetain !== null) {
     contents.additionalMetricsToRetain = deserializeAws_restJson1AdditionalMetricsToRetainList(
       data.additionalMetricsToRetain,
@@ -17528,7 +17530,7 @@ export const deserializeAws_restJson1DescribeStreamCommand = async (
     $metadata: deserializeMetadata(output),
     streamInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamInfo !== undefined && data.streamInfo !== null) {
     contents.streamInfo = deserializeAws_restJson1StreamInfo(data.streamInfo, context);
   }
@@ -17630,7 +17632,7 @@ export const deserializeAws_restJson1DescribeThingCommand = async (
     thingTypeName: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributes !== undefined && data.attributes !== null) {
     contents.attributes = deserializeAws_restJson1Attributes(data.attributes, context);
   }
@@ -17755,7 +17757,7 @@ export const deserializeAws_restJson1DescribeThingGroupCommand = async (
     thingGroupProperties: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexName !== undefined && data.indexName !== null) {
     contents.indexName = __expectString(data.indexName);
   }
@@ -17872,7 +17874,7 @@ export const deserializeAws_restJson1DescribeThingRegistrationTaskCommand = asyn
     taskId: undefined,
     templateBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -17996,7 +17998,7 @@ export const deserializeAws_restJson1DescribeThingTypeCommand = async (
     thingTypeName: undefined,
     thingTypeProperties: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingTypeArn !== undefined && data.thingTypeArn !== null) {
     contents.thingTypeArn = __expectString(data.thingTypeArn);
   }
@@ -18618,7 +18620,7 @@ export const deserializeAws_restJson1GetBehaviorModelTrainingSummariesCommand = 
     nextToken: undefined,
     summaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -18700,7 +18702,7 @@ export const deserializeAws_restJson1GetCardinalityCommand = async (
     $metadata: deserializeMetadata(output),
     cardinality: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cardinality !== undefined && data.cardinality !== null) {
     contents.cardinality = __expectInt32(data.cardinality);
   }
@@ -18819,7 +18821,7 @@ export const deserializeAws_restJson1GetEffectivePoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     effectivePolicies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.effectivePolicies !== undefined && data.effectivePolicies !== null) {
     contents.effectivePolicies = deserializeAws_restJson1EffectivePolicies(data.effectivePolicies, context);
   }
@@ -18923,7 +18925,7 @@ export const deserializeAws_restJson1GetIndexingConfigurationCommand = async (
     thingGroupIndexingConfiguration: undefined,
     thingIndexingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingGroupIndexingConfiguration !== undefined && data.thingGroupIndexingConfiguration !== null) {
     contents.thingGroupIndexingConfiguration = deserializeAws_restJson1ThingGroupIndexingConfiguration(
       data.thingGroupIndexingConfiguration,
@@ -19019,7 +19021,7 @@ export const deserializeAws_restJson1GetJobDocumentCommand = async (
     $metadata: deserializeMetadata(output),
     document: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.document !== undefined && data.document !== null) {
     contents.document = __expectString(data.document);
   }
@@ -19099,7 +19101,7 @@ export const deserializeAws_restJson1GetLoggingOptionsCommand = async (
     logLevel: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logLevel !== undefined && data.logLevel !== null) {
     contents.logLevel = __expectString(data.logLevel);
   }
@@ -19173,7 +19175,7 @@ export const deserializeAws_restJson1GetOTAUpdateCommand = async (
     $metadata: deserializeMetadata(output),
     otaUpdateInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.otaUpdateInfo !== undefined && data.otaUpdateInfo !== null) {
     contents.otaUpdateInfo = deserializeAws_restJson1OTAUpdateInfo(data.otaUpdateInfo, context);
   }
@@ -19268,7 +19270,7 @@ export const deserializeAws_restJson1GetPercentilesCommand = async (
     $metadata: deserializeMetadata(output),
     percentiles: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.percentiles !== undefined && data.percentiles !== null) {
     contents.percentiles = deserializeAws_restJson1Percentiles(data.percentiles, context);
   }
@@ -19393,7 +19395,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     policyDocument: undefined,
     policyName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -19513,7 +19515,7 @@ export const deserializeAws_restJson1GetPolicyVersionCommand = async (
     policyName: undefined,
     policyVersionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -19629,7 +19631,7 @@ export const deserializeAws_restJson1GetRegistrationCodeCommand = async (
     $metadata: deserializeMetadata(output),
     registrationCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.registrationCode !== undefined && data.registrationCode !== null) {
     contents.registrationCode = __expectString(data.registrationCode);
   }
@@ -19716,7 +19718,7 @@ export const deserializeAws_restJson1GetStatisticsCommand = async (
     $metadata: deserializeMetadata(output),
     statistics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.statistics !== undefined && data.statistics !== null) {
     contents.statistics = deserializeAws_restJson1Statistics(data.statistics, context);
   }
@@ -19836,7 +19838,7 @@ export const deserializeAws_restJson1GetTopicRuleCommand = async (
     rule: undefined,
     ruleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.rule !== undefined && data.rule !== null) {
     contents.rule = deserializeAws_restJson1TopicRule(data.rule, context);
   }
@@ -19918,7 +19920,7 @@ export const deserializeAws_restJson1GetTopicRuleDestinationCommand = async (
     $metadata: deserializeMetadata(output),
     topicRuleDestination: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.topicRuleDestination !== undefined && data.topicRuleDestination !== null) {
     contents.topicRuleDestination = deserializeAws_restJson1TopicRuleDestination(data.topicRuleDestination, context);
   }
@@ -19999,7 +20001,7 @@ export const deserializeAws_restJson1GetV2LoggingOptionsCommand = async (
     disableAllLogs: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultLogLevel !== undefined && data.defaultLogLevel !== null) {
     contents.defaultLogLevel = __expectString(data.defaultLogLevel);
   }
@@ -20077,7 +20079,7 @@ export const deserializeAws_restJson1ListActiveViolationsCommand = async (
     activeViolations: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.activeViolations !== undefined && data.activeViolations !== null) {
     contents.activeViolations = deserializeAws_restJson1ActiveViolations(data.activeViolations, context);
   }
@@ -20160,7 +20162,7 @@ export const deserializeAws_restJson1ListAttachedPoliciesCommand = async (
     nextMarker: undefined,
     policies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -20267,7 +20269,7 @@ export const deserializeAws_restJson1ListAuditFindingsCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1AuditFindings(data.findings, context);
   }
@@ -20342,7 +20344,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsExecutionsCommand
     actionsExecutions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionsExecutions !== undefined && data.actionsExecutions !== null) {
     contents.actionsExecutions = deserializeAws_restJson1AuditMitigationActionExecutionMetadataList(
       data.actionsExecutions,
@@ -20420,7 +20422,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsTasksCommand = as
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -20495,7 +20497,7 @@ export const deserializeAws_restJson1ListAuditSuppressionsCommand = async (
     nextToken: undefined,
     suppressions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -20570,7 +20572,7 @@ export const deserializeAws_restJson1ListAuditTasksCommand = async (
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -20645,7 +20647,7 @@ export const deserializeAws_restJson1ListAuthorizersCommand = async (
     authorizers: undefined,
     nextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizers !== undefined && data.authorizers !== null) {
     contents.authorizers = deserializeAws_restJson1Authorizers(data.authorizers, context);
   }
@@ -20736,7 +20738,7 @@ export const deserializeAws_restJson1ListBillingGroupsCommand = async (
     billingGroups: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.billingGroups !== undefined && data.billingGroups !== null) {
     contents.billingGroups = deserializeAws_restJson1BillingGroupNameAndArnList(data.billingGroups, context);
   }
@@ -20819,7 +20821,7 @@ export const deserializeAws_restJson1ListCACertificatesCommand = async (
     certificates: undefined,
     nextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificates !== undefined && data.certificates !== null) {
     contents.certificates = deserializeAws_restJson1CACertificates(data.certificates, context);
   }
@@ -20910,7 +20912,7 @@ export const deserializeAws_restJson1ListCertificatesCommand = async (
     certificates: undefined,
     nextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificates !== undefined && data.certificates !== null) {
     contents.certificates = deserializeAws_restJson1Certificates(data.certificates, context);
   }
@@ -21001,7 +21003,7 @@ export const deserializeAws_restJson1ListCertificatesByCACommand = async (
     certificates: undefined,
     nextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificates !== undefined && data.certificates !== null) {
     contents.certificates = deserializeAws_restJson1Certificates(data.certificates, context);
   }
@@ -21092,7 +21094,7 @@ export const deserializeAws_restJson1ListCustomMetricsCommand = async (
     metricNames: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.metricNames !== undefined && data.metricNames !== null) {
     contents.metricNames = deserializeAws_restJson1MetricNames(data.metricNames, context);
   }
@@ -21167,7 +21169,7 @@ export const deserializeAws_restJson1ListDetectMitigationActionsExecutionsComman
     actionsExecutions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionsExecutions !== undefined && data.actionsExecutions !== null) {
     contents.actionsExecutions = deserializeAws_restJson1DetectMitigationActionExecutionList(
       data.actionsExecutions,
@@ -21245,7 +21247,7 @@ export const deserializeAws_restJson1ListDetectMitigationActionsTasksCommand = a
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -21320,7 +21322,7 @@ export const deserializeAws_restJson1ListDimensionsCommand = async (
     dimensionNames: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dimensionNames !== undefined && data.dimensionNames !== null) {
     contents.dimensionNames = deserializeAws_restJson1DimensionNames(data.dimensionNames, context);
   }
@@ -21395,7 +21397,7 @@ export const deserializeAws_restJson1ListDomainConfigurationsCommand = async (
     domainConfigurations: undefined,
     nextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainConfigurations !== undefined && data.domainConfigurations !== null) {
     contents.domainConfigurations = deserializeAws_restJson1DomainConfigurations(data.domainConfigurations, context);
   }
@@ -21486,7 +21488,7 @@ export const deserializeAws_restJson1ListIndicesCommand = async (
     indexNames: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexNames !== undefined && data.indexNames !== null) {
     contents.indexNames = deserializeAws_restJson1IndexNamesList(data.indexNames, context);
   }
@@ -21577,7 +21579,7 @@ export const deserializeAws_restJson1ListJobExecutionsForJobCommand = async (
     executionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionSummaries !== undefined && data.executionSummaries !== null) {
     contents.executionSummaries = deserializeAws_restJson1JobExecutionSummaryForJobList(
       data.executionSummaries,
@@ -21663,7 +21665,7 @@ export const deserializeAws_restJson1ListJobExecutionsForThingCommand = async (
     executionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionSummaries !== undefined && data.executionSummaries !== null) {
     contents.executionSummaries = deserializeAws_restJson1JobExecutionSummaryForThingList(
       data.executionSummaries,
@@ -21749,7 +21751,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     jobs: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1JobSummaryList(data.jobs, context);
   }
@@ -21832,7 +21834,7 @@ export const deserializeAws_restJson1ListJobTemplatesCommand = async (
     jobTemplates: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplates !== undefined && data.jobTemplates !== null) {
     contents.jobTemplates = deserializeAws_restJson1JobTemplateSummaryList(data.jobTemplates, context);
   }
@@ -21907,7 +21909,7 @@ export const deserializeAws_restJson1ListMitigationActionsCommand = async (
     actionIdentifiers: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionIdentifiers !== undefined && data.actionIdentifiers !== null) {
     contents.actionIdentifiers = deserializeAws_restJson1MitigationActionIdentifierList(
       data.actionIdentifiers,
@@ -21985,7 +21987,7 @@ export const deserializeAws_restJson1ListOTAUpdatesCommand = async (
     nextToken: undefined,
     otaUpdates: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -22076,7 +22078,7 @@ export const deserializeAws_restJson1ListOutgoingCertificatesCommand = async (
     nextMarker: undefined,
     outgoingCertificates: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -22167,7 +22169,7 @@ export const deserializeAws_restJson1ListPoliciesCommand = async (
     nextMarker: undefined,
     policies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -22258,7 +22260,7 @@ export const deserializeAws_restJson1ListPolicyPrincipalsCommand = async (
     nextMarker: undefined,
     principals: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -22356,7 +22358,7 @@ export const deserializeAws_restJson1ListPolicyVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     policyVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policyVersions !== undefined && data.policyVersions !== null) {
     contents.policyVersions = deserializeAws_restJson1PolicyVersions(data.policyVersions, context);
   }
@@ -22452,7 +22454,7 @@ export const deserializeAws_restJson1ListPrincipalPoliciesCommand = async (
     nextMarker: undefined,
     policies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -22551,7 +22553,7 @@ export const deserializeAws_restJson1ListPrincipalThingsCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -22650,7 +22652,7 @@ export const deserializeAws_restJson1ListProvisioningTemplatesCommand = async (
     nextToken: undefined,
     templates: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -22733,7 +22735,7 @@ export const deserializeAws_restJson1ListProvisioningTemplateVersionsCommand = a
     nextToken: undefined,
     versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -22824,7 +22826,7 @@ export const deserializeAws_restJson1ListRoleAliasesCommand = async (
     nextMarker: undefined,
     roleAliases: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -22915,7 +22917,7 @@ export const deserializeAws_restJson1ListScheduledAuditsCommand = async (
     nextToken: undefined,
     scheduledAudits: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -22990,7 +22992,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
     nextToken: undefined,
     securityProfileIdentifiers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23076,7 +23078,7 @@ export const deserializeAws_restJson1ListSecurityProfilesForTargetCommand = asyn
     nextToken: undefined,
     securityProfileTargetMappings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23162,7 +23164,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
     nextToken: undefined,
     streams: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23253,7 +23255,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     nextToken: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23336,7 +23338,7 @@ export const deserializeAws_restJson1ListTargetsForPolicyCommand = async (
     nextMarker: undefined,
     targets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -23443,7 +23445,7 @@ export const deserializeAws_restJson1ListTargetsForSecurityProfileCommand = asyn
     nextToken: undefined,
     securityProfileTargets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23529,7 +23531,7 @@ export const deserializeAws_restJson1ListThingGroupsCommand = async (
     nextToken: undefined,
     thingGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23612,7 +23614,7 @@ export const deserializeAws_restJson1ListThingGroupsForThingCommand = async (
     nextToken: undefined,
     thingGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23695,7 +23697,7 @@ export const deserializeAws_restJson1ListThingPrincipalsCommand = async (
     nextToken: undefined,
     principals: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23795,7 +23797,7 @@ export const deserializeAws_restJson1ListThingRegistrationTaskReportsCommand = a
     reportType: undefined,
     resourceLinks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23881,7 +23883,7 @@ export const deserializeAws_restJson1ListThingRegistrationTasksCommand = async (
     nextToken: undefined,
     taskIds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -23964,7 +23966,7 @@ export const deserializeAws_restJson1ListThingsCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -24055,7 +24057,7 @@ export const deserializeAws_restJson1ListThingsInBillingGroupCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -24138,7 +24140,7 @@ export const deserializeAws_restJson1ListThingsInThingGroupCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -24221,7 +24223,7 @@ export const deserializeAws_restJson1ListThingTypesCommand = async (
     nextToken: undefined,
     thingTypes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -24312,7 +24314,7 @@ export const deserializeAws_restJson1ListTopicRuleDestinationsCommand = async (
     destinationSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinationSummaries !== undefined && data.destinationSummaries !== null) {
     contents.destinationSummaries = deserializeAws_restJson1TopicRuleDestinationSummaries(
       data.destinationSummaries,
@@ -24398,7 +24400,7 @@ export const deserializeAws_restJson1ListTopicRulesCommand = async (
     nextToken: undefined,
     rules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -24473,7 +24475,7 @@ export const deserializeAws_restJson1ListV2LoggingLevelsCommand = async (
     logTargetConfigurations: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logTargetConfigurations !== undefined && data.logTargetConfigurations !== null) {
     contents.logTargetConfigurations = deserializeAws_restJson1LogTargetConfigurations(
       data.logTargetConfigurations,
@@ -24559,7 +24561,7 @@ export const deserializeAws_restJson1ListViolationEventsCommand = async (
     nextToken: undefined,
     violationEvents: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -24634,7 +24636,7 @@ export const deserializeAws_restJson1RegisterCACertificateCommand = async (
     certificateArn: undefined,
     certificateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -24757,7 +24759,7 @@ export const deserializeAws_restJson1RegisterCertificateCommand = async (
     certificateArn: undefined,
     certificateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -24880,7 +24882,7 @@ export const deserializeAws_restJson1RegisterCertificateWithoutCACommand = async
     certificateArn: undefined,
     certificateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -24995,7 +24997,7 @@ export const deserializeAws_restJson1RegisterThingCommand = async (
     certificatePem: undefined,
     resourceArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificatePem !== undefined && data.certificatePem !== null) {
     contents.certificatePem = __expectString(data.certificatePem);
   }
@@ -25443,7 +25445,7 @@ export const deserializeAws_restJson1SearchIndexCommand = async (
     thingGroups: undefined,
     things: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -25561,7 +25563,7 @@ export const deserializeAws_restJson1SetDefaultAuthorizerCommand = async (
     authorizerArn: undefined,
     authorizerName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
     contents.authorizerArn = __expectString(data.authorizerArn);
   }
@@ -25975,7 +25977,7 @@ export const deserializeAws_restJson1StartAuditMitigationActionsTaskCommand = as
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -26062,7 +26064,7 @@ export const deserializeAws_restJson1StartDetectMitigationActionsTaskCommand = a
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -26149,7 +26151,7 @@ export const deserializeAws_restJson1StartOnDemandAuditTaskCommand = async (
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -26228,7 +26230,7 @@ export const deserializeAws_restJson1StartThingRegistrationTaskCommand = async (
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -26473,7 +26475,7 @@ export const deserializeAws_restJson1TestAuthorizationCommand = async (
     $metadata: deserializeMetadata(output),
     authResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authResults !== undefined && data.authResults !== null) {
     contents.authResults = deserializeAws_restJson1AuthResults(data.authResults, context);
   }
@@ -26580,7 +26582,7 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
     principalId: undefined,
     refreshAfterInSeconds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.disconnectAfterInSeconds !== undefined && data.disconnectAfterInSeconds !== null) {
     contents.disconnectAfterInSeconds = __expectInt32(data.disconnectAfterInSeconds);
   }
@@ -26695,7 +26697,7 @@ export const deserializeAws_restJson1TransferCertificateCommand = async (
     $metadata: deserializeMetadata(output),
     transferredCertificateArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transferredCertificateArn !== undefined && data.transferredCertificateArn !== null) {
     contents.transferredCertificateArn = __expectString(data.transferredCertificateArn);
   }
@@ -27024,7 +27026,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
     authorizerArn: undefined,
     authorizerName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
     contents.authorizerArn = __expectString(data.authorizerArn);
   }
@@ -27130,7 +27132,7 @@ export const deserializeAws_restJson1UpdateBillingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.version !== undefined && data.version !== null) {
     contents.version = __expectLong(data.version);
   }
@@ -27412,7 +27414,7 @@ export const deserializeAws_restJson1UpdateCustomMetricCommand = async (
     metricName: undefined,
     metricType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -27511,7 +27513,7 @@ export const deserializeAws_restJson1UpdateDimensionCommand = async (
     stringValues: undefined,
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -27606,7 +27608,7 @@ export const deserializeAws_restJson1UpdateDomainConfigurationCommand = async (
     domainConfigurationArn: undefined,
     domainConfigurationName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainConfigurationArn !== undefined && data.domainConfigurationArn !== null) {
     contents.domainConfigurationArn = __expectString(data.domainConfigurationArn);
   }
@@ -27712,7 +27714,7 @@ export const deserializeAws_restJson1UpdateDynamicThingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.version !== undefined && data.version !== null) {
     contents.version = __expectLong(data.version);
   }
@@ -28033,7 +28035,7 @@ export const deserializeAws_restJson1UpdateMitigationActionCommand = async (
     actionArn: undefined,
     actionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionArn !== undefined && data.actionArn !== null) {
     contents.actionArn = __expectString(data.actionArn);
   }
@@ -28199,7 +28201,7 @@ export const deserializeAws_restJson1UpdateRoleAliasCommand = async (
     roleAlias: undefined,
     roleAliasArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleAlias !== undefined && data.roleAlias !== null) {
     contents.roleAlias = __expectString(data.roleAlias);
   }
@@ -28297,7 +28299,7 @@ export const deserializeAws_restJson1UpdateScheduledAuditCommand = async (
     $metadata: deserializeMetadata(output),
     scheduledAuditArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.scheduledAuditArn !== undefined && data.scheduledAuditArn !== null) {
     contents.scheduledAuditArn = __expectString(data.scheduledAuditArn);
   }
@@ -28385,7 +28387,7 @@ export const deserializeAws_restJson1UpdateSecurityProfileCommand = async (
     securityProfileName: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.additionalMetricsToRetain !== undefined && data.additionalMetricsToRetain !== null) {
     contents.additionalMetricsToRetain = deserializeAws_restJson1AdditionalMetricsToRetainList(
       data.additionalMetricsToRetain,
@@ -28508,7 +28510,7 @@ export const deserializeAws_restJson1UpdateStreamCommand = async (
     streamId: undefined,
     streamVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -28711,7 +28713,7 @@ export const deserializeAws_restJson1UpdateThingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.version !== undefined && data.version !== null) {
     contents.version = __expectLong(data.version);
   }
@@ -28957,7 +28959,7 @@ export const deserializeAws_restJson1ValidateSecurityProfileBehaviorsCommand = a
     valid: undefined,
     validationErrors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.valid !== undefined && data.valid !== null) {
     contents.valid = __expectBoolean(data.valid);
   }

--- a/clients/client-iotanalytics/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1.ts
@@ -148,6 +148,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1265,7 +1267,7 @@ export const deserializeAws_restJson1BatchPutMessageCommand = async (
     $metadata: deserializeMetadata(output),
     batchPutMessageErrorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.batchPutMessageErrorEntries !== undefined && data.batchPutMessageErrorEntries !== null) {
     contents.batchPutMessageErrorEntries = deserializeAws_restJson1BatchPutMessageErrorEntries(
       data.batchPutMessageErrorEntries,
@@ -1440,7 +1442,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     channelName: undefined,
     retentionPeriod: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelArn !== undefined && data.channelArn !== null) {
     contents.channelArn = __expectString(data.channelArn);
   }
@@ -1543,7 +1545,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
     datasetName: undefined,
     retentionPeriod: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetArn !== undefined && data.datasetArn !== null) {
     contents.datasetArn = __expectString(data.datasetArn);
   }
@@ -1644,7 +1646,7 @@ export const deserializeAws_restJson1CreateDatasetContentCommand = async (
     $metadata: deserializeMetadata(output),
     versionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.versionId !== undefined && data.versionId !== null) {
     contents.versionId = __expectString(data.versionId);
   }
@@ -1733,7 +1735,7 @@ export const deserializeAws_restJson1CreateDatastoreCommand = async (
     datastoreName: undefined,
     retentionPeriod: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datastoreArn !== undefined && data.datastoreArn !== null) {
     contents.datastoreArn = __expectString(data.datastoreArn);
   }
@@ -1835,7 +1837,7 @@ export const deserializeAws_restJson1CreatePipelineCommand = async (
     pipelineArn: undefined,
     pipelineName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.pipelineArn !== undefined && data.pipelineArn !== null) {
     contents.pipelineArn = __expectString(data.pipelineArn);
   }
@@ -2349,7 +2351,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     channel: undefined,
     statistics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -2439,7 +2441,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     dataset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataset !== undefined && data.dataset !== null) {
     contents.dataset = deserializeAws_restJson1Dataset(data.dataset, context);
   }
@@ -2527,7 +2529,7 @@ export const deserializeAws_restJson1DescribeDatastoreCommand = async (
     datastore: undefined,
     statistics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datastore !== undefined && data.datastore !== null) {
     contents.datastore = deserializeAws_restJson1Datastore(data.datastore, context);
   }
@@ -2617,7 +2619,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
     $metadata: deserializeMetadata(output),
     loggingOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.loggingOptions !== undefined && data.loggingOptions !== null) {
     contents.loggingOptions = deserializeAws_restJson1LoggingOptions(data.loggingOptions, context);
   }
@@ -2704,7 +2706,7 @@ export const deserializeAws_restJson1DescribePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     pipeline: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.pipeline !== undefined && data.pipeline !== null) {
     contents.pipeline = deserializeAws_restJson1Pipeline(data.pipeline, context);
   }
@@ -2793,7 +2795,7 @@ export const deserializeAws_restJson1GetDatasetContentCommand = async (
     status: undefined,
     timestamp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entries !== undefined && data.entries !== null) {
     contents.entries = deserializeAws_restJson1DatasetEntries(data.entries, context);
   }
@@ -2887,7 +2889,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     channelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelSummaries !== undefined && data.channelSummaries !== null) {
     contents.channelSummaries = deserializeAws_restJson1ChannelSummaries(data.channelSummaries, context);
   }
@@ -2970,7 +2972,7 @@ export const deserializeAws_restJson1ListDatasetContentsCommand = async (
     datasetContentSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetContentSummaries !== undefined && data.datasetContentSummaries !== null) {
     contents.datasetContentSummaries = deserializeAws_restJson1DatasetContentSummaries(
       data.datasetContentSummaries,
@@ -3064,7 +3066,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     datasetSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetSummaries !== undefined && data.datasetSummaries !== null) {
     contents.datasetSummaries = deserializeAws_restJson1DatasetSummaries(data.datasetSummaries, context);
   }
@@ -3147,7 +3149,7 @@ export const deserializeAws_restJson1ListDatastoresCommand = async (
     datastoreSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datastoreSummaries !== undefined && data.datastoreSummaries !== null) {
     contents.datastoreSummaries = deserializeAws_restJson1DatastoreSummaries(data.datastoreSummaries, context);
   }
@@ -3230,7 +3232,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
     nextToken: undefined,
     pipelineSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3312,7 +3314,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
@@ -3483,7 +3485,7 @@ export const deserializeAws_restJson1RunPipelineActivityCommand = async (
     logResult: undefined,
     payloads: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logResult !== undefined && data.logResult !== null) {
     contents.logResult = __expectString(data.logResult);
   }
@@ -3565,7 +3567,7 @@ export const deserializeAws_restJson1SampleChannelDataCommand = async (
     $metadata: deserializeMetadata(output),
     payloads: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.payloads !== undefined && data.payloads !== null) {
     contents.payloads = deserializeAws_restJson1MessagePayloads(data.payloads, context);
   }
@@ -3652,7 +3654,7 @@ export const deserializeAws_restJson1StartPipelineReprocessingCommand = async (
     $metadata: deserializeMetadata(output),
     reprocessingId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reprocessingId !== undefined && data.reprocessingId !== null) {
     contents.reprocessingId = __expectString(data.reprocessingId);
   }

--- a/clients/client-iotdeviceadvisor/protocols/Aws_restJson1.ts
+++ b/clients/client-iotdeviceadvisor/protocols/Aws_restJson1.ts
@@ -44,6 +44,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -503,7 +505,7 @@ export const deserializeAws_restJson1CreateSuiteDefinitionCommand = async (
     suiteDefinitionId: undefined,
     suiteDefinitionName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
@@ -641,7 +643,7 @@ export const deserializeAws_restJson1GetSuiteDefinitionCommand = async (
     suiteDefinitionVersion: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
@@ -746,7 +748,7 @@ export const deserializeAws_restJson1GetSuiteRunCommand = async (
     tags: undefined,
     testResult: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endTime !== undefined && data.endTime !== null) {
     contents.endTime = new Date(Math.round(data.endTime * 1000));
   }
@@ -847,7 +849,7 @@ export const deserializeAws_restJson1GetSuiteRunReportCommand = async (
     $metadata: deserializeMetadata(output),
     qualificationReportDownloadUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.qualificationReportDownloadUrl !== undefined && data.qualificationReportDownloadUrl !== null) {
     contents.qualificationReportDownloadUrl = __expectString(data.qualificationReportDownloadUrl);
   }
@@ -919,7 +921,7 @@ export const deserializeAws_restJson1ListSuiteDefinitionsCommand = async (
     nextToken: undefined,
     suiteDefinitionInformationList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -989,7 +991,7 @@ export const deserializeAws_restJson1ListSuiteRunsCommand = async (
     nextToken: undefined,
     suiteRunsList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1055,7 +1057,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1128,7 +1130,7 @@ export const deserializeAws_restJson1StartSuiteRunCommand = async (
     suiteRunArn: undefined,
     suiteRunId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }
@@ -1411,7 +1413,7 @@ export const deserializeAws_restJson1UpdateSuiteDefinitionCommand = async (
     suiteDefinitionName: undefined,
     suiteDefinitionVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(Math.round(data.createdAt * 1000));
   }

--- a/clients/client-iotfleethub/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/protocols/Aws_restJson1.ts
@@ -24,6 +24,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -294,7 +296,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     applicationArn: undefined,
     applicationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -462,7 +464,7 @@ export const deserializeAws_restJson1DescribeApplicationCommand = async (
     ssoClientId: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -575,7 +577,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     applicationSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationSummaries !== undefined && data.applicationSummaries !== null) {
     contents.applicationSummaries = deserializeAws_restJson1ApplicationSummaries(data.applicationSummaries, context);
   }
@@ -649,7 +651,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-iotsitewise/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/protocols/Aws_restJson1.ts
@@ -211,6 +211,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -2666,7 +2668,7 @@ export const deserializeAws_restJson1BatchAssociateProjectAssetsCommand = async 
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchAssociateProjectAssetsErrors(data.errors, context);
   }
@@ -2753,7 +2755,7 @@ export const deserializeAws_restJson1BatchDisassociateProjectAssetsCommand = asy
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchDisassociateProjectAssetsErrors(data.errors, context);
   }
@@ -2832,7 +2834,7 @@ export const deserializeAws_restJson1BatchPutAssetPropertyValueCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchPutAssetPropertyErrorEntries(data.errorEntries, context);
   }
@@ -2936,7 +2938,7 @@ export const deserializeAws_restJson1CreateAccessPolicyCommand = async (
     accessPolicyArn: undefined,
     accessPolicyId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPolicyArn !== undefined && data.accessPolicyArn !== null) {
     contents.accessPolicyArn = __expectString(data.accessPolicyArn);
   }
@@ -3028,7 +3030,7 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
     assetId: undefined,
     assetStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetArn !== undefined && data.assetArn !== null) {
     contents.assetArn = __expectString(data.assetArn);
   }
@@ -3139,7 +3141,7 @@ export const deserializeAws_restJson1CreateAssetModelCommand = async (
     assetModelId: undefined,
     assetModelStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelArn !== undefined && data.assetModelArn !== null) {
     contents.assetModelArn = __expectString(data.assetModelArn);
   }
@@ -3249,7 +3251,7 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
     dashboardArn: undefined,
     dashboardId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dashboardArn !== undefined && data.dashboardArn !== null) {
     contents.dashboardArn = __expectString(data.dashboardArn);
   }
@@ -3340,7 +3342,7 @@ export const deserializeAws_restJson1CreateGatewayCommand = async (
     gatewayArn: undefined,
     gatewayId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.gatewayArn !== undefined && data.gatewayArn !== null) {
     contents.gatewayArn = __expectString(data.gatewayArn);
   }
@@ -3434,7 +3436,7 @@ export const deserializeAws_restJson1CreatePortalCommand = async (
     portalStatus: undefined,
     ssoApplicationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalArn !== undefined && data.portalArn !== null) {
     contents.portalArn = __expectString(data.portalArn);
   }
@@ -3534,7 +3536,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     projectArn: undefined,
     projectId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.projectArn !== undefined && data.projectArn !== null) {
     contents.projectArn = __expectString(data.projectArn);
   }
@@ -3699,7 +3701,7 @@ export const deserializeAws_restJson1DeleteAssetCommand = async (
     $metadata: deserializeMetadata(output),
     assetStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetStatus !== undefined && data.assetStatus !== null) {
     contents.assetStatus = deserializeAws_restJson1AssetStatus(data.assetStatus, context);
   }
@@ -3786,7 +3788,7 @@ export const deserializeAws_restJson1DeleteAssetModelCommand = async (
     $metadata: deserializeMetadata(output),
     assetModelStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelStatus !== undefined && data.assetModelStatus !== null) {
     contents.assetModelStatus = deserializeAws_restJson1AssetModelStatus(data.assetModelStatus, context);
   }
@@ -4023,7 +4025,7 @@ export const deserializeAws_restJson1DeletePortalCommand = async (
     $metadata: deserializeMetadata(output),
     portalStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalStatus !== undefined && data.portalStatus !== null) {
     contents.portalStatus = deserializeAws_restJson1PortalStatus(data.portalStatus, context);
   }
@@ -4191,7 +4193,7 @@ export const deserializeAws_restJson1DescribeAccessPolicyCommand = async (
     accessPolicyPermission: undefined,
     accessPolicyResource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPolicyArn !== undefined && data.accessPolicyArn !== null) {
     contents.accessPolicyArn = __expectString(data.accessPolicyArn);
   }
@@ -4297,7 +4299,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
     assetProperties: undefined,
     assetStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetArn !== undefined && data.assetArn !== null) {
     contents.assetArn = __expectString(data.assetArn);
   }
@@ -4412,7 +4414,7 @@ export const deserializeAws_restJson1DescribeAssetModelCommand = async (
     assetModelProperties: undefined,
     assetModelStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelArn !== undefined && data.assetModelArn !== null) {
     contents.assetModelArn = __expectString(data.assetModelArn);
   }
@@ -4525,7 +4527,7 @@ export const deserializeAws_restJson1DescribeAssetPropertyCommand = async (
     assetProperty: undefined,
     compositeModel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetId !== undefined && data.assetId !== null) {
     contents.assetId = __expectString(data.assetId);
   }
@@ -4623,7 +4625,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
     dashboardName: undefined,
     projectId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dashboardArn !== undefined && data.dashboardArn !== null) {
     contents.dashboardArn = __expectString(data.dashboardArn);
   }
@@ -4725,7 +4727,7 @@ export const deserializeAws_restJson1DescribeDefaultEncryptionConfigurationComma
     encryptionType: undefined,
     kmsKeyArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -4808,7 +4810,7 @@ export const deserializeAws_restJson1DescribeGatewayCommand = async (
     gatewayPlatform: undefined,
     lastUpdateDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = new Date(Math.round(data.creationDate * 1000));
   }
@@ -4911,7 +4913,7 @@ export const deserializeAws_restJson1DescribeGatewayCapabilityConfigurationComma
     capabilitySyncStatus: undefined,
     gatewayId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.capabilityConfiguration !== undefined && data.capabilityConfiguration !== null) {
     contents.capabilityConfiguration = __expectString(data.capabilityConfiguration);
   }
@@ -4999,7 +5001,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
     $metadata: deserializeMetadata(output),
     loggingOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.loggingOptions !== undefined && data.loggingOptions !== null) {
     contents.loggingOptions = deserializeAws_restJson1LoggingOptions(data.loggingOptions, context);
   }
@@ -5092,7 +5094,7 @@ export const deserializeAws_restJson1DescribePortalCommand = async (
     portalStatus: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarms !== undefined && data.alarms !== null) {
     contents.alarms = deserializeAws_restJson1Alarms(data.alarms, context);
   }
@@ -5219,7 +5221,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     projectLastUpdateDate: undefined,
     projectName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalId !== undefined && data.portalId !== null) {
     contents.portalId = __expectString(data.portalId);
   }
@@ -5319,7 +5321,7 @@ export const deserializeAws_restJson1DescribeStorageConfigurationCommand = async
     multiLayerStorage: undefined,
     storageType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -5507,7 +5509,7 @@ export const deserializeAws_restJson1GetAssetPropertyAggregatesCommand = async (
     aggregatedValues: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.aggregatedValues !== undefined && data.aggregatedValues !== null) {
     contents.aggregatedValues = deserializeAws_restJson1AggregatedValues(data.aggregatedValues, context);
   }
@@ -5597,7 +5599,7 @@ export const deserializeAws_restJson1GetAssetPropertyValueCommand = async (
     $metadata: deserializeMetadata(output),
     propertyValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.propertyValue !== undefined && data.propertyValue !== null) {
     contents.propertyValue = deserializeAws_restJson1AssetPropertyValue(data.propertyValue, context);
   }
@@ -5685,7 +5687,7 @@ export const deserializeAws_restJson1GetAssetPropertyValueHistoryCommand = async
     assetPropertyValueHistory: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetPropertyValueHistory !== undefined && data.assetPropertyValueHistory !== null) {
     contents.assetPropertyValueHistory = deserializeAws_restJson1AssetPropertyValueHistory(
       data.assetPropertyValueHistory,
@@ -5779,7 +5781,7 @@ export const deserializeAws_restJson1GetInterpolatedAssetPropertyValuesCommand =
     interpolatedAssetPropertyValues: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.interpolatedAssetPropertyValues !== undefined && data.interpolatedAssetPropertyValues !== null) {
     contents.interpolatedAssetPropertyValues = deserializeAws_restJson1InterpolatedAssetPropertyValues(
       data.interpolatedAssetPropertyValues,
@@ -5873,7 +5875,7 @@ export const deserializeAws_restJson1ListAccessPoliciesCommand = async (
     accessPolicySummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPolicySummaries !== undefined && data.accessPolicySummaries !== null) {
     contents.accessPolicySummaries = deserializeAws_restJson1AccessPolicySummaries(data.accessPolicySummaries, context);
   }
@@ -5948,7 +5950,7 @@ export const deserializeAws_restJson1ListAssetModelsCommand = async (
     assetModelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelSummaries !== undefined && data.assetModelSummaries !== null) {
     contents.assetModelSummaries = deserializeAws_restJson1AssetModelSummaries(data.assetModelSummaries, context);
   }
@@ -6023,7 +6025,7 @@ export const deserializeAws_restJson1ListAssetRelationshipsCommand = async (
     assetRelationshipSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetRelationshipSummaries !== undefined && data.assetRelationshipSummaries !== null) {
     contents.assetRelationshipSummaries = deserializeAws_restJson1AssetRelationshipSummaries(
       data.assetRelationshipSummaries,
@@ -6109,7 +6111,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
     assetSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetSummaries !== undefined && data.assetSummaries !== null) {
     contents.assetSummaries = deserializeAws_restJson1AssetSummaries(data.assetSummaries, context);
   }
@@ -6192,7 +6194,7 @@ export const deserializeAws_restJson1ListAssociatedAssetsCommand = async (
     assetSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetSummaries !== undefined && data.assetSummaries !== null) {
     contents.assetSummaries = deserializeAws_restJson1AssociatedAssetsSummaries(data.assetSummaries, context);
   }
@@ -6275,7 +6277,7 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
     dashboardSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dashboardSummaries !== undefined && data.dashboardSummaries !== null) {
     contents.dashboardSummaries = deserializeAws_restJson1DashboardSummaries(data.dashboardSummaries, context);
   }
@@ -6350,7 +6352,7 @@ export const deserializeAws_restJson1ListGatewaysCommand = async (
     gatewaySummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.gatewaySummaries !== undefined && data.gatewaySummaries !== null) {
     contents.gatewaySummaries = deserializeAws_restJson1GatewaySummaries(data.gatewaySummaries, context);
   }
@@ -6425,7 +6427,7 @@ export const deserializeAws_restJson1ListPortalsCommand = async (
     nextToken: undefined,
     portalSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6500,7 +6502,7 @@ export const deserializeAws_restJson1ListProjectAssetsCommand = async (
     assetIds: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetIds !== undefined && data.assetIds !== null) {
     contents.assetIds = deserializeAws_restJson1AssetIDs(data.assetIds, context);
   }
@@ -6575,7 +6577,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     nextToken: undefined,
     projectSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6649,7 +6651,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -6754,7 +6756,7 @@ export const deserializeAws_restJson1PutDefaultEncryptionConfigurationCommand = 
     encryptionType: undefined,
     kmsKeyArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -6932,7 +6934,7 @@ export const deserializeAws_restJson1PutStorageConfigurationCommand = async (
     multiLayerStorage: undefined,
     storageType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -7322,7 +7324,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     $metadata: deserializeMetadata(output),
     assetStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetStatus !== undefined && data.assetStatus !== null) {
     contents.assetStatus = deserializeAws_restJson1AssetStatus(data.assetStatus, context);
   }
@@ -7417,7 +7419,7 @@ export const deserializeAws_restJson1UpdateAssetModelCommand = async (
     $metadata: deserializeMetadata(output),
     assetModelStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelStatus !== undefined && data.assetModelStatus !== null) {
     contents.assetModelStatus = deserializeAws_restJson1AssetModelStatus(data.assetModelStatus, context);
   }
@@ -7762,7 +7764,7 @@ export const deserializeAws_restJson1UpdateGatewayCapabilityConfigurationCommand
     capabilityNamespace: undefined,
     capabilitySyncStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.capabilityNamespace !== undefined && data.capabilityNamespace !== null) {
     contents.capabilityNamespace = __expectString(data.capabilityNamespace);
   }
@@ -7860,7 +7862,7 @@ export const deserializeAws_restJson1UpdatePortalCommand = async (
     $metadata: deserializeMetadata(output),
     portalStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalStatus !== undefined && data.portalStatus !== null) {
     contents.portalStatus = deserializeAws_restJson1PortalStatus(data.portalStatus, context);
   }

--- a/clients/client-ivs/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/protocols/Aws_restJson1.ts
@@ -77,6 +77,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -793,7 +795,7 @@ export const deserializeAws_restJson1BatchGetChannelCommand = async (
     channels: undefined,
     errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.channels = deserializeAws_restJson1Channels(data.channels, context);
   }
@@ -844,7 +846,7 @@ export const deserializeAws_restJson1BatchGetStreamKeyCommand = async (
     errors: undefined,
     streamKeys: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchErrors(data.errors, context);
   }
@@ -895,7 +897,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     channel: undefined,
     streamKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -985,7 +987,7 @@ export const deserializeAws_restJson1CreateRecordingConfigurationCommand = async
     $metadata: deserializeMetadata(output),
     recordingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recordingConfiguration !== undefined && data.recordingConfiguration !== null) {
     contents.recordingConfiguration = deserializeAws_restJson1RecordingConfiguration(
       data.recordingConfiguration,
@@ -1083,7 +1085,7 @@ export const deserializeAws_restJson1CreateStreamKeyCommand = async (
     $metadata: deserializeMetadata(output),
     streamKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamKey !== undefined && data.streamKey !== null) {
     contents.streamKey = deserializeAws_restJson1StreamKey(data.streamKey, context);
   }
@@ -1486,7 +1488,7 @@ export const deserializeAws_restJson1GetChannelCommand = async (
     $metadata: deserializeMetadata(output),
     channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -1557,7 +1559,7 @@ export const deserializeAws_restJson1GetPlaybackKeyPairCommand = async (
     $metadata: deserializeMetadata(output),
     keyPair: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keyPair !== undefined && data.keyPair !== null) {
     contents.keyPair = deserializeAws_restJson1PlaybackKeyPair(data.keyPair, context);
   }
@@ -1628,7 +1630,7 @@ export const deserializeAws_restJson1GetRecordingConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     recordingConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recordingConfiguration !== undefined && data.recordingConfiguration !== null) {
     contents.recordingConfiguration = deserializeAws_restJson1RecordingConfiguration(
       data.recordingConfiguration,
@@ -1710,7 +1712,7 @@ export const deserializeAws_restJson1GetStreamCommand = async (
     $metadata: deserializeMetadata(output),
     stream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.stream !== undefined && data.stream !== null) {
     contents.stream = deserializeAws_restJson1_Stream(data.stream, context);
   }
@@ -1789,7 +1791,7 @@ export const deserializeAws_restJson1GetStreamKeyCommand = async (
     $metadata: deserializeMetadata(output),
     streamKey: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamKey !== undefined && data.streamKey !== null) {
     contents.streamKey = deserializeAws_restJson1StreamKey(data.streamKey, context);
   }
@@ -1860,7 +1862,7 @@ export const deserializeAws_restJson1ImportPlaybackKeyPairCommand = async (
     $metadata: deserializeMetadata(output),
     keyPair: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keyPair !== undefined && data.keyPair !== null) {
     contents.keyPair = deserializeAws_restJson1PlaybackKeyPair(data.keyPair, context);
   }
@@ -1948,7 +1950,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     channels: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.channels = deserializeAws_restJson1ChannelList(data.channels, context);
   }
@@ -2023,7 +2025,7 @@ export const deserializeAws_restJson1ListPlaybackKeyPairsCommand = async (
     keyPairs: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keyPairs !== undefined && data.keyPairs !== null) {
     contents.keyPairs = deserializeAws_restJson1PlaybackKeyPairList(data.keyPairs, context);
   }
@@ -2090,7 +2092,7 @@ export const deserializeAws_restJson1ListRecordingConfigurationsCommand = async 
     nextToken: undefined,
     recordingConfigurations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2168,7 +2170,7 @@ export const deserializeAws_restJson1ListStreamKeysCommand = async (
     nextToken: undefined,
     streamKeys: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2243,7 +2245,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
     nextToken: undefined,
     streams: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2302,7 +2304,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     nextToken: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2676,7 +2678,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }

--- a/clients/client-kafka/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1.ts
@@ -133,6 +133,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1167,7 +1169,7 @@ export const deserializeAws_restJson1BatchAssociateScramSecretCommand = async (
     ClusterArn: undefined,
     UnprocessedScramSecrets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1277,7 +1279,7 @@ export const deserializeAws_restJson1BatchDisassociateScramSecretCommand = async
     ClusterArn: undefined,
     UnprocessedScramSecrets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1388,7 +1390,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
     ClusterName: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1501,7 +1503,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1617,7 +1619,7 @@ export const deserializeAws_restJson1DeleteClusterCommand = async (
     ClusterArn: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1700,7 +1702,7 @@ export const deserializeAws_restJson1DeleteConfigurationCommand = async (
     Arn: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1782,7 +1784,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
     $metadata: deserializeMetadata(output),
     ClusterInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterInfo !== undefined && data.clusterInfo !== null) {
     contents.ClusterInfo = deserializeAws_restJson1ClusterInfo(data.clusterInfo, context);
   }
@@ -1869,7 +1871,7 @@ export const deserializeAws_restJson1DescribeClusterOperationCommand = async (
     $metadata: deserializeMetadata(output),
     ClusterOperationInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterOperationInfo !== undefined && data.clusterOperationInfo !== null) {
     contents.ClusterOperationInfo = deserializeAws_restJson1ClusterOperationInfo(data.clusterOperationInfo, context);
   }
@@ -1962,7 +1964,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2079,7 +2081,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     Revision: undefined,
     ServerProperties: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2189,7 +2191,7 @@ export const deserializeAws_restJson1GetBootstrapBrokersCommand = async (
     BootstrapBrokerStringSaslScram: undefined,
     BootstrapBrokerStringTls: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bootstrapBrokerString !== undefined && data.bootstrapBrokerString !== null) {
     contents.BootstrapBrokerString = __expectString(data.bootstrapBrokerString);
   }
@@ -2285,7 +2287,7 @@ export const deserializeAws_restJson1GetCompatibleKafkaVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     CompatibleKafkaVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.compatibleKafkaVersions !== undefined && data.compatibleKafkaVersions !== null) {
     contents.CompatibleKafkaVersions = deserializeAws_restJson1__listOfCompatibleKafkaVersion(
       data.compatibleKafkaVersions,
@@ -2392,7 +2394,7 @@ export const deserializeAws_restJson1ListClusterOperationsCommand = async (
     ClusterOperationInfoList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterOperationInfoList !== undefined && data.clusterOperationInfoList !== null) {
     contents.ClusterOperationInfoList = deserializeAws_restJson1__listOfClusterOperationInfo(
       data.clusterOperationInfoList,
@@ -2478,7 +2480,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     ClusterInfoList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterInfoList !== undefined && data.clusterInfoList !== null) {
     contents.ClusterInfoList = deserializeAws_restJson1__listOfClusterInfo(data.clusterInfoList, context);
   }
@@ -2561,7 +2563,7 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
     NextToken: undefined,
     Revisions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2660,7 +2662,7 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
     Configurations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurations !== undefined && data.configurations !== null) {
     contents.Configurations = deserializeAws_restJson1__listOfConfiguration(data.configurations, context);
   }
@@ -2751,7 +2753,7 @@ export const deserializeAws_restJson1ListKafkaVersionsCommand = async (
     KafkaVersions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.kafkaVersions !== undefined && data.kafkaVersions !== null) {
     contents.KafkaVersions = deserializeAws_restJson1__listOfKafkaVersion(data.kafkaVersions, context);
   }
@@ -2834,7 +2836,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
     NextToken: undefined,
     NodeInfoList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2917,7 +2919,7 @@ export const deserializeAws_restJson1ListScramSecretsCommand = async (
     NextToken: undefined,
     SecretArnList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -3023,7 +3025,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -3095,7 +3097,7 @@ export const deserializeAws_restJson1RebootBrokerCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3336,7 +3338,7 @@ export const deserializeAws_restJson1UpdateBrokerCountCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3427,7 +3429,7 @@ export const deserializeAws_restJson1UpdateBrokerStorageCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3518,7 +3520,7 @@ export const deserializeAws_restJson1UpdateBrokerTypeCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3625,7 +3627,7 @@ export const deserializeAws_restJson1UpdateClusterConfigurationCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3724,7 +3726,7 @@ export const deserializeAws_restJson1UpdateClusterKafkaVersionCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3831,7 +3833,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
     Arn: undefined,
     LatestRevision: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -3930,7 +3932,7 @@ export const deserializeAws_restJson1UpdateMonitoringCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }

--- a/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
@@ -33,7 +33,12 @@ import {
   UnsupportedStreamMediaTypeException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectLong as __expectLong, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -341,7 +346,7 @@ export const deserializeAws_restJson1GetDASHStreamingSessionURLCommand = async (
     $metadata: deserializeMetadata(output),
     DASHStreamingSessionURL: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DASHStreamingSessionURL !== undefined && data.DASHStreamingSessionURL !== null) {
     contents.DASHStreamingSessionURL = __expectString(data.DASHStreamingSessionURL);
   }
@@ -452,7 +457,7 @@ export const deserializeAws_restJson1GetHLSStreamingSessionURLCommand = async (
     $metadata: deserializeMetadata(output),
     HLSStreamingSessionURL: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HLSStreamingSessionURL !== undefined && data.HLSStreamingSessionURL !== null) {
     contents.HLSStreamingSessionURL = __expectString(data.HLSStreamingSessionURL);
   }
@@ -645,7 +650,7 @@ export const deserializeAws_restJson1ListFragmentsCommand = async (
     Fragments: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Fragments !== undefined && data.Fragments !== null) {
     contents.Fragments = deserializeAws_restJson1FragmentList(data.Fragments, context);
   }

--- a/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
@@ -13,7 +13,12 @@ import {
   SessionExpiredException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -90,7 +95,7 @@ export const deserializeAws_restJson1GetIceServerConfigCommand = async (
     $metadata: deserializeMetadata(output),
     IceServerList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IceServerList !== undefined && data.IceServerList !== null) {
     contents.IceServerList = deserializeAws_restJson1IceServerList(data.IceServerList, context);
   }
@@ -185,7 +190,7 @@ export const deserializeAws_restJson1SendAlexaOfferToMasterCommand = async (
     $metadata: deserializeMetadata(output),
     Answer: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Answer !== undefined && data.Answer !== null) {
     contents.Answer = __expectString(data.Answer);
   }

--- a/clients/client-kinesis-video/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1.ts
@@ -66,7 +66,12 @@ import {
   VersionMismatchException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -619,7 +624,7 @@ export const deserializeAws_restJson1CreateSignalingChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelARN: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelARN !== undefined && data.ChannelARN !== null) {
     contents.ChannelARN = __expectString(data.ChannelARN);
   }
@@ -714,7 +719,7 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
     $metadata: deserializeMetadata(output),
     StreamARN: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamARN !== undefined && data.StreamARN !== null) {
     contents.StreamARN = __expectString(data.StreamARN);
   }
@@ -999,7 +1004,7 @@ export const deserializeAws_restJson1DescribeSignalingChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelInfo !== undefined && data.ChannelInfo !== null) {
     contents.ChannelInfo = deserializeAws_restJson1ChannelInfo(data.ChannelInfo, context);
   }
@@ -1078,7 +1083,7 @@ export const deserializeAws_restJson1DescribeStreamCommand = async (
     $metadata: deserializeMetadata(output),
     StreamInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamInfo !== undefined && data.StreamInfo !== null) {
     contents.StreamInfo = deserializeAws_restJson1StreamInfo(data.StreamInfo, context);
   }
@@ -1157,7 +1162,7 @@ export const deserializeAws_restJson1GetDataEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     DataEndpoint: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataEndpoint !== undefined && data.DataEndpoint !== null) {
     contents.DataEndpoint = __expectString(data.DataEndpoint);
   }
@@ -1236,7 +1241,7 @@ export const deserializeAws_restJson1GetSignalingChannelEndpointCommand = async 
     $metadata: deserializeMetadata(output),
     ResourceEndpointList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceEndpointList !== undefined && data.ResourceEndpointList !== null) {
     contents.ResourceEndpointList = deserializeAws_restJson1ResourceEndpointList(data.ResourceEndpointList, context);
   }
@@ -1324,7 +1329,7 @@ export const deserializeAws_restJson1ListSignalingChannelsCommand = async (
     ChannelInfoList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelInfoList !== undefined && data.ChannelInfoList !== null) {
     contents.ChannelInfoList = deserializeAws_restJson1ChannelInfoList(data.ChannelInfoList, context);
   }
@@ -1399,7 +1404,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
     NextToken: undefined,
     StreamInfoList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1466,7 +1471,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1549,7 +1554,7 @@ export const deserializeAws_restJson1ListTagsForStreamCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -238,6 +238,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -2449,7 +2451,7 @@ export const deserializeAws_restJson1AddLayerVersionPermissionCommand = async (
     RevisionId: undefined,
     Statement: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
     contents.RevisionId = __expectString(data.RevisionId);
   }
@@ -2555,7 +2557,7 @@ export const deserializeAws_restJson1AddPermissionCommand = async (
     $metadata: deserializeMetadata(output),
     Statement: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Statement !== undefined && data.Statement !== null) {
     contents.Statement = __expectString(data.Statement);
   }
@@ -2663,7 +2665,7 @@ export const deserializeAws_restJson1CreateAliasCommand = async (
     RevisionId: undefined,
     RoutingConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
     contents.AliasArn = __expectString(data.AliasArn);
   }
@@ -2765,7 +2767,7 @@ export const deserializeAws_restJson1CreateCodeSigningConfigCommand = async (
     $metadata: deserializeMetadata(output),
     CodeSigningConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfig !== undefined && data.CodeSigningConfig !== null) {
     contents.CodeSigningConfig = deserializeAws_restJson1CodeSigningConfig(data.CodeSigningConfig, context);
   }
@@ -2849,7 +2851,7 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -3038,7 +3040,7 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
     contents.CodeSha256 = __expectString(data.CodeSha256);
   }
@@ -3418,7 +3420,7 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -4060,7 +4062,7 @@ export const deserializeAws_restJson1GetAccountSettingsCommand = async (
     AccountLimit: undefined,
     AccountUsage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountLimit !== undefined && data.AccountLimit !== null) {
     contents.AccountLimit = deserializeAws_restJson1AccountLimit(data.AccountLimit, context);
   }
@@ -4131,7 +4133,7 @@ export const deserializeAws_restJson1GetAliasCommand = async (
     RevisionId: undefined,
     RoutingConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
     contents.AliasArn = __expectString(data.AliasArn);
   }
@@ -4225,7 +4227,7 @@ export const deserializeAws_restJson1GetCodeSigningConfigCommand = async (
     $metadata: deserializeMetadata(output),
     CodeSigningConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfig !== undefined && data.CodeSigningConfig !== null) {
     contents.CodeSigningConfig = deserializeAws_restJson1CodeSigningConfig(data.CodeSigningConfig, context);
   }
@@ -4317,7 +4319,7 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -4471,7 +4473,7 @@ export const deserializeAws_restJson1GetFunctionCommand = async (
     Configuration: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Code !== undefined && data.Code !== null) {
     contents.Code = deserializeAws_restJson1FunctionCodeLocation(data.Code, context);
   }
@@ -4560,7 +4562,7 @@ export const deserializeAws_restJson1GetFunctionCodeSigningConfigCommand = async
     CodeSigningConfigArn: undefined,
     FunctionName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfigArn !== undefined && data.CodeSigningConfigArn !== null) {
     contents.CodeSigningConfigArn = __expectString(data.CodeSigningConfigArn);
   }
@@ -4642,7 +4644,7 @@ export const deserializeAws_restJson1GetFunctionConcurrencyCommand = async (
     $metadata: deserializeMetadata(output),
     ReservedConcurrentExecutions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReservedConcurrentExecutions !== undefined && data.ReservedConcurrentExecutions !== null) {
     contents.ReservedConcurrentExecutions = __expectInt32(data.ReservedConcurrentExecutions);
   }
@@ -4751,7 +4753,7 @@ export const deserializeAws_restJson1GetFunctionConfigurationCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
     contents.CodeSha256 = __expectString(data.CodeSha256);
   }
@@ -4924,7 +4926,7 @@ export const deserializeAws_restJson1GetFunctionEventInvokeConfigCommand = async
     MaximumEventAgeInSeconds: undefined,
     MaximumRetryAttempts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
@@ -5022,7 +5024,7 @@ export const deserializeAws_restJson1GetLayerVersionCommand = async (
     LicenseInfo: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleRuntimes !== undefined && data.CompatibleRuntimes !== null) {
     contents.CompatibleRuntimes = deserializeAws_restJson1CompatibleRuntimes(data.CompatibleRuntimes, context);
   }
@@ -5129,7 +5131,7 @@ export const deserializeAws_restJson1GetLayerVersionByArnCommand = async (
     LicenseInfo: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleRuntimes !== undefined && data.CompatibleRuntimes !== null) {
     contents.CompatibleRuntimes = deserializeAws_restJson1CompatibleRuntimes(data.CompatibleRuntimes, context);
   }
@@ -5230,7 +5232,7 @@ export const deserializeAws_restJson1GetLayerVersionPolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = __expectString(data.Policy);
   }
@@ -5313,7 +5315,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = __expectString(data.Policy);
   }
@@ -5400,7 +5402,7 @@ export const deserializeAws_restJson1GetProvisionedConcurrencyConfigCommand = as
     Status: undefined,
     StatusReason: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.AllocatedProvisionedConcurrentExecutions !== undefined &&
     data.AllocatedProvisionedConcurrentExecutions !== null
@@ -5868,7 +5870,7 @@ export const deserializeAws_restJson1ListAliasesCommand = async (
     Aliases: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Aliases !== undefined && data.Aliases !== null) {
     contents.Aliases = deserializeAws_restJson1AliasList(data.Aliases, context);
   }
@@ -5951,7 +5953,7 @@ export const deserializeAws_restJson1ListCodeSigningConfigsCommand = async (
     CodeSigningConfigs: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfigs !== undefined && data.CodeSigningConfigs !== null) {
     contents.CodeSigningConfigs = deserializeAws_restJson1CodeSigningConfigList(data.CodeSigningConfigs, context);
   }
@@ -6018,7 +6020,7 @@ export const deserializeAws_restJson1ListEventSourceMappingsCommand = async (
     EventSourceMappings: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventSourceMappings !== undefined && data.EventSourceMappings !== null) {
     contents.EventSourceMappings = deserializeAws_restJson1EventSourceMappingsList(data.EventSourceMappings, context);
   }
@@ -6101,7 +6103,7 @@ export const deserializeAws_restJson1ListFunctionEventInvokeConfigsCommand = asy
     FunctionEventInvokeConfigs: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FunctionEventInvokeConfigs !== undefined && data.FunctionEventInvokeConfigs !== null) {
     contents.FunctionEventInvokeConfigs = deserializeAws_restJson1FunctionEventInvokeConfigList(
       data.FunctionEventInvokeConfigs,
@@ -6187,7 +6189,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
     Functions: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Functions !== undefined && data.Functions !== null) {
     contents.Functions = deserializeAws_restJson1FunctionList(data.Functions, context);
   }
@@ -6262,7 +6264,7 @@ export const deserializeAws_restJson1ListFunctionsByCodeSigningConfigCommand = a
     FunctionArns: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FunctionArns !== undefined && data.FunctionArns !== null) {
     contents.FunctionArns = deserializeAws_restJson1FunctionArnList(data.FunctionArns, context);
   }
@@ -6337,7 +6339,7 @@ export const deserializeAws_restJson1ListLayersCommand = async (
     Layers: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Layers !== undefined && data.Layers !== null) {
     contents.Layers = deserializeAws_restJson1LayersList(data.Layers, context);
   }
@@ -6412,7 +6414,7 @@ export const deserializeAws_restJson1ListLayerVersionsCommand = async (
     LayerVersions: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LayerVersions !== undefined && data.LayerVersions !== null) {
     contents.LayerVersions = deserializeAws_restJson1LayerVersionsList(data.LayerVersions, context);
   }
@@ -6495,7 +6497,7 @@ export const deserializeAws_restJson1ListProvisionedConcurrencyConfigsCommand = 
     NextMarker: undefined,
     ProvisionedConcurrencyConfigs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
     contents.NextMarker = __expectString(data.NextMarker);
   }
@@ -6580,7 +6582,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -6660,7 +6662,7 @@ export const deserializeAws_restJson1ListVersionsByFunctionCommand = async (
     NextMarker: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
     contents.NextMarker = __expectString(data.NextMarker);
   }
@@ -6749,7 +6751,7 @@ export const deserializeAws_restJson1PublishLayerVersionCommand = async (
     LicenseInfo: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleRuntimes !== undefined && data.CompatibleRuntimes !== null) {
     contents.CompatibleRuntimes = deserializeAws_restJson1CompatibleRuntimes(data.CompatibleRuntimes, context);
   }
@@ -6887,7 +6889,7 @@ export const deserializeAws_restJson1PublishVersionCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
     contents.CodeSha256 = __expectString(data.CodeSha256);
   }
@@ -7081,7 +7083,7 @@ export const deserializeAws_restJson1PutFunctionCodeSigningConfigCommand = async
     CodeSigningConfigArn: undefined,
     FunctionName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfigArn !== undefined && data.CodeSigningConfigArn !== null) {
     contents.CodeSigningConfigArn = __expectString(data.CodeSigningConfigArn);
   }
@@ -7179,7 +7181,7 @@ export const deserializeAws_restJson1PutFunctionConcurrencyCommand = async (
     $metadata: deserializeMetadata(output),
     ReservedConcurrentExecutions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReservedConcurrentExecutions !== undefined && data.ReservedConcurrentExecutions !== null) {
     contents.ReservedConcurrentExecutions = __expectInt32(data.ReservedConcurrentExecutions);
   }
@@ -7270,7 +7272,7 @@ export const deserializeAws_restJson1PutFunctionEventInvokeConfigCommand = async
     MaximumEventAgeInSeconds: undefined,
     MaximumRetryAttempts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
@@ -7374,7 +7376,7 @@ export const deserializeAws_restJson1PutProvisionedConcurrencyConfigCommand = as
     Status: undefined,
     StatusReason: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.AllocatedProvisionedConcurrentExecutions !== undefined &&
     data.AllocatedProvisionedConcurrentExecutions !== null
@@ -7822,7 +7824,7 @@ export const deserializeAws_restJson1UpdateAliasCommand = async (
     RevisionId: undefined,
     RoutingConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
     contents.AliasArn = __expectString(data.AliasArn);
   }
@@ -7932,7 +7934,7 @@ export const deserializeAws_restJson1UpdateCodeSigningConfigCommand = async (
     $metadata: deserializeMetadata(output),
     CodeSigningConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfig !== undefined && data.CodeSigningConfig !== null) {
     contents.CodeSigningConfig = deserializeAws_restJson1CodeSigningConfig(data.CodeSigningConfig, context);
   }
@@ -8024,7 +8026,7 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -8221,7 +8223,7 @@ export const deserializeAws_restJson1UpdateFunctionCodeCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
     contents.CodeSha256 = __expectString(data.CodeSha256);
   }
@@ -8468,7 +8470,7 @@ export const deserializeAws_restJson1UpdateFunctionConfigurationCommand = async 
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSha256 !== undefined && data.CodeSha256 !== null) {
     contents.CodeSha256 = __expectString(data.CodeSha256);
   }
@@ -8681,7 +8683,7 @@ export const deserializeAws_restJson1UpdateFunctionEventInvokeConfigCommand = as
     MaximumEventAgeInSeconds: undefined,
     MaximumRetryAttempts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
@@ -119,6 +119,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1655,7 +1657,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     version: undefined,
     voiceId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortStatement !== undefined && data.abortStatement !== null) {
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
@@ -1815,7 +1817,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
     slots: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -1970,7 +1972,7 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
     valueSelectionStrategy: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -2907,7 +2909,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
     version: undefined,
     voiceId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortStatement !== undefined && data.abortStatement !== null) {
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
@@ -3044,7 +3046,7 @@ export const deserializeAws_restJson1GetBotAliasCommand = async (
     lastUpdatedDate: undefined,
     name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botName !== undefined && data.botName !== null) {
     contents.botName = __expectString(data.botName);
   }
@@ -3145,7 +3147,7 @@ export const deserializeAws_restJson1GetBotAliasesCommand = async (
     BotAliases: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BotAliases !== undefined && data.BotAliases !== null) {
     contents.BotAliases = deserializeAws_restJson1BotAliasMetadataList(data.BotAliases, context);
   }
@@ -3227,7 +3229,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationCommand = async (
     status: undefined,
     type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAlias !== undefined && data.botAlias !== null) {
     contents.botAlias = __expectString(data.botAlias);
   }
@@ -3331,7 +3333,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationsCommand = async (
     botChannelAssociations: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botChannelAssociations !== undefined && data.botChannelAssociations !== null) {
     contents.botChannelAssociations = deserializeAws_restJson1BotChannelAssociationList(
       data.botChannelAssociations,
@@ -3409,7 +3411,7 @@ export const deserializeAws_restJson1GetBotsCommand = async (
     bots: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bots !== undefined && data.bots !== null) {
     contents.bots = deserializeAws_restJson1BotMetadataList(data.bots, context);
   }
@@ -3492,7 +3494,7 @@ export const deserializeAws_restJson1GetBotVersionsCommand = async (
     bots: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bots !== undefined && data.bots !== null) {
     contents.bots = deserializeAws_restJson1BotMetadataList(data.bots, context);
   }
@@ -3576,7 +3578,7 @@ export const deserializeAws_restJson1GetBuiltinIntentCommand = async (
     slots: undefined,
     supportedLocales: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.signature !== undefined && data.signature !== null) {
     contents.signature = __expectString(data.signature);
   }
@@ -3662,7 +3664,7 @@ export const deserializeAws_restJson1GetBuiltinIntentsCommand = async (
     intents: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1BuiltinIntentMetadataList(data.intents, context);
   }
@@ -3737,7 +3739,7 @@ export const deserializeAws_restJson1GetBuiltinSlotTypesCommand = async (
     nextToken: undefined,
     slotTypes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3817,7 +3819,7 @@ export const deserializeAws_restJson1GetExportCommand = async (
     url: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.exportStatus !== undefined && data.exportStatus !== null) {
     contents.exportStatus = __expectString(data.exportStatus);
   }
@@ -3920,7 +3922,7 @@ export const deserializeAws_restJson1GetImportCommand = async (
     name: undefined,
     resourceType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -4034,7 +4036,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
     slots: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -4165,7 +4167,7 @@ export const deserializeAws_restJson1GetIntentsCommand = async (
     intents: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1IntentMetadataList(data.intents, context);
   }
@@ -4248,7 +4250,7 @@ export const deserializeAws_restJson1GetIntentVersionsCommand = async (
     intents: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1IntentMetadataList(data.intents, context);
   }
@@ -4339,7 +4341,7 @@ export const deserializeAws_restJson1GetMigrationCommand = async (
     v2BotId: undefined,
     v2BotRole: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alerts !== undefined && data.alerts !== null) {
     contents.alerts = deserializeAws_restJson1MigrationAlerts(data.alerts, context);
   }
@@ -4446,7 +4448,7 @@ export const deserializeAws_restJson1GetMigrationsCommand = async (
     migrationSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.migrationSummaries !== undefined && data.migrationSummaries !== null) {
     contents.migrationSummaries = deserializeAws_restJson1MigrationSummaryList(data.migrationSummaries, context);
   }
@@ -4529,7 +4531,7 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
     valueSelectionStrategy: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -4639,7 +4641,7 @@ export const deserializeAws_restJson1GetSlotTypesCommand = async (
     nextToken: undefined,
     slotTypes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4722,7 +4724,7 @@ export const deserializeAws_restJson1GetSlotTypeVersionsCommand = async (
     nextToken: undefined,
     slotTypes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4805,7 +4807,7 @@ export const deserializeAws_restJson1GetUtterancesViewCommand = async (
     botName: undefined,
     utterances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botName !== undefined && data.botName !== null) {
     contents.botName = __expectString(data.botName);
   }
@@ -4879,7 +4881,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
@@ -4977,7 +4979,7 @@ export const deserializeAws_restJson1PutBotCommand = async (
     version: undefined,
     voiceId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortStatement !== undefined && data.abortStatement !== null) {
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
@@ -5129,7 +5131,7 @@ export const deserializeAws_restJson1PutBotAliasCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botName !== undefined && data.botName !== null) {
     contents.botName = __expectString(data.botName);
   }
@@ -5258,7 +5260,7 @@ export const deserializeAws_restJson1PutIntentCommand = async (
     slots: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -5409,7 +5411,7 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
     valueSelectionStrategy: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -5535,7 +5537,7 @@ export const deserializeAws_restJson1StartImportCommand = async (
     resourceType: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = new Date(Math.round(data.createdDate * 1000));
   }
@@ -5631,7 +5633,7 @@ export const deserializeAws_restJson1StartMigrationCommand = async (
     v2BotId: undefined,
     v2BotRole: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.migrationId !== undefined && data.migrationId !== null) {
     contents.migrationId = __expectString(data.migrationId);
   }

--- a/clients/client-lex-models-v2/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/protocols/Aws_restJson1.ts
@@ -171,6 +171,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -2781,7 +2783,7 @@ export const deserializeAws_restJson1BuildBotLocaleCommand = async (
     lastBuildSubmittedDateTime: undefined,
     localeId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -2897,7 +2899,7 @@ export const deserializeAws_restJson1CreateBotCommand = async (
     roleArn: undefined,
     testBotAliasTags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3029,7 +3031,7 @@ export const deserializeAws_restJson1CreateBotAliasCommand = async (
     sentimentAnalysisSettings: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -3171,7 +3173,7 @@ export const deserializeAws_restJson1CreateBotLocaleCommand = async (
     nluIntentConfidenceThreshold: undefined,
     voiceSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3295,7 +3297,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     creationDateTime: undefined,
     description: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3412,7 +3414,7 @@ export const deserializeAws_restJson1CreateExportCommand = async (
     fileFormat: undefined,
     resourceSpecification: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
@@ -3537,7 +3539,7 @@ export const deserializeAws_restJson1CreateIntentCommand = async (
     parentIntentSignature: undefined,
     sampleUtterances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3684,7 +3686,7 @@ export const deserializeAws_restJson1CreateResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -3783,7 +3785,7 @@ export const deserializeAws_restJson1CreateResourcePolicyStatementCommand = asyn
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -3900,7 +3902,7 @@ export const deserializeAws_restJson1CreateSlotCommand = async (
     slotTypeId: undefined,
     valueElicitationSetting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4040,7 +4042,7 @@ export const deserializeAws_restJson1CreateSlotTypeCommand = async (
     slotTypeValues: undefined,
     valueSelectionSetting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4166,7 +4168,7 @@ export const deserializeAws_restJson1CreateUploadUrlCommand = async (
     importId: undefined,
     uploadUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
   }
@@ -4257,7 +4259,7 @@ export const deserializeAws_restJson1DeleteBotCommand = async (
     botId: undefined,
     botStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4357,7 +4359,7 @@ export const deserializeAws_restJson1DeleteBotAliasCommand = async (
     botAliasStatus: undefined,
     botId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -4461,7 +4463,7 @@ export const deserializeAws_restJson1DeleteBotLocaleCommand = async (
     botVersion: undefined,
     localeId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4567,7 +4569,7 @@ export const deserializeAws_restJson1DeleteBotVersionCommand = async (
     botStatus: undefined,
     botVersion: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4669,7 +4671,7 @@ export const deserializeAws_restJson1DeleteExportCommand = async (
     exportId: undefined,
     exportStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.exportId !== undefined && data.exportId !== null) {
     contents.exportId = __expectString(data.exportId);
   }
@@ -4760,7 +4762,7 @@ export const deserializeAws_restJson1DeleteImportCommand = async (
     importId: undefined,
     importStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
   }
@@ -4942,7 +4944,7 @@ export const deserializeAws_restJson1DeleteResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -5025,7 +5027,7 @@ export const deserializeAws_restJson1DeleteResourcePolicyStatementCommand = asyn
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -5297,7 +5299,7 @@ export const deserializeAws_restJson1DescribeBotCommand = async (
     lastUpdatedDateTime: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5419,7 +5421,7 @@ export const deserializeAws_restJson1DescribeBotAliasCommand = async (
     lastUpdatedDateTime: undefined,
     sentimentAnalysisSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasHistoryEvents !== undefined && data.botAliasHistoryEvents !== null) {
     contents.botAliasHistoryEvents = deserializeAws_restJson1BotAliasHistoryEventsList(
       data.botAliasHistoryEvents,
@@ -5565,7 +5567,7 @@ export const deserializeAws_restJson1DescribeBotLocaleCommand = async (
     slotTypesCount: undefined,
     voiceSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5706,7 +5708,7 @@ export const deserializeAws_restJson1DescribeBotVersionCommand = async (
     idleSessionTTLInSeconds: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5827,7 +5829,7 @@ export const deserializeAws_restJson1DescribeExportCommand = async (
     lastUpdatedDateTime: undefined,
     resourceSpecification: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
@@ -5938,7 +5940,7 @@ export const deserializeAws_restJson1DescribeImportCommand = async (
     mergeStrategy: undefined,
     resourceSpecification: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
@@ -6061,7 +6063,7 @@ export const deserializeAws_restJson1DescribeIntentCommand = async (
     sampleUtterances: undefined,
     slotPriorities: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6207,7 +6209,7 @@ export const deserializeAws_restJson1DescribeResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -6296,7 +6298,7 @@ export const deserializeAws_restJson1DescribeSlotCommand = async (
     slotTypeId: undefined,
     valueElicitationSetting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6432,7 +6434,7 @@ export const deserializeAws_restJson1DescribeSlotTypeCommand = async (
     slotTypeValues: undefined,
     valueSelectionSetting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6554,7 +6556,7 @@ export const deserializeAws_restJson1ListBotAliasesCommand = async (
     botId: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasSummaries !== undefined && data.botAliasSummaries !== null) {
     contents.botAliasSummaries = deserializeAws_restJson1BotAliasSummaryList(data.botAliasSummaries, context);
   }
@@ -6642,7 +6644,7 @@ export const deserializeAws_restJson1ListBotLocalesCommand = async (
     botVersion: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6731,7 +6733,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     botSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botSummaries !== undefined && data.botSummaries !== null) {
     contents.botSummaries = deserializeAws_restJson1BotSummaryList(data.botSummaries, context);
   }
@@ -6815,7 +6817,7 @@ export const deserializeAws_restJson1ListBotVersionsCommand = async (
     botVersionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6902,7 +6904,7 @@ export const deserializeAws_restJson1ListBuiltInIntentsCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.builtInIntentSummaries !== undefined && data.builtInIntentSummaries !== null) {
     contents.builtInIntentSummaries = deserializeAws_restJson1BuiltInIntentSummaryList(
       data.builtInIntentSummaries,
@@ -6992,7 +6994,7 @@ export const deserializeAws_restJson1ListBuiltInSlotTypesCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.builtInSlotTypeSummaries !== undefined && data.builtInSlotTypeSummaries !== null) {
     contents.builtInSlotTypeSummaries = deserializeAws_restJson1BuiltInSlotTypeSummaryList(
       data.builtInSlotTypeSummaries,
@@ -7083,7 +7085,7 @@ export const deserializeAws_restJson1ListExportsCommand = async (
     exportSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7166,7 +7168,7 @@ export const deserializeAws_restJson1ListImportsCommand = async (
     importSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7250,7 +7252,7 @@ export const deserializeAws_restJson1ListIntentsCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7346,7 +7348,7 @@ export const deserializeAws_restJson1ListSlotsCommand = async (
     nextToken: undefined,
     slotSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7444,7 +7446,7 @@ export const deserializeAws_restJson1ListSlotTypesCommand = async (
     nextToken: undefined,
     slotTypeSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7535,7 +7537,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -7618,7 +7620,7 @@ export const deserializeAws_restJson1StartImportCommand = async (
     mergeStrategy: undefined,
     resourceSpecification: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
@@ -7886,7 +7888,7 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
     lastUpdatedDateTime: undefined,
     roleArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8015,7 +8017,7 @@ export const deserializeAws_restJson1UpdateBotAliasCommand = async (
     lastUpdatedDateTime: undefined,
     sentimentAnalysisSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -8159,7 +8161,7 @@ export const deserializeAws_restJson1UpdateBotLocaleCommand = async (
     nluIntentConfidenceThreshold: undefined,
     voiceSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8289,7 +8291,7 @@ export const deserializeAws_restJson1UpdateExportCommand = async (
     lastUpdatedDateTime: undefined,
     resourceSpecification: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
   }
@@ -8419,7 +8421,7 @@ export const deserializeAws_restJson1UpdateIntentCommand = async (
     sampleUtterances: undefined,
     slotPriorities: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8572,7 +8574,7 @@ export const deserializeAws_restJson1UpdateResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -8682,7 +8684,7 @@ export const deserializeAws_restJson1UpdateSlotCommand = async (
     slotTypeId: undefined,
     valueElicitationSetting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8826,7 +8828,7 @@ export const deserializeAws_restJson1UpdateSlotTypeCommand = async (
     slotTypeValues: undefined,
     valueSelectionSetting: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
@@ -30,6 +30,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   LazyJsonString as __LazyJsonString,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -357,7 +359,7 @@ export const deserializeAws_restJson1DeleteSessionCommand = async (
     sessionId: undefined,
     userId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAlias !== undefined && data.botAlias !== null) {
     contents.botAlias = __expectString(data.botAlias);
   }
@@ -457,7 +459,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
     sessionAttributes: undefined,
     sessionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.activeContexts !== undefined && data.activeContexts !== null) {
     contents.activeContexts = deserializeAws_restJson1ActiveContextsList(data.activeContexts, context);
   }
@@ -770,7 +772,7 @@ export const deserializeAws_restJson1PostTextCommand = async (
     slotToElicit: undefined,
     slots: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.activeContexts !== undefined && data.activeContexts !== null) {
     contents.activeContexts = deserializeAws_restJson1ActiveContextsList(data.activeContexts, context);
   }

--- a/clients/client-lex-runtime-v2/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/protocols/Aws_restJson1.ts
@@ -45,6 +45,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -462,7 +464,7 @@ export const deserializeAws_restJson1DeleteSessionCommand = async (
     localeId: undefined,
     sessionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -569,7 +571,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
     sessionId: undefined,
     sessionState: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.interpretations !== undefined && data.interpretations !== null) {
     contents.interpretations = deserializeAws_restJson1Interpretations(data.interpretations, context);
   }
@@ -798,7 +800,7 @@ export const deserializeAws_restJson1RecognizeTextCommand = async (
     sessionId: undefined,
     sessionState: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.interpretations !== undefined && data.interpretations !== null) {
     contents.interpretations = deserializeAws_restJson1Interpretations(data.interpretations, context);
   }

--- a/clients/client-location/protocols/Aws_restJson1.ts
+++ b/clients/client-location/protocols/Aws_restJson1.ts
@@ -172,6 +172,8 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -2383,7 +2385,7 @@ export const deserializeAws_restJson1BatchDeleteDevicePositionHistoryCommand = a
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchDeleteDevicePositionHistoryErrorList(data.Errors, context);
   }
@@ -2470,7 +2472,7 @@ export const deserializeAws_restJson1BatchDeleteGeofenceCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchDeleteGeofenceErrorList(data.Errors, context);
   }
@@ -2557,7 +2559,7 @@ export const deserializeAws_restJson1BatchEvaluateGeofencesCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchEvaluateGeofencesErrorList(data.Errors, context);
   }
@@ -2645,7 +2647,7 @@ export const deserializeAws_restJson1BatchGetDevicePositionCommand = async (
     DevicePositions: undefined,
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DevicePositions !== undefined && data.DevicePositions !== null) {
     contents.DevicePositions = deserializeAws_restJson1DevicePositionList(data.DevicePositions, context);
   }
@@ -2736,7 +2738,7 @@ export const deserializeAws_restJson1BatchPutGeofenceCommand = async (
     Errors: undefined,
     Successes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchPutGeofenceErrorList(data.Errors, context);
   }
@@ -2826,7 +2828,7 @@ export const deserializeAws_restJson1BatchUpdateDevicePositionCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchUpdateDevicePositionErrorList(data.Errors, context);
   }
@@ -2914,7 +2916,7 @@ export const deserializeAws_restJson1CalculateRouteCommand = async (
     Legs: undefined,
     Summary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Legs !== undefined && data.Legs !== null) {
     contents.Legs = deserializeAws_restJson1LegList(data.Legs, context);
   }
@@ -3006,7 +3008,7 @@ export const deserializeAws_restJson1CreateGeofenceCollectionCommand = async (
     CollectionName: undefined,
     CreateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
     contents.CollectionArn = __expectString(data.CollectionArn);
   }
@@ -3101,7 +3103,7 @@ export const deserializeAws_restJson1CreateMapCommand = async (
     MapArn: undefined,
     MapName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
@@ -3196,7 +3198,7 @@ export const deserializeAws_restJson1CreatePlaceIndexCommand = async (
     IndexArn: undefined,
     IndexName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
@@ -3291,7 +3293,7 @@ export const deserializeAws_restJson1CreateRouteCalculatorCommand = async (
     CalculatorName: undefined,
     CreateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
     contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
@@ -3386,7 +3388,7 @@ export const deserializeAws_restJson1CreateTrackerCommand = async (
     TrackerArn: undefined,
     TrackerName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
@@ -3902,7 +3904,7 @@ export const deserializeAws_restJson1DescribeGeofenceCollectionCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
     contents.CollectionArn = __expectString(data.CollectionArn);
   }
@@ -4021,7 +4023,7 @@ export const deserializeAws_restJson1DescribeMapCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Configuration !== undefined && data.Configuration !== null) {
     contents.Configuration = deserializeAws_restJson1MapConfiguration(data.Configuration, context);
   }
@@ -4140,7 +4142,7 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
@@ -4261,7 +4263,7 @@ export const deserializeAws_restJson1DescribeRouteCalculatorCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
     contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
@@ -4377,7 +4379,7 @@ export const deserializeAws_restJson1DescribeTrackerCommand = async (
     TrackerName: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
@@ -4574,7 +4576,7 @@ export const deserializeAws_restJson1GetDevicePositionCommand = async (
     ReceivedTime: undefined,
     SampleTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceId !== undefined && data.DeviceId !== null) {
     contents.DeviceId = __expectString(data.DeviceId);
   }
@@ -4671,7 +4673,7 @@ export const deserializeAws_restJson1GetDevicePositionHistoryCommand = async (
     DevicePositions: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DevicePositions !== undefined && data.DevicePositions !== null) {
     contents.DevicePositions = deserializeAws_restJson1DevicePositionList(data.DevicePositions, context);
   }
@@ -4765,7 +4767,7 @@ export const deserializeAws_restJson1GetGeofenceCommand = async (
     Status: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
@@ -5221,7 +5223,7 @@ export const deserializeAws_restJson1ListDevicePositionsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListDevicePositionsResponseEntryList(data.Entries, context);
   }
@@ -5304,7 +5306,7 @@ export const deserializeAws_restJson1ListGeofenceCollectionsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListGeofenceCollectionsResponseEntryList(data.Entries, context);
   }
@@ -5387,7 +5389,7 @@ export const deserializeAws_restJson1ListGeofencesCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListGeofenceResponseEntryList(data.Entries, context);
   }
@@ -5478,7 +5480,7 @@ export const deserializeAws_restJson1ListMapsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListMapsResponseEntryList(data.Entries, context);
   }
@@ -5561,7 +5563,7 @@ export const deserializeAws_restJson1ListPlaceIndexesCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListPlaceIndexesResponseEntryList(data.Entries, context);
   }
@@ -5644,7 +5646,7 @@ export const deserializeAws_restJson1ListRouteCalculatorsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListRouteCalculatorsResponseEntryList(data.Entries, context);
   }
@@ -5726,7 +5728,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -5814,7 +5816,7 @@ export const deserializeAws_restJson1ListTrackerConsumersCommand = async (
     ConsumerArns: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConsumerArns !== undefined && data.ConsumerArns !== null) {
     contents.ConsumerArns = deserializeAws_restJson1ArnList(data.ConsumerArns, context);
   }
@@ -5905,7 +5907,7 @@ export const deserializeAws_restJson1ListTrackersCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListTrackersResponseEntryList(data.Entries, context);
   }
@@ -5989,7 +5991,7 @@ export const deserializeAws_restJson1PutGeofenceCommand = async (
     GeofenceId: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = new Date(data.CreateTime);
   }
@@ -6091,7 +6093,7 @@ export const deserializeAws_restJson1SearchPlaceIndexForPositionCommand = async 
     Results: undefined,
     Summary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Results !== undefined && data.Results !== null) {
     contents.Results = deserializeAws_restJson1SearchForPositionResultList(data.Results, context);
   }
@@ -6182,7 +6184,7 @@ export const deserializeAws_restJson1SearchPlaceIndexForTextCommand = async (
     Results: undefined,
     Summary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Results !== undefined && data.Results !== null) {
     contents.Results = deserializeAws_restJson1SearchForTextResultList(data.Results, context);
   }
@@ -6440,7 +6442,7 @@ export const deserializeAws_restJson1UpdateGeofenceCollectionCommand = async (
     CollectionName: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
     contents.CollectionArn = __expectString(data.CollectionArn);
   }
@@ -6535,7 +6537,7 @@ export const deserializeAws_restJson1UpdateMapCommand = async (
     MapName: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MapArn !== undefined && data.MapArn !== null) {
     contents.MapArn = __expectString(data.MapArn);
   }
@@ -6630,7 +6632,7 @@ export const deserializeAws_restJson1UpdatePlaceIndexCommand = async (
     IndexName: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IndexArn !== undefined && data.IndexArn !== null) {
     contents.IndexArn = __expectString(data.IndexArn);
   }
@@ -6725,7 +6727,7 @@ export const deserializeAws_restJson1UpdateRouteCalculatorCommand = async (
     CalculatorName: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
     contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
@@ -6820,7 +6822,7 @@ export const deserializeAws_restJson1UpdateTrackerCommand = async (
     TrackerName: undefined,
     UpdateTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TrackerArn !== undefined && data.TrackerArn !== null) {
     contents.TrackerArn = __expectString(data.TrackerArn);
   }

--- a/clients/client-lookoutmetrics/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutmetrics/protocols/Aws_restJson1.ts
@@ -106,6 +106,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1041,7 +1043,7 @@ export const deserializeAws_restJson1CreateAlertCommand = async (
     $metadata: deserializeMetadata(output),
     AlertArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AlertArn !== undefined && data.AlertArn !== null) {
     contents.AlertArn = __expectString(data.AlertArn);
   }
@@ -1144,7 +1146,7 @@ export const deserializeAws_restJson1CreateAnomalyDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     AnomalyDetectorArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -1239,7 +1241,7 @@ export const deserializeAws_restJson1CreateMetricSetCommand = async (
     $metadata: deserializeMetadata(output),
     MetricSetArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricSetArn !== undefined && data.MetricSetArn !== null) {
     contents.MetricSetArn = __expectString(data.MetricSetArn);
   }
@@ -1516,7 +1518,7 @@ export const deserializeAws_restJson1DescribeAlertCommand = async (
     $metadata: deserializeMetadata(output),
     Alert: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Alert !== undefined && data.Alert !== null) {
     contents.Alert = deserializeAws_restJson1Alert(data.Alert, context);
   }
@@ -1604,7 +1606,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectionExecutionsCommand =
     ExecutionList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExecutionList !== undefined && data.ExecutionList !== null) {
     contents.ExecutionList = deserializeAws_restJson1ExecutionList(data.ExecutionList, context);
   }
@@ -1702,7 +1704,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectorCommand = async (
     LastModificationTime: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -1828,7 +1830,7 @@ export const deserializeAws_restJson1DescribeMetricSetCommand = async (
     TimestampColumn: undefined,
     Timezone: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -1951,7 +1953,7 @@ export const deserializeAws_restJson1GetAnomalyGroupCommand = async (
     $metadata: deserializeMetadata(output),
     AnomalyGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroup !== undefined && data.AnomalyGroup !== null) {
     contents.AnomalyGroup = deserializeAws_restJson1AnomalyGroup(data.AnomalyGroup, context);
   }
@@ -2039,7 +2041,7 @@ export const deserializeAws_restJson1GetFeedbackCommand = async (
     AnomalyGroupTimeSeriesFeedback: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroupTimeSeriesFeedback !== undefined && data.AnomalyGroupTimeSeriesFeedback !== null) {
     contents.AnomalyGroupTimeSeriesFeedback = deserializeAws_restJson1TimeSeriesFeedbackList(
       data.AnomalyGroupTimeSeriesFeedback,
@@ -2133,7 +2135,7 @@ export const deserializeAws_restJson1GetSampleDataCommand = async (
     HeaderValues: undefined,
     SampleRows: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HeaderValues !== undefined && data.HeaderValues !== null) {
     contents.HeaderValues = deserializeAws_restJson1HeaderValueList(data.HeaderValues, context);
   }
@@ -2224,7 +2226,7 @@ export const deserializeAws_restJson1ListAlertsCommand = async (
     AlertSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AlertSummaryList !== undefined && data.AlertSummaryList !== null) {
     contents.AlertSummaryList = deserializeAws_restJson1AlertSummaryList(data.AlertSummaryList, context);
   }
@@ -2315,7 +2317,7 @@ export const deserializeAws_restJson1ListAnomalyDetectorsCommand = async (
     AnomalyDetectorSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorSummaryList !== undefined && data.AnomalyDetectorSummaryList !== null) {
     contents.AnomalyDetectorSummaryList = deserializeAws_restJson1AnomalyDetectorSummaryList(
       data.AnomalyDetectorSummaryList,
@@ -2410,7 +2412,7 @@ export const deserializeAws_restJson1ListAnomalyGroupSummariesCommand = async (
     AnomalyGroupSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroupStatistics !== undefined && data.AnomalyGroupStatistics !== null) {
     contents.AnomalyGroupStatistics = deserializeAws_restJson1AnomalyGroupStatistics(
       data.AnomalyGroupStatistics,
@@ -2513,7 +2515,7 @@ export const deserializeAws_restJson1ListAnomalyGroupTimeSeriesCommand = async (
     TimeSeriesList: undefined,
     TimestampList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroupId !== undefined && data.AnomalyGroupId !== null) {
     contents.AnomalyGroupId = __expectString(data.AnomalyGroupId);
   }
@@ -2613,7 +2615,7 @@ export const deserializeAws_restJson1ListMetricSetsCommand = async (
     MetricSetSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricSetSummaryList !== undefined && data.MetricSetSummaryList !== null) {
     contents.MetricSetSummaryList = deserializeAws_restJson1MetricSetSummaryList(data.MetricSetSummaryList, context);
   }
@@ -2703,7 +2705,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -2991,7 +2993,7 @@ export const deserializeAws_restJson1UpdateAnomalyDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     AnomalyDetectorArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -3078,7 +3080,7 @@ export const deserializeAws_restJson1UpdateMetricSetCommand = async (
     $metadata: deserializeMetadata(output),
     MetricSetArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricSetArn !== undefined && data.MetricSetArn !== null) {
     contents.MetricSetArn = __expectString(data.MetricSetArn);
   }

--- a/clients/client-lookoutvision/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/protocols/Aws_restJson1.ts
@@ -53,6 +53,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
@@ -788,7 +790,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     DatasetMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DatasetMetadata !== undefined && data.DatasetMetadata !== null) {
     contents.DatasetMetadata = deserializeAws_restJson1DatasetMetadata(data.DatasetMetadata, context);
   }
@@ -891,7 +893,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
     $metadata: deserializeMetadata(output),
     ModelMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelMetadata !== undefined && data.ModelMetadata !== null) {
     contents.ModelMetadata = deserializeAws_restJson1ModelMetadata(data.ModelMetadata, context);
   }
@@ -994,7 +996,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProjectMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProjectMetadata !== undefined && data.ProjectMetadata !== null) {
     contents.ProjectMetadata = deserializeAws_restJson1ProjectMetadata(data.ProjectMetadata, context);
   }
@@ -1188,7 +1190,7 @@ export const deserializeAws_restJson1DeleteModelCommand = async (
     $metadata: deserializeMetadata(output),
     ModelArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelArn !== undefined && data.ModelArn !== null) {
     contents.ModelArn = __expectString(data.ModelArn);
   }
@@ -1283,7 +1285,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProjectArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProjectArn !== undefined && data.ProjectArn !== null) {
     contents.ProjectArn = __expectString(data.ProjectArn);
   }
@@ -1378,7 +1380,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     DatasetDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DatasetDescription !== undefined && data.DatasetDescription !== null) {
     contents.DatasetDescription = deserializeAws_restJson1DatasetDescription(data.DatasetDescription, context);
   }
@@ -1473,7 +1475,7 @@ export const deserializeAws_restJson1DescribeModelCommand = async (
     $metadata: deserializeMetadata(output),
     ModelDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelDescription !== undefined && data.ModelDescription !== null) {
     contents.ModelDescription = deserializeAws_restJson1ModelDescription(data.ModelDescription, context);
   }
@@ -1568,7 +1570,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProjectDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProjectDescription !== undefined && data.ProjectDescription !== null) {
     contents.ProjectDescription = deserializeAws_restJson1ProjectDescription(data.ProjectDescription, context);
   }
@@ -1663,7 +1665,7 @@ export const deserializeAws_restJson1DetectAnomaliesCommand = async (
     $metadata: deserializeMetadata(output),
     DetectAnomalyResult: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DetectAnomalyResult !== undefined && data.DetectAnomalyResult !== null) {
     contents.DetectAnomalyResult = deserializeAws_restJson1DetectAnomalyResult(data.DetectAnomalyResult, context);
   }
@@ -1759,7 +1761,7 @@ export const deserializeAws_restJson1ListDatasetEntriesCommand = async (
     DatasetEntries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DatasetEntries !== undefined && data.DatasetEntries !== null) {
     contents.DatasetEntries = deserializeAws_restJson1DatasetEntryList(data.DatasetEntries, context);
   }
@@ -1858,7 +1860,7 @@ export const deserializeAws_restJson1ListModelsCommand = async (
     Models: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Models !== undefined && data.Models !== null) {
     contents.Models = deserializeAws_restJson1ModelMetadataList(data.Models, context);
   }
@@ -1957,7 +1959,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     NextToken: undefined,
     Projects: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2055,7 +2057,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -2150,7 +2152,7 @@ export const deserializeAws_restJson1StartModelCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -2253,7 +2255,7 @@ export const deserializeAws_restJson1StopModelCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -2538,7 +2540,7 @@ export const deserializeAws_restJson1UpdateDatasetEntriesCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }

--- a/clients/client-macie2/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/protocols/Aws_restJson1.ts
@@ -280,6 +280,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1962,7 +1964,7 @@ export const deserializeAws_restJson1BatchGetCustomDataIdentifiersCommand = asyn
     customDataIdentifiers: undefined,
     notFoundIdentifierIds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.customDataIdentifiers !== undefined && data.customDataIdentifiers !== null) {
     contents.customDataIdentifiers = deserializeAws_restJson1__listOfBatchGetCustomDataIdentifierSummary(
       data.customDataIdentifiers,
@@ -2072,7 +2074,7 @@ export const deserializeAws_restJson1CreateClassificationJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobArn !== undefined && data.jobArn !== null) {
     contents.jobArn = __expectString(data.jobArn);
   }
@@ -2178,7 +2180,7 @@ export const deserializeAws_restJson1CreateCustomDataIdentifierCommand = async (
     $metadata: deserializeMetadata(output),
     customDataIdentifierId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.customDataIdentifierId !== undefined && data.customDataIdentifierId !== null) {
     contents.customDataIdentifierId = __expectString(data.customDataIdentifierId);
   }
@@ -2282,7 +2284,7 @@ export const deserializeAws_restJson1CreateFindingsFilterCommand = async (
     arn: undefined,
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2388,7 +2390,7 @@ export const deserializeAws_restJson1CreateInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.unprocessedAccounts = deserializeAws_restJson1__listOfUnprocessedAccount(
       data.unprocessedAccounts,
@@ -2494,7 +2496,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2696,7 +2698,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.unprocessedAccounts = deserializeAws_restJson1__listOfUnprocessedAccount(
       data.unprocessedAccounts,
@@ -3000,7 +3002,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.unprocessedAccounts = deserializeAws_restJson1__listOfUnprocessedAccount(
       data.unprocessedAccounts,
@@ -3206,7 +3208,7 @@ export const deserializeAws_restJson1DescribeBucketsCommand = async (
     buckets: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.buckets !== undefined && data.buckets !== null) {
     contents.buckets = deserializeAws_restJson1__listOfBucketMetadata(data.buckets, context);
   }
@@ -3329,7 +3331,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     tags: undefined,
     userPausedDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -3484,7 +3486,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     autoEnable: undefined,
     maxAccountLimitReached: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
     contents.autoEnable = __expectBoolean(data.autoEnable);
   }
@@ -4283,7 +4285,7 @@ export const deserializeAws_restJson1GetAdministratorAccountCommand = async (
     $metadata: deserializeMetadata(output),
     administrator: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.administrator !== undefined && data.administrator !== null) {
     contents.administrator = deserializeAws_restJson1Invitation(data.administrator, context);
   }
@@ -4398,7 +4400,7 @@ export const deserializeAws_restJson1GetBucketStatisticsCommand = async (
     unclassifiableObjectCount: undefined,
     unclassifiableObjectSizeInBytes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bucketCount !== undefined && data.bucketCount !== null) {
     contents.bucketCount = __expectLong(data.bucketCount);
   }
@@ -4559,7 +4561,7 @@ export const deserializeAws_restJson1GetClassificationExportConfigurationCommand
     $metadata: deserializeMetadata(output),
     configuration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configuration !== undefined && data.configuration !== null) {
     contents.configuration = deserializeAws_restJson1ClassificationExportConfiguration(data.configuration, context);
   }
@@ -4672,7 +4674,7 @@ export const deserializeAws_restJson1GetCustomDataIdentifierCommand = async (
     regex: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4805,7 +4807,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
     $metadata: deserializeMetadata(output),
     findings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1__listOfFinding(data.findings, context);
   }
@@ -4915,7 +4917,7 @@ export const deserializeAws_restJson1GetFindingsFilterCommand = async (
     position: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.action !== undefined && data.action !== null) {
     contents.action = __expectString(data.action);
   }
@@ -5039,7 +5041,7 @@ export const deserializeAws_restJson1GetFindingsPublicationConfigurationCommand 
     $metadata: deserializeMetadata(output),
     securityHubConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityHubConfiguration !== undefined && data.securityHubConfiguration !== null) {
     contents.securityHubConfiguration = deserializeAws_restJson1SecurityHubConfiguration(
       data.securityHubConfiguration,
@@ -5145,7 +5147,7 @@ export const deserializeAws_restJson1GetFindingStatisticsCommand = async (
     $metadata: deserializeMetadata(output),
     countsByGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.countsByGroup !== undefined && data.countsByGroup !== null) {
     contents.countsByGroup = deserializeAws_restJson1__listOfGroupCount(data.countsByGroup, context);
   }
@@ -5248,7 +5250,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
     $metadata: deserializeMetadata(output),
     invitationsCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitationsCount !== undefined && data.invitationsCount !== null) {
     contents.invitationsCount = __expectLong(data.invitationsCount);
   }
@@ -5355,7 +5357,7 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
     status: undefined,
     updatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = new Date(data.createdAt);
   }
@@ -5470,7 +5472,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     master: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.master !== undefined && data.master !== null) {
     contents.master = deserializeAws_restJson1Invitation(data.master, context);
   }
@@ -5581,7 +5583,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     tags: undefined,
     updatedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accountId !== undefined && data.accountId !== null) {
     contents.accountId = __expectString(data.accountId);
   }
@@ -5710,7 +5712,7 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
     records: undefined,
     timeRange: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5820,7 +5822,7 @@ export const deserializeAws_restJson1GetUsageTotalsCommand = async (
     timeRange: undefined,
     usageTotals: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.timeRange !== undefined && data.timeRange !== null) {
     contents.timeRange = __expectString(data.timeRange);
   }
@@ -5927,7 +5929,7 @@ export const deserializeAws_restJson1ListClassificationJobsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1__listOfJobSummary(data.items, context);
   }
@@ -6034,7 +6036,7 @@ export const deserializeAws_restJson1ListCustomDataIdentifiersCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1__listOfCustomDataIdentifierSummary(data.items, context);
   }
@@ -6141,7 +6143,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     findingIds: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingIds !== undefined && data.findingIds !== null) {
     contents.findingIds = deserializeAws_restJson1__listOf__string(data.findingIds, context);
   }
@@ -6248,7 +6250,7 @@ export const deserializeAws_restJson1ListFindingsFiltersCommand = async (
     findingsFilterListItems: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingsFilterListItems !== undefined && data.findingsFilterListItems !== null) {
     contents.findingsFilterListItems = deserializeAws_restJson1__listOfFindingsFilterListItem(
       data.findingsFilterListItems,
@@ -6358,7 +6360,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     invitations: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitations !== undefined && data.invitations !== null) {
     contents.invitations = deserializeAws_restJson1__listOfInvitation(data.invitations, context);
   }
@@ -6465,7 +6467,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     members: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.members = deserializeAws_restJson1__listOfMember(data.members, context);
   }
@@ -6572,7 +6574,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     adminAccounts: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccounts !== undefined && data.adminAccounts !== null) {
     contents.adminAccounts = deserializeAws_restJson1__listOfAdminAccount(data.adminAccounts, context);
   }
@@ -6678,7 +6680,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -6725,7 +6727,7 @@ export const deserializeAws_restJson1PutClassificationExportConfigurationCommand
     $metadata: deserializeMetadata(output),
     configuration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configuration !== undefined && data.configuration !== null) {
     contents.configuration = deserializeAws_restJson1ClassificationExportConfiguration(data.configuration, context);
   }
@@ -6928,7 +6930,7 @@ export const deserializeAws_restJson1SearchResourcesCommand = async (
     matchingResources: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.matchingResources !== undefined && data.matchingResources !== null) {
     contents.matchingResources = deserializeAws_restJson1__listOfMatchingResource(data.matchingResources, context);
   }
@@ -7077,7 +7079,7 @@ export const deserializeAws_restJson1TestCustomDataIdentifierCommand = async (
     $metadata: deserializeMetadata(output),
     matchCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.matchCount !== undefined && data.matchCount !== null) {
     contents.matchCount = __expectInt32(data.matchCount);
   }
@@ -7323,7 +7325,7 @@ export const deserializeAws_restJson1UpdateFindingsFilterCommand = async (
     arn: undefined,
     id: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-managedblockchain/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1.ts
@@ -75,6 +75,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -958,7 +960,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
     $metadata: deserializeMetadata(output),
     MemberId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberId !== undefined && data.MemberId !== null) {
     contents.MemberId = __expectString(data.MemberId);
   }
@@ -1078,7 +1080,7 @@ export const deserializeAws_restJson1CreateNetworkCommand = async (
     MemberId: undefined,
     NetworkId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberId !== undefined && data.MemberId !== null) {
     contents.MemberId = __expectString(data.MemberId);
   }
@@ -1184,7 +1186,7 @@ export const deserializeAws_restJson1CreateNodeCommand = async (
     $metadata: deserializeMetadata(output),
     NodeId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NodeId !== undefined && data.NodeId !== null) {
     contents.NodeId = __expectString(data.NodeId);
   }
@@ -1303,7 +1305,7 @@ export const deserializeAws_restJson1CreateProposalCommand = async (
     $metadata: deserializeMetadata(output),
     ProposalId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProposalId !== undefined && data.ProposalId !== null) {
     contents.ProposalId = __expectString(data.ProposalId);
   }
@@ -1588,7 +1590,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     $metadata: deserializeMetadata(output),
     Member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Member !== undefined && data.Member !== null) {
     contents.Member = deserializeAws_restJson1Member(data.Member, context);
   }
@@ -1675,7 +1677,7 @@ export const deserializeAws_restJson1GetNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     Network: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Network !== undefined && data.Network !== null) {
     contents.Network = deserializeAws_restJson1Network(data.Network, context);
   }
@@ -1762,7 +1764,7 @@ export const deserializeAws_restJson1GetNodeCommand = async (
     $metadata: deserializeMetadata(output),
     Node: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Node !== undefined && data.Node !== null) {
     contents.Node = deserializeAws_restJson1Node(data.Node, context);
   }
@@ -1849,7 +1851,7 @@ export const deserializeAws_restJson1GetProposalCommand = async (
     $metadata: deserializeMetadata(output),
     Proposal: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proposal !== undefined && data.Proposal !== null) {
     contents.Proposal = deserializeAws_restJson1Proposal(data.Proposal, context);
   }
@@ -1937,7 +1939,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invitations !== undefined && data.Invitations !== null) {
     contents.Invitations = deserializeAws_restJson1InvitationList(data.Invitations, context);
   }
@@ -2036,7 +2038,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     Members: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberSummaryList(data.Members, context);
   }
@@ -2119,7 +2121,7 @@ export const deserializeAws_restJson1ListNetworksCommand = async (
     Networks: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Networks !== undefined && data.Networks !== null) {
     contents.Networks = deserializeAws_restJson1NetworkSummaryList(data.Networks, context);
   }
@@ -2202,7 +2204,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
     NextToken: undefined,
     Nodes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2285,7 +2287,7 @@ export const deserializeAws_restJson1ListProposalsCommand = async (
     NextToken: undefined,
     Proposals: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2376,7 +2378,7 @@ export const deserializeAws_restJson1ListProposalVotesCommand = async (
     NextToken: undefined,
     ProposalVotes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2458,7 +2460,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1OutputTagMap(data.Tags, context);
   }

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
@@ -24,6 +24,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -207,7 +209,7 @@ export const deserializeAws_restJson1CancelChangeSetCommand = async (
     ChangeSetArn: undefined,
     ChangeSetId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSetArn !== undefined && data.ChangeSetArn !== null) {
     contents.ChangeSetArn = __expectString(data.ChangeSetArn);
   }
@@ -313,7 +315,7 @@ export const deserializeAws_restJson1DescribeChangeSetCommand = async (
     StartTime: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSet !== undefined && data.ChangeSet !== null) {
     contents.ChangeSet = deserializeAws_restJson1ChangeSetDescription(data.ChangeSet, context);
   }
@@ -428,7 +430,7 @@ export const deserializeAws_restJson1DescribeEntityCommand = async (
     EntityType: undefined,
     LastModifiedDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Details !== undefined && data.Details !== null) {
     contents.Details = __expectString(data.Details);
   }
@@ -536,7 +538,7 @@ export const deserializeAws_restJson1ListChangeSetsCommand = async (
     ChangeSetSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSetSummaryList !== undefined && data.ChangeSetSummaryList !== null) {
     contents.ChangeSetSummaryList = deserializeAws_restJson1ChangeSetSummaryList(data.ChangeSetSummaryList, context);
   }
@@ -619,7 +621,7 @@ export const deserializeAws_restJson1ListEntitiesCommand = async (
     EntitySummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EntitySummaryList !== undefined && data.EntitySummaryList !== null) {
     contents.EntitySummaryList = deserializeAws_restJson1EntitySummaryList(data.EntitySummaryList, context);
   }
@@ -710,7 +712,7 @@ export const deserializeAws_restJson1StartChangeSetCommand = async (
     ChangeSetArn: undefined,
     ChangeSetId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSetArn !== undefined && data.ChangeSetArn !== null) {
     contents.ChangeSetArn = __expectString(data.ChangeSetArn);
   }

--- a/clients/client-mediaconnect/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1.ts
@@ -112,6 +112,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1229,7 +1231,7 @@ export const deserializeAws_restJson1AddFlowMediaStreamsCommand = async (
     FlowArn: undefined,
     MediaStreams: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1328,7 +1330,7 @@ export const deserializeAws_restJson1AddFlowOutputsCommand = async (
     FlowArn: undefined,
     Outputs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1435,7 +1437,7 @@ export const deserializeAws_restJson1AddFlowSourcesCommand = async (
     FlowArn: undefined,
     Sources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1534,7 +1536,7 @@ export const deserializeAws_restJson1AddFlowVpcInterfacesCommand = async (
     FlowArn: undefined,
     VpcInterfaces: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1632,7 +1634,7 @@ export const deserializeAws_restJson1CreateFlowCommand = async (
     $metadata: deserializeMetadata(output),
     Flow: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flow !== undefined && data.flow !== null) {
     contents.Flow = deserializeAws_restJson1Flow(data.flow, context);
   }
@@ -1728,7 +1730,7 @@ export const deserializeAws_restJson1DeleteFlowCommand = async (
     FlowArn: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1827,7 +1829,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     Flow: undefined,
     Messages: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flow !== undefined && data.flow !== null) {
     contents.Flow = deserializeAws_restJson1Flow(data.flow, context);
   }
@@ -1925,7 +1927,7 @@ export const deserializeAws_restJson1DescribeOfferingCommand = async (
     $metadata: deserializeMetadata(output),
     Offering: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.offering !== undefined && data.offering !== null) {
     contents.Offering = deserializeAws_restJson1Offering(data.offering, context);
   }
@@ -2012,7 +2014,7 @@ export const deserializeAws_restJson1DescribeReservationCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }
@@ -2100,7 +2102,7 @@ export const deserializeAws_restJson1GrantFlowEntitlementsCommand = async (
     Entitlements: undefined,
     FlowArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlements !== undefined && data.entitlements !== null) {
     contents.Entitlements = deserializeAws_restJson1__listOfEntitlement(data.entitlements, context);
   }
@@ -2207,7 +2209,7 @@ export const deserializeAws_restJson1ListEntitlementsCommand = async (
     Entitlements: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlements !== undefined && data.entitlements !== null) {
     contents.Entitlements = deserializeAws_restJson1__listOfListedEntitlement(data.entitlements, context);
   }
@@ -2290,7 +2292,7 @@ export const deserializeAws_restJson1ListFlowsCommand = async (
     Flows: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flows !== undefined && data.flows !== null) {
     contents.Flows = deserializeAws_restJson1__listOfListedFlow(data.flows, context);
   }
@@ -2373,7 +2375,7 @@ export const deserializeAws_restJson1ListOfferingsCommand = async (
     NextToken: undefined,
     Offerings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2456,7 +2458,7 @@ export const deserializeAws_restJson1ListReservationsCommand = async (
     NextToken: undefined,
     Reservations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2538,7 +2540,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2609,7 +2611,7 @@ export const deserializeAws_restJson1PurchaseOfferingCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }
@@ -2705,7 +2707,7 @@ export const deserializeAws_restJson1RemoveFlowMediaStreamCommand = async (
     FlowArn: undefined,
     MediaStreamName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2804,7 +2806,7 @@ export const deserializeAws_restJson1RemoveFlowOutputCommand = async (
     FlowArn: undefined,
     OutputArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2903,7 +2905,7 @@ export const deserializeAws_restJson1RemoveFlowSourceCommand = async (
     FlowArn: undefined,
     SourceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -3003,7 +3005,7 @@ export const deserializeAws_restJson1RemoveFlowVpcInterfaceCommand = async (
     NonDeletedNetworkInterfaceIds: undefined,
     VpcInterfaceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -3108,7 +3110,7 @@ export const deserializeAws_restJson1RevokeFlowEntitlementCommand = async (
     EntitlementArn: undefined,
     FlowArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlementArn !== undefined && data.entitlementArn !== null) {
     contents.EntitlementArn = __expectString(data.entitlementArn);
   }
@@ -3207,7 +3209,7 @@ export const deserializeAws_restJson1StartFlowCommand = async (
     FlowArn: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -3306,7 +3308,7 @@ export const deserializeAws_restJson1StopFlowCommand = async (
     FlowArn: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -3538,7 +3540,7 @@ export const deserializeAws_restJson1UpdateFlowCommand = async (
     $metadata: deserializeMetadata(output),
     Flow: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flow !== undefined && data.flow !== null) {
     contents.Flow = deserializeAws_restJson1Flow(data.flow, context);
   }
@@ -3634,7 +3636,7 @@ export const deserializeAws_restJson1UpdateFlowEntitlementCommand = async (
     Entitlement: undefined,
     FlowArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlement !== undefined && data.entitlement !== null) {
     contents.Entitlement = deserializeAws_restJson1Entitlement(data.entitlement, context);
   }
@@ -3733,7 +3735,7 @@ export const deserializeAws_restJson1UpdateFlowMediaStreamCommand = async (
     FlowArn: undefined,
     MediaStream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -3832,7 +3834,7 @@ export const deserializeAws_restJson1UpdateFlowOutputCommand = async (
     FlowArn: undefined,
     Output: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -3931,7 +3933,7 @@ export const deserializeAws_restJson1UpdateFlowSourceCommand = async (
     FlowArn: undefined,
     Source: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }

--- a/clients/client-mediaconvert/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1.ts
@@ -208,6 +208,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1199,7 +1201,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -1294,7 +1296,7 @@ export const deserializeAws_restJson1CreateJobTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     JobTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplate !== undefined && data.jobTemplate !== null) {
     contents.JobTemplate = deserializeAws_restJson1JobTemplate(data.jobTemplate, context);
   }
@@ -1389,7 +1391,7 @@ export const deserializeAws_restJson1CreatePresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preset !== undefined && data.preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.preset, context);
   }
@@ -1484,7 +1486,7 @@ export const deserializeAws_restJson1CreateQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.queue !== undefined && data.queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.queue, context);
   }
@@ -1853,7 +1855,7 @@ export const deserializeAws_restJson1DescribeEndpointsCommand = async (
     Endpoints: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpoints !== undefined && data.endpoints !== null) {
     contents.Endpoints = deserializeAws_restJson1__listOfEndpoint(data.endpoints, context);
   }
@@ -2042,7 +2044,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2137,7 +2139,7 @@ export const deserializeAws_restJson1GetJobTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     JobTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplate !== undefined && data.jobTemplate !== null) {
     contents.JobTemplate = deserializeAws_restJson1JobTemplate(data.jobTemplate, context);
   }
@@ -2232,7 +2234,7 @@ export const deserializeAws_restJson1GetPresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preset !== undefined && data.preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.preset, context);
   }
@@ -2327,7 +2329,7 @@ export const deserializeAws_restJson1GetQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.queue !== undefined && data.queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.queue, context);
   }
@@ -2423,7 +2425,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.Jobs = deserializeAws_restJson1__listOfJob(data.jobs, context);
   }
@@ -2522,7 +2524,7 @@ export const deserializeAws_restJson1ListJobTemplatesCommand = async (
     JobTemplates: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplates !== undefined && data.jobTemplates !== null) {
     contents.JobTemplates = deserializeAws_restJson1__listOfJobTemplate(data.jobTemplates, context);
   }
@@ -2621,7 +2623,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
     NextToken: undefined,
     Presets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2720,7 +2722,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
     NextToken: undefined,
     Queues: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2818,7 +2820,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceTags !== undefined && data.resourceTags !== null) {
     contents.ResourceTags = deserializeAws_restJson1ResourceTags(data.resourceTags, context);
   }
@@ -3095,7 +3097,7 @@ export const deserializeAws_restJson1UpdateJobTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     JobTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplate !== undefined && data.jobTemplate !== null) {
     contents.JobTemplate = deserializeAws_restJson1JobTemplate(data.jobTemplate, context);
   }
@@ -3190,7 +3192,7 @@ export const deserializeAws_restJson1UpdatePresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preset !== undefined && data.preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.preset, context);
   }
@@ -3285,7 +3287,7 @@ export const deserializeAws_restJson1UpdateQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.queue !== undefined && data.queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.queue, context);
   }

--- a/clients/client-medialive/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1.ts
@@ -354,6 +354,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -2360,7 +2362,7 @@ export const deserializeAws_restJson1BatchDeleteCommand = async (
     Failed: undefined,
     Successful: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failed !== undefined && data.failed !== null) {
     contents.Failed = deserializeAws_restJson1__listOfBatchFailedResultModel(data.failed, context);
   }
@@ -2475,7 +2477,7 @@ export const deserializeAws_restJson1BatchStartCommand = async (
     Failed: undefined,
     Successful: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failed !== undefined && data.failed !== null) {
     contents.Failed = deserializeAws_restJson1__listOfBatchFailedResultModel(data.failed, context);
   }
@@ -2590,7 +2592,7 @@ export const deserializeAws_restJson1BatchStopCommand = async (
     Failed: undefined,
     Successful: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failed !== undefined && data.failed !== null) {
     contents.Failed = deserializeAws_restJson1__listOfBatchFailedResultModel(data.failed, context);
   }
@@ -2705,7 +2707,7 @@ export const deserializeAws_restJson1BatchUpdateScheduleCommand = async (
     Creates: undefined,
     Deletes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creates !== undefined && data.creates !== null) {
     contents.Creates = deserializeAws_restJson1BatchScheduleActionCreateResult(data.creates, context);
   }
@@ -2934,7 +2936,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -3045,7 +3047,7 @@ export const deserializeAws_restJson1CreateInputCommand = async (
     $metadata: deserializeMetadata(output),
     Input: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.Input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -3140,7 +3142,7 @@ export const deserializeAws_restJson1CreateInputSecurityGroupCommand = async (
     $metadata: deserializeMetadata(output),
     SecurityGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityGroup !== undefined && data.securityGroup !== null) {
     contents.SecurityGroup = deserializeAws_restJson1InputSecurityGroup(data.securityGroup, context);
   }
@@ -3235,7 +3237,7 @@ export const deserializeAws_restJson1CreateMultiplexCommand = async (
     $metadata: deserializeMetadata(output),
     Multiplex: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplex !== undefined && data.multiplex !== null) {
     contents.Multiplex = deserializeAws_restJson1Multiplex(data.multiplex, context);
   }
@@ -3346,7 +3348,7 @@ export const deserializeAws_restJson1CreateMultiplexProgramCommand = async (
     $metadata: deserializeMetadata(output),
     MultiplexProgram: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexProgram !== undefined && data.multiplexProgram !== null) {
     contents.MultiplexProgram = deserializeAws_restJson1MultiplexProgram(data.multiplexProgram, context);
   }
@@ -3457,7 +3459,7 @@ export const deserializeAws_restJson1CreatePartnerInputCommand = async (
     $metadata: deserializeMetadata(output),
     Input: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.Input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -3643,7 +3645,7 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4017,7 +4019,7 @@ export const deserializeAws_restJson1DeleteMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4159,7 +4161,7 @@ export const deserializeAws_restJson1DeleteMultiplexProgramCommand = async (
     PipelineDetails: undefined,
     ProgramName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelId !== undefined && data.channelId !== null) {
     contents.ChannelId = __expectString(data.channelId);
   }
@@ -4308,7 +4310,7 @@ export const deserializeAws_restJson1DeleteReservationCommand = async (
     Tags: undefined,
     UsagePrice: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4663,7 +4665,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4829,7 +4831,7 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
     Tags: undefined,
     Type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4988,7 +4990,7 @@ export const deserializeAws_restJson1DescribeInputDeviceCommand = async (
     Type: undefined,
     UhdDeviceSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -5246,7 +5248,7 @@ export const deserializeAws_restJson1DescribeInputSecurityGroupCommand = async (
     Tags: undefined,
     WhitelistRules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -5373,7 +5375,7 @@ export const deserializeAws_restJson1DescribeMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -5507,7 +5509,7 @@ export const deserializeAws_restJson1DescribeMultiplexProgramCommand = async (
     PipelineDetails: undefined,
     ProgramName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelId !== undefined && data.channelId !== null) {
     contents.ChannelId = __expectString(data.channelId);
   }
@@ -5641,7 +5643,7 @@ export const deserializeAws_restJson1DescribeOfferingCommand = async (
     ResourceSpecification: undefined,
     UsagePrice: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -5794,7 +5796,7 @@ export const deserializeAws_restJson1DescribeReservationCommand = async (
     Tags: undefined,
     UsagePrice: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -5952,7 +5954,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
     NextToken: undefined,
     ScheduleActions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -6059,7 +6061,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.Channels = deserializeAws_restJson1__listOfChannelSummary(data.channels, context);
   }
@@ -6158,7 +6160,7 @@ export const deserializeAws_restJson1ListInputDevicesCommand = async (
     InputDevices: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputDevices !== undefined && data.inputDevices !== null) {
     contents.InputDevices = deserializeAws_restJson1__listOfInputDeviceSummary(data.inputDevices, context);
   }
@@ -6257,7 +6259,7 @@ export const deserializeAws_restJson1ListInputDeviceTransfersCommand = async (
     InputDeviceTransfers: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputDeviceTransfers !== undefined && data.inputDeviceTransfers !== null) {
     contents.InputDeviceTransfers = deserializeAws_restJson1__listOfTransferringInputDeviceSummary(
       data.inputDeviceTransfers,
@@ -6367,7 +6369,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
     Inputs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputs !== undefined && data.inputs !== null) {
     contents.Inputs = deserializeAws_restJson1__listOfInput(data.inputs, context);
   }
@@ -6466,7 +6468,7 @@ export const deserializeAws_restJson1ListInputSecurityGroupsCommand = async (
     InputSecurityGroups: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputSecurityGroups !== undefined && data.inputSecurityGroups !== null) {
     contents.InputSecurityGroups = deserializeAws_restJson1__listOfInputSecurityGroup(
       data.inputSecurityGroups,
@@ -6568,7 +6570,7 @@ export const deserializeAws_restJson1ListMultiplexesCommand = async (
     Multiplexes: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexes !== undefined && data.multiplexes !== null) {
     contents.Multiplexes = deserializeAws_restJson1__listOfMultiplexSummary(data.multiplexes, context);
   }
@@ -6667,7 +6669,7 @@ export const deserializeAws_restJson1ListMultiplexProgramsCommand = async (
     MultiplexPrograms: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexPrograms !== undefined && data.multiplexPrograms !== null) {
     contents.MultiplexPrograms = deserializeAws_restJson1__listOfMultiplexProgramSummary(
       data.multiplexPrograms,
@@ -6777,7 +6779,7 @@ export const deserializeAws_restJson1ListOfferingsCommand = async (
     NextToken: undefined,
     Offerings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -6876,7 +6878,7 @@ export const deserializeAws_restJson1ListReservationsCommand = async (
     NextToken: undefined,
     Reservations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -6974,7 +6976,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -7053,7 +7055,7 @@ export const deserializeAws_restJson1PurchaseOfferingCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }
@@ -7295,7 +7297,7 @@ export const deserializeAws_restJson1StartChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -7463,7 +7465,7 @@ export const deserializeAws_restJson1StartMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -7617,7 +7619,7 @@ export const deserializeAws_restJson1StopChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -7785,7 +7787,7 @@ export const deserializeAws_restJson1StopMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -8038,7 +8040,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -8141,7 +8143,7 @@ export const deserializeAws_restJson1UpdateChannelClassCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -8260,7 +8262,7 @@ export const deserializeAws_restJson1UpdateInputCommand = async (
     $metadata: deserializeMetadata(output),
     Input: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.Input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -8374,7 +8376,7 @@ export const deserializeAws_restJson1UpdateInputDeviceCommand = async (
     Type: undefined,
     UhdDeviceSettings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -8518,7 +8520,7 @@ export const deserializeAws_restJson1UpdateInputSecurityGroupCommand = async (
     $metadata: deserializeMetadata(output),
     SecurityGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityGroup !== undefined && data.securityGroup !== null) {
     contents.SecurityGroup = deserializeAws_restJson1InputSecurityGroup(data.securityGroup, context);
   }
@@ -8621,7 +8623,7 @@ export const deserializeAws_restJson1UpdateMultiplexCommand = async (
     $metadata: deserializeMetadata(output),
     Multiplex: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplex !== undefined && data.multiplex !== null) {
     contents.Multiplex = deserializeAws_restJson1Multiplex(data.multiplex, context);
   }
@@ -8732,7 +8734,7 @@ export const deserializeAws_restJson1UpdateMultiplexProgramCommand = async (
     $metadata: deserializeMetadata(output),
     MultiplexProgram: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexProgram !== undefined && data.multiplexProgram !== null) {
     contents.MultiplexProgram = deserializeAws_restJson1MultiplexProgram(data.multiplexProgram, context);
   }
@@ -8843,7 +8845,7 @@ export const deserializeAws_restJson1UpdateReservationCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
@@ -77,6 +77,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -615,7 +617,7 @@ export const deserializeAws_restJson1ConfigureLogsCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -733,7 +735,7 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
     SourceRoleArn: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -859,7 +861,7 @@ export const deserializeAws_restJson1CreatePackagingConfigurationCommand = async
     PackagingGroupId: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -980,7 +982,7 @@ export const deserializeAws_restJson1CreatePackagingGroupCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1371,7 +1373,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
     SourceRoleArn: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1497,7 +1499,7 @@ export const deserializeAws_restJson1DescribePackagingConfigurationCommand = asy
     PackagingGroupId: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1618,7 +1620,7 @@ export const deserializeAws_restJson1DescribePackagingGroupCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1729,7 +1731,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
     Assets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assets !== undefined && data.assets !== null) {
     contents.Assets = deserializeAws_restJson1__listOfAssetShallow(data.assets, context);
   }
@@ -1828,7 +1830,7 @@ export const deserializeAws_restJson1ListPackagingConfigurationsCommand = async 
     NextToken: undefined,
     PackagingConfigurations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -1930,7 +1932,7 @@ export const deserializeAws_restJson1ListPackagingGroupsCommand = async (
     NextToken: undefined,
     PackagingGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2028,7 +2030,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2166,7 +2168,7 @@ export const deserializeAws_restJson1UpdatePackagingGroupCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }

--- a/clients/client-mediapackage/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1.ts
@@ -78,6 +78,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -719,7 +721,7 @@ export const deserializeAws_restJson1ConfigureLogsCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -838,7 +840,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -959,7 +961,7 @@ export const deserializeAws_restJson1CreateHarvestJobCommand = async (
     StartTime: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1093,7 +1095,7 @@ export const deserializeAws_restJson1CreateOriginEndpointCommand = async (
     Url: undefined,
     Whitelist: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1421,7 +1423,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1542,7 +1544,7 @@ export const deserializeAws_restJson1DescribeHarvestJobCommand = async (
     StartTime: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1676,7 +1678,7 @@ export const deserializeAws_restJson1DescribeOriginEndpointCommand = async (
     Url: undefined,
     Whitelist: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1817,7 +1819,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.Channels = deserializeAws_restJson1__listOfChannel(data.channels, context);
   }
@@ -1916,7 +1918,7 @@ export const deserializeAws_restJson1ListHarvestJobsCommand = async (
     HarvestJobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.harvestJobs !== undefined && data.harvestJobs !== null) {
     contents.HarvestJobs = deserializeAws_restJson1__listOfHarvestJob(data.harvestJobs, context);
   }
@@ -2015,7 +2017,7 @@ export const deserializeAws_restJson1ListOriginEndpointsCommand = async (
     NextToken: undefined,
     OriginEndpoints: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2113,7 +2115,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2166,7 +2168,7 @@ export const deserializeAws_restJson1RotateChannelCredentialsCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2285,7 +2287,7 @@ export const deserializeAws_restJson1RotateIngestEndpointCredentialsCommand = as
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2490,7 +2492,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2618,7 +2620,7 @@ export const deserializeAws_restJson1UpdateOriginEndpointCommand = async (
     Url: undefined,
     Whitelist: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }

--- a/clients/client-mediastore-data/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1.ts
@@ -13,6 +13,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseLong as __strictParseLong,
@@ -471,7 +473,7 @@ export const deserializeAws_restJson1ListItemsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ItemList(data.Items, context);
   }
@@ -539,7 +541,7 @@ export const deserializeAws_restJson1PutObjectCommand = async (
     ETag: undefined,
     StorageClass: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContentSHA256 !== undefined && data.ContentSHA256 !== null) {
     contents.ContentSHA256 = __expectString(data.ContentSHA256);
   }

--- a/clients/client-mediatailor/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1.ts
@@ -101,6 +101,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1258,7 +1260,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     PlaybackMode: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1332,7 +1334,7 @@ export const deserializeAws_restJson1CreateProgramCommand = async (
     SourceLocationName: undefined,
     VodSourceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdBreaks !== undefined && data.AdBreaks !== null) {
     contents.AdBreaks = deserializeAws_restJson1__listOfAdBreak(data.AdBreaks, context);
   }
@@ -1404,7 +1406,7 @@ export const deserializeAws_restJson1CreateSourceLocationCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessConfiguration !== undefined && data.AccessConfiguration !== null) {
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
@@ -1481,7 +1483,7 @@ export const deserializeAws_restJson1CreateVodSourceCommand = async (
     Tags: undefined,
     VodSourceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1814,7 +1816,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     PlaybackMode: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1888,7 +1890,7 @@ export const deserializeAws_restJson1DescribeProgramCommand = async (
     SourceLocationName: undefined,
     VodSourceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdBreaks !== undefined && data.AdBreaks !== null) {
     contents.AdBreaks = deserializeAws_restJson1__listOfAdBreak(data.AdBreaks, context);
   }
@@ -1960,7 +1962,7 @@ export const deserializeAws_restJson1DescribeSourceLocationCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessConfiguration !== undefined && data.AccessConfiguration !== null) {
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
@@ -2037,7 +2039,7 @@ export const deserializeAws_restJson1DescribeVodSourceCommand = async (
     Tags: undefined,
     VodSourceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2105,7 +2107,7 @@ export const deserializeAws_restJson1GetChannelPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = __expectString(data.Policy);
   }
@@ -2153,7 +2155,7 @@ export const deserializeAws_restJson1GetChannelScheduleCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfScheduleEntry(data.Items, context);
   }
@@ -2220,7 +2222,7 @@ export const deserializeAws_restJson1GetPlaybackConfigurationCommand = async (
     TranscodeProfileName: undefined,
     VideoContentSourceUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdDecisionServerUrl !== undefined && data.AdDecisionServerUrl !== null) {
     contents.AdDecisionServerUrl = __expectString(data.AdDecisionServerUrl);
   }
@@ -2328,7 +2330,7 @@ export const deserializeAws_restJson1ListAlertsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfAlert(data.Items, context);
   }
@@ -2379,7 +2381,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfChannel(data.Items, context);
   }
@@ -2430,7 +2432,7 @@ export const deserializeAws_restJson1ListPlaybackConfigurationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfPlaybackConfiguration(data.Items, context);
   }
@@ -2481,7 +2483,7 @@ export const deserializeAws_restJson1ListSourceLocationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfSourceLocation(data.Items, context);
   }
@@ -2531,7 +2533,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2587,7 +2589,7 @@ export const deserializeAws_restJson1ListVodSourcesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfVodSource(data.Items, context);
   }
@@ -2697,7 +2699,7 @@ export const deserializeAws_restJson1PutPlaybackConfigurationCommand = async (
     TranscodeProfileName: undefined,
     VideoContentSourceUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdDecisionServerUrl !== undefined && data.AdDecisionServerUrl !== null) {
     contents.AdDecisionServerUrl = __expectString(data.AdDecisionServerUrl);
   }
@@ -2999,7 +3001,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     PlaybackMode: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3074,7 +3076,7 @@ export const deserializeAws_restJson1UpdateSourceLocationCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessConfiguration !== undefined && data.AccessConfiguration !== null) {
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
@@ -3151,7 +3153,7 @@ export const deserializeAws_restJson1UpdateVodSourceCommand = async (
     Tags: undefined,
     VodSourceName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-mgn/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/protocols/Aws_restJson1.ts
@@ -114,6 +114,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseLong as __strictParseLong,
@@ -956,7 +958,7 @@ export const deserializeAws_restJson1ChangeServerLifeCycleStateCommand = async (
     sourceServerID: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1070,7 +1072,7 @@ export const deserializeAws_restJson1CreateReplicationConfigurationTemplateComma
     tags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1388,7 +1390,7 @@ export const deserializeAws_restJson1DescribeJobLogItemsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1JobLogs(data.items, context);
   }
@@ -1455,7 +1457,7 @@ export const deserializeAws_restJson1DescribeJobsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1JobsList(data.items, context);
   }
@@ -1522,7 +1524,7 @@ export const deserializeAws_restJson1DescribeReplicationConfigurationTemplatesCo
     items: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1ReplicationConfigurationTemplates(data.items, context);
   }
@@ -1597,7 +1599,7 @@ export const deserializeAws_restJson1DescribeSourceServersCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1SourceServersList(data.items, context);
   }
@@ -1670,7 +1672,7 @@ export const deserializeAws_restJson1DisconnectFromServiceCommand = async (
     sourceServerID: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1769,7 +1771,7 @@ export const deserializeAws_restJson1FinalizeCutoverCommand = async (
     sourceServerID: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1876,7 +1878,7 @@ export const deserializeAws_restJson1GetLaunchConfigurationCommand = async (
     sourceServerID: undefined,
     targetInstanceTypeRightSizingMethod: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.copyPrivateIp !== undefined && data.copyPrivateIp !== null) {
     contents.copyPrivateIp = __expectBoolean(data.copyPrivateIp);
   }
@@ -1974,7 +1976,7 @@ export const deserializeAws_restJson1GetReplicationConfigurationCommand = async 
     stagingAreaTags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
     contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
@@ -2144,7 +2146,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2238,7 +2240,7 @@ export const deserializeAws_restJson1MarkAsArchivedCommand = async (
     sourceServerID: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2337,7 +2339,7 @@ export const deserializeAws_restJson1RetryDataReplicationCommand = async (
     sourceServerID: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2429,7 +2431,7 @@ export const deserializeAws_restJson1StartCutoverCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2500,7 +2502,7 @@ export const deserializeAws_restJson1StartTestCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2654,7 +2656,7 @@ export const deserializeAws_restJson1TerminateTargetInstancesCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2815,7 +2817,7 @@ export const deserializeAws_restJson1UpdateLaunchConfigurationCommand = async (
     sourceServerID: undefined,
     targetInstanceTypeRightSizingMethod: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.copyPrivateIp !== undefined && data.copyPrivateIp !== null) {
     contents.copyPrivateIp = __expectBoolean(data.copyPrivateIp);
   }
@@ -2929,7 +2931,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationCommand = asy
     stagingAreaTags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
     contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
@@ -3078,7 +3080,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationTemplateComma
     tags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-mobile/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1.ts
@@ -24,6 +24,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -293,7 +295,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1ProjectDetails(data.details, context);
   }
@@ -397,7 +399,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
     deletedResources: undefined,
     orphanedResources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deletedResources !== undefined && data.deletedResources !== null) {
     contents.deletedResources = deserializeAws_restJson1Resources(data.deletedResources, context);
   }
@@ -487,7 +489,7 @@ export const deserializeAws_restJson1DescribeBundleCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1BundleDetails(data.details, context);
   }
@@ -582,7 +584,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1ProjectDetails(data.details, context);
   }
@@ -677,7 +679,7 @@ export const deserializeAws_restJson1ExportBundleCommand = async (
     $metadata: deserializeMetadata(output),
     downloadUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
     contents.downloadUrl = __expectString(data.downloadUrl);
   }
@@ -774,7 +776,7 @@ export const deserializeAws_restJson1ExportProjectCommand = async (
     shareUrl: undefined,
     snapshotId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
     contents.downloadUrl = __expectString(data.downloadUrl);
   }
@@ -876,7 +878,7 @@ export const deserializeAws_restJson1ListBundlesCommand = async (
     bundleList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bundleList !== undefined && data.bundleList !== null) {
     contents.bundleList = deserializeAws_restJson1BundleList(data.bundleList, context);
   }
@@ -967,7 +969,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     nextToken: undefined,
     projects: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1057,7 +1059,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1ProjectDetails(data.details, context);
   }

--- a/clients/client-mq/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1.ts
@@ -75,6 +75,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -870,7 +872,7 @@ export const deserializeAws_restJson1CreateBrokerCommand = async (
     BrokerArn: undefined,
     BrokerId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerArn !== undefined && data.brokerArn !== null) {
     contents.BrokerArn = __expectString(data.brokerArn);
   }
@@ -965,7 +967,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     LatestRevision: undefined,
     Name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1217,7 +1219,7 @@ export const deserializeAws_restJson1DeleteBrokerCommand = async (
     $metadata: deserializeMetadata(output),
     BrokerId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerId !== undefined && data.brokerId !== null) {
     contents.BrokerId = __expectString(data.brokerId);
   }
@@ -1473,7 +1475,7 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
     Tags: undefined,
     Users: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authenticationStrategy !== undefined && data.authenticationStrategy !== null) {
     contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
@@ -1641,7 +1643,7 @@ export const deserializeAws_restJson1DescribeBrokerEngineTypesCommand = async (
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerEngineTypes !== undefined && data.brokerEngineTypes !== null) {
     contents.BrokerEngineTypes = deserializeAws_restJson1__listOfBrokerEngineType(data.brokerEngineTypes, context);
   }
@@ -1720,7 +1722,7 @@ export const deserializeAws_restJson1DescribeBrokerInstanceOptionsCommand = asyn
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerInstanceOptions !== undefined && data.brokerInstanceOptions !== null) {
     contents.BrokerInstanceOptions = deserializeAws_restJson1__listOfBrokerInstanceOption(
       data.brokerInstanceOptions,
@@ -1809,7 +1811,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     Name: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1918,7 +1920,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     Data: undefined,
     Description: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationId !== undefined && data.configurationId !== null) {
     contents.ConfigurationId = __expectString(data.configurationId);
   }
@@ -2010,7 +2012,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
     Pending: undefined,
     Username: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerId !== undefined && data.brokerId !== null) {
     contents.BrokerId = __expectString(data.brokerId);
   }
@@ -2102,7 +2104,7 @@ export const deserializeAws_restJson1ListBrokersCommand = async (
     BrokerSummaries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerSummaries !== undefined && data.brokerSummaries !== null) {
     contents.BrokerSummaries = deserializeAws_restJson1__listOfBrokerSummary(data.brokerSummaries, context);
   }
@@ -2179,7 +2181,7 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
     NextToken: undefined,
     Revisions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationId !== undefined && data.configurationId !== null) {
     contents.ConfigurationId = __expectString(data.configurationId);
   }
@@ -2269,7 +2271,7 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurations !== undefined && data.configurations !== null) {
     contents.Configurations = deserializeAws_restJson1__listOfConfiguration(data.configurations, context);
   }
@@ -2346,7 +2348,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2428,7 +2430,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     NextToken: undefined,
     Users: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerId !== undefined && data.brokerId !== null) {
     contents.BrokerId = __expectString(data.brokerId);
   }
@@ -2600,7 +2602,7 @@ export const deserializeAws_restJson1UpdateBrokerCommand = async (
     MaintenanceWindowStartTime: undefined,
     SecurityGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authenticationStrategy !== undefined && data.authenticationStrategy !== null) {
     contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
@@ -2722,7 +2724,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
     Name: undefined,
     Warnings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }

--- a/clients/client-mwaa/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/protocols/Aws_restJson1.ts
@@ -41,6 +41,8 @@ import {
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   serializeFloat as __serializeFloat,
@@ -555,7 +557,7 @@ export const deserializeAws_restJson1CreateCliTokenCommand = async (
     CliToken: undefined,
     WebServerHostname: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CliToken !== undefined && data.CliToken !== null) {
     contents.CliToken = __expectString(data.CliToken);
   }
@@ -613,7 +615,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -677,7 +679,7 @@ export const deserializeAws_restJson1CreateWebLoginTokenCommand = async (
     WebServerHostname: undefined,
     WebToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WebServerHostname !== undefined && data.WebServerHostname !== null) {
     contents.WebServerHostname = __expectString(data.WebServerHostname);
   }
@@ -826,7 +828,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     Environment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Environment !== undefined && data.Environment !== null) {
     contents.Environment = deserializeAws_restJson1Environment(data.Environment, context);
   }
@@ -898,7 +900,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     Environments: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Environments !== undefined && data.Environments !== null) {
     contents.Environments = deserializeAws_restJson1EnvironmentList(data.Environments, context);
   }
@@ -964,7 +966,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -1228,7 +1230,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-networkmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1.ts
@@ -105,6 +105,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseInt32 as __strictParseInt32,
@@ -1458,7 +1460,7 @@ export const deserializeAws_restJson1AssociateCustomerGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     CustomerGatewayAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomerGatewayAssociation !== undefined && data.CustomerGatewayAssociation !== null) {
     contents.CustomerGatewayAssociation = deserializeAws_restJson1CustomerGatewayAssociation(
       data.CustomerGatewayAssociation,
@@ -1564,7 +1566,7 @@ export const deserializeAws_restJson1AssociateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     LinkAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkAssociation !== undefined && data.LinkAssociation !== null) {
     contents.LinkAssociation = deserializeAws_restJson1LinkAssociation(data.LinkAssociation, context);
   }
@@ -1667,7 +1669,7 @@ export const deserializeAws_restJson1AssociateTransitGatewayConnectPeerCommand =
     $metadata: deserializeMetadata(output),
     TransitGatewayConnectPeerAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayConnectPeerAssociation !== undefined && data.TransitGatewayConnectPeerAssociation !== null) {
     contents.TransitGatewayConnectPeerAssociation = deserializeAws_restJson1TransitGatewayConnectPeerAssociation(
       data.TransitGatewayConnectPeerAssociation,
@@ -1773,7 +1775,7 @@ export const deserializeAws_restJson1CreateConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1Connection(data.Connection, context);
   }
@@ -1868,7 +1870,7 @@ export const deserializeAws_restJson1CreateDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Device: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Device !== undefined && data.Device !== null) {
     contents.Device = deserializeAws_restJson1Device(data.Device, context);
   }
@@ -1971,7 +1973,7 @@ export const deserializeAws_restJson1CreateGlobalNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     GlobalNetwork: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetwork !== undefined && data.GlobalNetwork !== null) {
     contents.GlobalNetwork = deserializeAws_restJson1GlobalNetwork(data.GlobalNetwork, context);
   }
@@ -2066,7 +2068,7 @@ export const deserializeAws_restJson1CreateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     Link: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Link !== undefined && data.Link !== null) {
     contents.Link = deserializeAws_restJson1Link(data.Link, context);
   }
@@ -2169,7 +2171,7 @@ export const deserializeAws_restJson1CreateSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -2272,7 +2274,7 @@ export const deserializeAws_restJson1DeleteConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1Connection(data.Connection, context);
   }
@@ -2367,7 +2369,7 @@ export const deserializeAws_restJson1DeleteDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Device: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Device !== undefined && data.Device !== null) {
     contents.Device = deserializeAws_restJson1Device(data.Device, context);
   }
@@ -2462,7 +2464,7 @@ export const deserializeAws_restJson1DeleteGlobalNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     GlobalNetwork: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetwork !== undefined && data.GlobalNetwork !== null) {
     contents.GlobalNetwork = deserializeAws_restJson1GlobalNetwork(data.GlobalNetwork, context);
   }
@@ -2557,7 +2559,7 @@ export const deserializeAws_restJson1DeleteLinkCommand = async (
     $metadata: deserializeMetadata(output),
     Link: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Link !== undefined && data.Link !== null) {
     contents.Link = deserializeAws_restJson1Link(data.Link, context);
   }
@@ -2652,7 +2654,7 @@ export const deserializeAws_restJson1DeleteSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -2747,7 +2749,7 @@ export const deserializeAws_restJson1DeregisterTransitGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     TransitGatewayRegistration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayRegistration !== undefined && data.TransitGatewayRegistration !== null) {
     contents.TransitGatewayRegistration = deserializeAws_restJson1TransitGatewayRegistration(
       data.TransitGatewayRegistration,
@@ -2846,7 +2848,7 @@ export const deserializeAws_restJson1DescribeGlobalNetworksCommand = async (
     GlobalNetworks: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetworks !== undefined && data.GlobalNetworks !== null) {
     contents.GlobalNetworks = deserializeAws_restJson1GlobalNetworkList(data.GlobalNetworks, context);
   }
@@ -2936,7 +2938,7 @@ export const deserializeAws_restJson1DisassociateCustomerGatewayCommand = async 
     $metadata: deserializeMetadata(output),
     CustomerGatewayAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomerGatewayAssociation !== undefined && data.CustomerGatewayAssociation !== null) {
     contents.CustomerGatewayAssociation = deserializeAws_restJson1CustomerGatewayAssociation(
       data.CustomerGatewayAssociation,
@@ -3034,7 +3036,7 @@ export const deserializeAws_restJson1DisassociateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     LinkAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkAssociation !== undefined && data.LinkAssociation !== null) {
     contents.LinkAssociation = deserializeAws_restJson1LinkAssociation(data.LinkAssociation, context);
   }
@@ -3129,7 +3131,7 @@ export const deserializeAws_restJson1DisassociateTransitGatewayConnectPeerComman
     $metadata: deserializeMetadata(output),
     TransitGatewayConnectPeerAssociation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayConnectPeerAssociation !== undefined && data.TransitGatewayConnectPeerAssociation !== null) {
     contents.TransitGatewayConnectPeerAssociation = deserializeAws_restJson1TransitGatewayConnectPeerAssociation(
       data.TransitGatewayConnectPeerAssociation,
@@ -3228,7 +3230,7 @@ export const deserializeAws_restJson1GetConnectionsCommand = async (
     Connections: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connections !== undefined && data.Connections !== null) {
     contents.Connections = deserializeAws_restJson1ConnectionList(data.Connections, context);
   }
@@ -3319,7 +3321,7 @@ export const deserializeAws_restJson1GetCustomerGatewayAssociationsCommand = asy
     CustomerGatewayAssociations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomerGatewayAssociations !== undefined && data.CustomerGatewayAssociations !== null) {
     contents.CustomerGatewayAssociations = deserializeAws_restJson1CustomerGatewayAssociationList(
       data.CustomerGatewayAssociations,
@@ -3421,7 +3423,7 @@ export const deserializeAws_restJson1GetDevicesCommand = async (
     Devices: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Devices !== undefined && data.Devices !== null) {
     contents.Devices = deserializeAws_restJson1DeviceList(data.Devices, context);
   }
@@ -3512,7 +3514,7 @@ export const deserializeAws_restJson1GetLinkAssociationsCommand = async (
     LinkAssociations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkAssociations !== undefined && data.LinkAssociations !== null) {
     contents.LinkAssociations = deserializeAws_restJson1LinkAssociationList(data.LinkAssociations, context);
   }
@@ -3603,7 +3605,7 @@ export const deserializeAws_restJson1GetLinksCommand = async (
     Links: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Links !== undefined && data.Links !== null) {
     contents.Links = deserializeAws_restJson1LinkList(data.Links, context);
   }
@@ -3694,7 +3696,7 @@ export const deserializeAws_restJson1GetSitesCommand = async (
     NextToken: undefined,
     Sites: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3785,7 +3787,7 @@ export const deserializeAws_restJson1GetTransitGatewayConnectPeerAssociationsCom
     NextToken: undefined,
     TransitGatewayConnectPeerAssociations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3887,7 +3889,7 @@ export const deserializeAws_restJson1GetTransitGatewayRegistrationsCommand = asy
     NextToken: undefined,
     TransitGatewayRegistrations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3980,7 +3982,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     TagList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagList !== undefined && data.TagList !== null) {
     contents.TagList = deserializeAws_restJson1TagList(data.TagList, context);
   }
@@ -4067,7 +4069,7 @@ export const deserializeAws_restJson1RegisterTransitGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     TransitGatewayRegistration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayRegistration !== undefined && data.TransitGatewayRegistration !== null) {
     contents.TransitGatewayRegistration = deserializeAws_restJson1TransitGatewayRegistration(
       data.TransitGatewayRegistration,
@@ -4355,7 +4357,7 @@ export const deserializeAws_restJson1UpdateConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1Connection(data.Connection, context);
   }
@@ -4450,7 +4452,7 @@ export const deserializeAws_restJson1UpdateDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Device: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Device !== undefined && data.Device !== null) {
     contents.Device = deserializeAws_restJson1Device(data.Device, context);
   }
@@ -4545,7 +4547,7 @@ export const deserializeAws_restJson1UpdateGlobalNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     GlobalNetwork: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetwork !== undefined && data.GlobalNetwork !== null) {
     contents.GlobalNetwork = deserializeAws_restJson1GlobalNetwork(data.GlobalNetwork, context);
   }
@@ -4640,7 +4642,7 @@ export const deserializeAws_restJson1UpdateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     Link: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Link !== undefined && data.Link !== null) {
     contents.Link = deserializeAws_restJson1Link(data.Link, context);
   }
@@ -4743,7 +4745,7 @@ export const deserializeAws_restJson1UpdateSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }

--- a/clients/client-nimble/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/protocols/Aws_restJson1.ts
@@ -165,6 +165,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -2023,7 +2025,7 @@ export const deserializeAws_restJson1AcceptEulasCommand = async (
     $metadata: deserializeMetadata(output),
     eulaAcceptances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eulaAcceptances !== undefined && data.eulaAcceptances !== null) {
     contents.eulaAcceptances = deserializeAws_restJson1EulaAcceptanceList(data.eulaAcceptances, context);
   }
@@ -2126,7 +2128,7 @@ export const deserializeAws_restJson1CreateLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -2229,7 +2231,7 @@ export const deserializeAws_restJson1CreateStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -2332,7 +2334,7 @@ export const deserializeAws_restJson1CreateStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -2435,7 +2437,7 @@ export const deserializeAws_restJson1CreateStreamingSessionStreamCommand = async
     $metadata: deserializeMetadata(output),
     stream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.stream !== undefined && data.stream !== null) {
     contents.stream = deserializeAws_restJson1StreamingSessionStream(data.stream, context);
   }
@@ -2538,7 +2540,7 @@ export const deserializeAws_restJson1CreateStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -2641,7 +2643,7 @@ export const deserializeAws_restJson1CreateStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }
@@ -2744,7 +2746,7 @@ export const deserializeAws_restJson1DeleteLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -2946,7 +2948,7 @@ export const deserializeAws_restJson1DeleteStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -3049,7 +3051,7 @@ export const deserializeAws_restJson1DeleteStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -3152,7 +3154,7 @@ export const deserializeAws_restJson1DeleteStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -3255,7 +3257,7 @@ export const deserializeAws_restJson1DeleteStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }
@@ -3457,7 +3459,7 @@ export const deserializeAws_restJson1GetEulaCommand = async (
     $metadata: deserializeMetadata(output),
     eula: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eula !== undefined && data.eula !== null) {
     contents.eula = deserializeAws_restJson1Eula(data.eula, context);
   }
@@ -3560,7 +3562,7 @@ export const deserializeAws_restJson1GetLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -3665,7 +3667,7 @@ export const deserializeAws_restJson1GetLaunchProfileDetailsCommand = async (
     streamingImages: undefined,
     studioComponentSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -3777,7 +3779,7 @@ export const deserializeAws_restJson1GetLaunchProfileInitializationCommand = asy
     $metadata: deserializeMetadata(output),
     launchProfileInitialization: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfileInitialization !== undefined && data.launchProfileInitialization !== null) {
     contents.launchProfileInitialization = deserializeAws_restJson1LaunchProfileInitialization(
       data.launchProfileInitialization,
@@ -3883,7 +3885,7 @@ export const deserializeAws_restJson1GetLaunchProfileMemberCommand = async (
     $metadata: deserializeMetadata(output),
     member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.member !== undefined && data.member !== null) {
     contents.member = deserializeAws_restJson1LaunchProfileMembership(data.member, context);
   }
@@ -3986,7 +3988,7 @@ export const deserializeAws_restJson1GetStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -4089,7 +4091,7 @@ export const deserializeAws_restJson1GetStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -4192,7 +4194,7 @@ export const deserializeAws_restJson1GetStreamingSessionStreamCommand = async (
     $metadata: deserializeMetadata(output),
     stream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.stream !== undefined && data.stream !== null) {
     contents.stream = deserializeAws_restJson1StreamingSessionStream(data.stream, context);
   }
@@ -4295,7 +4297,7 @@ export const deserializeAws_restJson1GetStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -4398,7 +4400,7 @@ export const deserializeAws_restJson1GetStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }
@@ -4501,7 +4503,7 @@ export const deserializeAws_restJson1GetStudioMemberCommand = async (
     $metadata: deserializeMetadata(output),
     member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.member !== undefined && data.member !== null) {
     contents.member = deserializeAws_restJson1StudioMembership(data.member, context);
   }
@@ -4605,7 +4607,7 @@ export const deserializeAws_restJson1ListEulaAcceptancesCommand = async (
     eulaAcceptances: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eulaAcceptances !== undefined && data.eulaAcceptances !== null) {
     contents.eulaAcceptances = deserializeAws_restJson1EulaAcceptanceList(data.eulaAcceptances, context);
   }
@@ -4712,7 +4714,7 @@ export const deserializeAws_restJson1ListEulasCommand = async (
     eulas: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eulas !== undefined && data.eulas !== null) {
     contents.eulas = deserializeAws_restJson1EulaList(data.eulas, context);
   }
@@ -4819,7 +4821,7 @@ export const deserializeAws_restJson1ListLaunchProfileMembersCommand = async (
     members: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.members = deserializeAws_restJson1LaunchProfileMembershipList(data.members, context);
   }
@@ -4926,7 +4928,7 @@ export const deserializeAws_restJson1ListLaunchProfilesCommand = async (
     launchProfiles: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfiles !== undefined && data.launchProfiles !== null) {
     contents.launchProfiles = deserializeAws_restJson1LaunchProfileList(data.launchProfiles, context);
   }
@@ -5033,7 +5035,7 @@ export const deserializeAws_restJson1ListStreamingImagesCommand = async (
     nextToken: undefined,
     streamingImages: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5140,7 +5142,7 @@ export const deserializeAws_restJson1ListStreamingSessionsCommand = async (
     nextToken: undefined,
     sessions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5247,7 +5249,7 @@ export const deserializeAws_restJson1ListStudioComponentsCommand = async (
     nextToken: undefined,
     studioComponents: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5354,7 +5356,7 @@ export const deserializeAws_restJson1ListStudioMembersCommand = async (
     members: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.members = deserializeAws_restJson1StudioMembershipList(data.members, context);
   }
@@ -5461,7 +5463,7 @@ export const deserializeAws_restJson1ListStudiosCommand = async (
     nextToken: undefined,
     studios: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5567,7 +5569,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -5868,7 +5870,7 @@ export const deserializeAws_restJson1StartStudioSSOConfigurationRepairCommand = 
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -6169,7 +6171,7 @@ export const deserializeAws_restJson1UpdateLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -6272,7 +6274,7 @@ export const deserializeAws_restJson1UpdateLaunchProfileMemberCommand = async (
     $metadata: deserializeMetadata(output),
     member: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.member !== undefined && data.member !== null) {
     contents.member = deserializeAws_restJson1LaunchProfileMembership(data.member, context);
   }
@@ -6375,7 +6377,7 @@ export const deserializeAws_restJson1UpdateStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -6478,7 +6480,7 @@ export const deserializeAws_restJson1UpdateStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -6581,7 +6583,7 @@ export const deserializeAws_restJson1UpdateStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }

--- a/clients/client-outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/protocols/Aws_restJson1.ts
@@ -27,6 +27,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -348,7 +350,7 @@ export const deserializeAws_restJson1CreateOutpostCommand = async (
     $metadata: deserializeMetadata(output),
     Outpost: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Outpost !== undefined && data.Outpost !== null) {
     contents.Outpost = deserializeAws_restJson1Outpost(data.Outpost, context);
   }
@@ -609,7 +611,7 @@ export const deserializeAws_restJson1GetOutpostCommand = async (
     $metadata: deserializeMetadata(output),
     Outpost: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Outpost !== undefined && data.Outpost !== null) {
     contents.Outpost = deserializeAws_restJson1Outpost(data.Outpost, context);
   }
@@ -691,7 +693,7 @@ export const deserializeAws_restJson1GetOutpostInstanceTypesCommand = async (
     OutpostArn: undefined,
     OutpostId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InstanceTypes !== undefined && data.InstanceTypes !== null) {
     contents.InstanceTypes = deserializeAws_restJson1InstanceTypeListDefinition(data.InstanceTypes, context);
   }
@@ -780,7 +782,7 @@ export const deserializeAws_restJson1ListOutpostsCommand = async (
     NextToken: undefined,
     Outposts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -855,7 +857,7 @@ export const deserializeAws_restJson1ListSitesCommand = async (
     NextToken: undefined,
     Sites: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -929,7 +931,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
@@ -5,7 +5,12 @@ import {
 import { GetRecommendationsCommandInput, GetRecommendationsCommandOutput } from "../commands/GetRecommendationsCommand";
 import { InvalidInputException, PredictedItem, ResourceNotFoundException } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString, limitedParseDouble as __limitedParseDouble } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+  limitedParseDouble as __limitedParseDouble,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -90,7 +95,7 @@ export const deserializeAws_restJson1GetPersonalizedRankingCommand = async (
     personalizedRanking: undefined,
     recommendationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.personalizedRanking !== undefined && data.personalizedRanking !== null) {
     contents.personalizedRanking = deserializeAws_restJson1ItemList(data.personalizedRanking, context);
   }
@@ -157,7 +162,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     itemList: undefined,
     recommendationId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.itemList !== undefined && data.itemList !== null) {
     contents.itemList = deserializeAws_restJson1ItemList(data.itemList, context);
   }

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
@@ -199,6 +199,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -1790,7 +1792,7 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
     DeliverabilityTestStatus: undefined,
     ReportId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestStatus !== undefined && data.DeliverabilityTestStatus !== null) {
     contents.DeliverabilityTestStatus = __expectString(data.DeliverabilityTestStatus);
   }
@@ -1914,7 +1916,7 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
     IdentityType: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimAttributes !== undefined && data.DkimAttributes !== null) {
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
@@ -2295,7 +2297,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     SendQuota: undefined,
     SendingEnabled: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpAutoWarmupEnabled !== undefined && data.DedicatedIpAutoWarmupEnabled !== null) {
     contents.DedicatedIpAutoWarmupEnabled = __expectBoolean(data.DedicatedIpAutoWarmupEnabled);
   }
@@ -2370,7 +2372,7 @@ export const deserializeAws_restJson1GetBlacklistReportsCommand = async (
     $metadata: deserializeMetadata(output),
     BlacklistReport: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlacklistReport !== undefined && data.BlacklistReport !== null) {
     contents.BlacklistReport = deserializeAws_restJson1BlacklistReport(data.BlacklistReport, context);
   }
@@ -2446,7 +2448,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
     Tags: undefined,
     TrackingOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
     contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
@@ -2532,7 +2534,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
     $metadata: deserializeMetadata(output),
     EventDestinations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventDestinations !== undefined && data.EventDestinations !== null) {
     contents.EventDestinations = deserializeAws_restJson1EventDestinations(data.EventDestinations, context);
   }
@@ -2603,7 +2605,7 @@ export const deserializeAws_restJson1GetDedicatedIpCommand = async (
     $metadata: deserializeMetadata(output),
     DedicatedIp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIp !== undefined && data.DedicatedIp !== null) {
     contents.DedicatedIp = deserializeAws_restJson1DedicatedIp(data.DedicatedIp, context);
   }
@@ -2675,7 +2677,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
     DedicatedIps: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIps !== undefined && data.DedicatedIps !== null) {
     contents.DedicatedIps = deserializeAws_restJson1DedicatedIpList(data.DedicatedIps, context);
   }
@@ -2753,7 +2755,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     PendingExpirationSubscribedDomains: undefined,
     SubscriptionExpiryDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountStatus !== undefined && data.AccountStatus !== null) {
     contents.AccountStatus = __expectString(data.AccountStatus);
   }
@@ -2846,7 +2848,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
     OverallPlacement: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReport !== undefined && data.DeliverabilityTestReport !== null) {
     contents.DeliverabilityTestReport = deserializeAws_restJson1DeliverabilityTestReport(
       data.DeliverabilityTestReport,
@@ -2932,7 +2934,7 @@ export const deserializeAws_restJson1GetDomainDeliverabilityCampaignCommand = as
     $metadata: deserializeMetadata(output),
     DomainDeliverabilityCampaign: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaign !== undefined && data.DomainDeliverabilityCampaign !== null) {
     contents.DomainDeliverabilityCampaign = deserializeAws_restJson1DomainDeliverabilityCampaign(
       data.DomainDeliverabilityCampaign,
@@ -3007,7 +3009,7 @@ export const deserializeAws_restJson1GetDomainStatisticsReportCommand = async (
     DailyVolumes: undefined,
     OverallVolume: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DailyVolumes !== undefined && data.DailyVolumes !== null) {
     contents.DailyVolumes = deserializeAws_restJson1DailyVolumes(data.DailyVolumes, context);
   }
@@ -3086,7 +3088,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
     Tags: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimAttributes !== undefined && data.DkimAttributes !== null) {
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
@@ -3173,7 +3175,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     ConfigurationSets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSets !== undefined && data.ConfigurationSets !== null) {
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSetNameList(data.ConfigurationSets, context);
   }
@@ -3240,7 +3242,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
     DedicatedIpPools: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpPools !== undefined && data.DedicatedIpPools !== null) {
     contents.DedicatedIpPools = deserializeAws_restJson1ListOfDedicatedIpPools(data.DedicatedIpPools, context);
   }
@@ -3307,7 +3309,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
     DeliverabilityTestReports: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReports !== undefined && data.DeliverabilityTestReports !== null) {
     contents.DeliverabilityTestReports = deserializeAws_restJson1DeliverabilityTestReports(
       data.DeliverabilityTestReports,
@@ -3385,7 +3387,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
     DomainDeliverabilityCampaigns: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaigns !== undefined && data.DomainDeliverabilityCampaigns !== null) {
     contents.DomainDeliverabilityCampaigns = deserializeAws_restJson1DomainDeliverabilityCampaignList(
       data.DomainDeliverabilityCampaigns,
@@ -3463,7 +3465,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
     EmailIdentities: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmailIdentities !== undefined && data.EmailIdentities !== null) {
     contents.EmailIdentities = deserializeAws_restJson1IdentityInfoList(data.EmailIdentities, context);
   }
@@ -3529,7 +3531,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -4404,7 +4406,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
@@ -48,6 +48,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -664,7 +666,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
     $metadata: deserializeMetadata(output),
     EventDestinations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventDestinations !== undefined && data.EventDestinations !== null) {
     contents.EventDestinations = deserializeAws_restJson1EventDestinations(data.EventDestinations, context);
   }
@@ -744,7 +746,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     ConfigurationSets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSets !== undefined && data.ConfigurationSets !== null) {
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSets(data.ConfigurationSets, context);
   }
@@ -818,7 +820,7 @@ export const deserializeAws_restJson1SendVoiceMessageCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }

--- a/clients/client-pinpoint/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1.ts
@@ -414,6 +414,7 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -4528,7 +4529,7 @@ export const deserializeAws_restJson1CreateAppCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationResponse = deserializeAws_restJson1ApplicationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -4629,7 +4630,7 @@ export const deserializeAws_restJson1CreateCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -4730,7 +4731,7 @@ export const deserializeAws_restJson1CreateEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -4815,7 +4816,7 @@ export const deserializeAws_restJson1CreateExportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobResponse = deserializeAws_restJson1ExportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -4916,7 +4917,7 @@ export const deserializeAws_restJson1CreateImportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobResponse = deserializeAws_restJson1ImportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5017,7 +5018,7 @@ export const deserializeAws_restJson1CreateJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5118,7 +5119,7 @@ export const deserializeAws_restJson1CreatePushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -5203,7 +5204,7 @@ export const deserializeAws_restJson1CreateRecommenderConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5304,7 +5305,7 @@ export const deserializeAws_restJson1CreateSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5405,7 +5406,7 @@ export const deserializeAws_restJson1CreateSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -5490,7 +5491,7 @@ export const deserializeAws_restJson1CreateVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -5575,7 +5576,7 @@ export const deserializeAws_restJson1DeleteAdmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ADMChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ADMChannelResponse = deserializeAws_restJson1ADMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5676,7 +5677,7 @@ export const deserializeAws_restJson1DeleteApnsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSChannelResponse = deserializeAws_restJson1APNSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5777,7 +5778,7 @@ export const deserializeAws_restJson1DeleteApnsSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSSandboxChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSSandboxChannelResponse = deserializeAws_restJson1APNSSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5878,7 +5879,7 @@ export const deserializeAws_restJson1DeleteApnsVoipChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipChannelResponse = deserializeAws_restJson1APNSVoipChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5979,7 +5980,7 @@ export const deserializeAws_restJson1DeleteApnsVoipSandboxChannelCommand = async
     $metadata: deserializeMetadata(output),
     APNSVoipSandboxChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipSandboxChannelResponse = deserializeAws_restJson1APNSVoipSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6080,7 +6081,7 @@ export const deserializeAws_restJson1DeleteAppCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationResponse = deserializeAws_restJson1ApplicationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6181,7 +6182,7 @@ export const deserializeAws_restJson1DeleteBaiduChannelCommand = async (
     $metadata: deserializeMetadata(output),
     BaiduChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.BaiduChannelResponse = deserializeAws_restJson1BaiduChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6282,7 +6283,7 @@ export const deserializeAws_restJson1DeleteCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6383,7 +6384,7 @@ export const deserializeAws_restJson1DeleteEmailChannelCommand = async (
     $metadata: deserializeMetadata(output),
     EmailChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailChannelResponse = deserializeAws_restJson1EmailChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6484,7 +6485,7 @@ export const deserializeAws_restJson1DeleteEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -6585,7 +6586,7 @@ export const deserializeAws_restJson1DeleteEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointResponse = deserializeAws_restJson1EndpointResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6686,7 +6687,7 @@ export const deserializeAws_restJson1DeleteEventStreamCommand = async (
     $metadata: deserializeMetadata(output),
     EventStream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventStream = deserializeAws_restJson1EventStream(data, context);
   return Promise.resolve(contents);
 };
@@ -6787,7 +6788,7 @@ export const deserializeAws_restJson1DeleteGcmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     GCMChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.GCMChannelResponse = deserializeAws_restJson1GCMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6888,7 +6889,7 @@ export const deserializeAws_restJson1DeleteJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6989,7 +6990,7 @@ export const deserializeAws_restJson1DeletePushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -7090,7 +7091,7 @@ export const deserializeAws_restJson1DeleteRecommenderConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7191,7 +7192,7 @@ export const deserializeAws_restJson1DeleteSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7292,7 +7293,7 @@ export const deserializeAws_restJson1DeleteSmsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     SMSChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSChannelResponse = deserializeAws_restJson1SMSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7393,7 +7394,7 @@ export const deserializeAws_restJson1DeleteSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -7494,7 +7495,7 @@ export const deserializeAws_restJson1DeleteUserEndpointsCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointsResponse = deserializeAws_restJson1EndpointsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7595,7 +7596,7 @@ export const deserializeAws_restJson1DeleteVoiceChannelCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceChannelResponse = deserializeAws_restJson1VoiceChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7696,7 +7697,7 @@ export const deserializeAws_restJson1DeleteVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -7797,7 +7798,7 @@ export const deserializeAws_restJson1GetAdmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ADMChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ADMChannelResponse = deserializeAws_restJson1ADMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7898,7 +7899,7 @@ export const deserializeAws_restJson1GetApnsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSChannelResponse = deserializeAws_restJson1APNSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7999,7 +8000,7 @@ export const deserializeAws_restJson1GetApnsSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSSandboxChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSSandboxChannelResponse = deserializeAws_restJson1APNSSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8100,7 +8101,7 @@ export const deserializeAws_restJson1GetApnsVoipChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipChannelResponse = deserializeAws_restJson1APNSVoipChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8201,7 +8202,7 @@ export const deserializeAws_restJson1GetApnsVoipSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipSandboxChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipSandboxChannelResponse = deserializeAws_restJson1APNSVoipSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8302,7 +8303,7 @@ export const deserializeAws_restJson1GetAppCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationResponse = deserializeAws_restJson1ApplicationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8403,7 +8404,7 @@ export const deserializeAws_restJson1GetApplicationDateRangeKpiCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationDateRangeKpiResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationDateRangeKpiResponse = deserializeAws_restJson1ApplicationDateRangeKpiResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8504,7 +8505,7 @@ export const deserializeAws_restJson1GetApplicationSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationSettingsResource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationSettingsResource = deserializeAws_restJson1ApplicationSettingsResource(data, context);
   return Promise.resolve(contents);
 };
@@ -8605,7 +8606,7 @@ export const deserializeAws_restJson1GetAppsCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationsResponse = deserializeAws_restJson1ApplicationsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8706,7 +8707,7 @@ export const deserializeAws_restJson1GetBaiduChannelCommand = async (
     $metadata: deserializeMetadata(output),
     BaiduChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.BaiduChannelResponse = deserializeAws_restJson1BaiduChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8807,7 +8808,7 @@ export const deserializeAws_restJson1GetCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8908,7 +8909,7 @@ export const deserializeAws_restJson1GetCampaignActivitiesCommand = async (
     $metadata: deserializeMetadata(output),
     ActivitiesResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ActivitiesResponse = deserializeAws_restJson1ActivitiesResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9009,7 +9010,7 @@ export const deserializeAws_restJson1GetCampaignDateRangeKpiCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignDateRangeKpiResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignDateRangeKpiResponse = deserializeAws_restJson1CampaignDateRangeKpiResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9110,7 +9111,7 @@ export const deserializeAws_restJson1GetCampaignsCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignsResponse = deserializeAws_restJson1CampaignsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9211,7 +9212,7 @@ export const deserializeAws_restJson1GetCampaignVersionCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9312,7 +9313,7 @@ export const deserializeAws_restJson1GetCampaignVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignsResponse = deserializeAws_restJson1CampaignsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9413,7 +9414,7 @@ export const deserializeAws_restJson1GetChannelsCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ChannelsResponse = deserializeAws_restJson1ChannelsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9514,7 +9515,7 @@ export const deserializeAws_restJson1GetEmailChannelCommand = async (
     $metadata: deserializeMetadata(output),
     EmailChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailChannelResponse = deserializeAws_restJson1EmailChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9615,7 +9616,7 @@ export const deserializeAws_restJson1GetEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     EmailTemplateResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailTemplateResponse = deserializeAws_restJson1EmailTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9716,7 +9717,7 @@ export const deserializeAws_restJson1GetEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointResponse = deserializeAws_restJson1EndpointResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9817,7 +9818,7 @@ export const deserializeAws_restJson1GetEventStreamCommand = async (
     $metadata: deserializeMetadata(output),
     EventStream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventStream = deserializeAws_restJson1EventStream(data, context);
   return Promise.resolve(contents);
 };
@@ -9918,7 +9919,7 @@ export const deserializeAws_restJson1GetExportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobResponse = deserializeAws_restJson1ExportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10019,7 +10020,7 @@ export const deserializeAws_restJson1GetExportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobsResponse = deserializeAws_restJson1ExportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10120,7 +10121,7 @@ export const deserializeAws_restJson1GetGcmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     GCMChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.GCMChannelResponse = deserializeAws_restJson1GCMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10221,7 +10222,7 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobResponse = deserializeAws_restJson1ImportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10322,7 +10323,7 @@ export const deserializeAws_restJson1GetImportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobsResponse = deserializeAws_restJson1ImportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10423,7 +10424,7 @@ export const deserializeAws_restJson1GetJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10524,7 +10525,7 @@ export const deserializeAws_restJson1GetJourneyDateRangeKpiCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyDateRangeKpiResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyDateRangeKpiResponse = deserializeAws_restJson1JourneyDateRangeKpiResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10625,7 +10626,7 @@ export const deserializeAws_restJson1GetJourneyExecutionActivityMetricsCommand =
     $metadata: deserializeMetadata(output),
     JourneyExecutionActivityMetricsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyExecutionActivityMetricsResponse = deserializeAws_restJson1JourneyExecutionActivityMetricsResponse(
     data,
     context
@@ -10729,7 +10730,7 @@ export const deserializeAws_restJson1GetJourneyExecutionMetricsCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyExecutionMetricsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyExecutionMetricsResponse = deserializeAws_restJson1JourneyExecutionMetricsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10830,7 +10831,7 @@ export const deserializeAws_restJson1GetPushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     PushNotificationTemplateResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PushNotificationTemplateResponse = deserializeAws_restJson1PushNotificationTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10931,7 +10932,7 @@ export const deserializeAws_restJson1GetRecommenderConfigurationCommand = async 
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11032,7 +11033,7 @@ export const deserializeAws_restJson1GetRecommenderConfigurationsCommand = async
     $metadata: deserializeMetadata(output),
     ListRecommenderConfigurationsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ListRecommenderConfigurationsResponse = deserializeAws_restJson1ListRecommenderConfigurationsResponse(
     data,
     context
@@ -11136,7 +11137,7 @@ export const deserializeAws_restJson1GetSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11237,7 +11238,7 @@ export const deserializeAws_restJson1GetSegmentExportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobsResponse = deserializeAws_restJson1ExportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11338,7 +11339,7 @@ export const deserializeAws_restJson1GetSegmentImportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobsResponse = deserializeAws_restJson1ImportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11439,7 +11440,7 @@ export const deserializeAws_restJson1GetSegmentsCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentsResponse = deserializeAws_restJson1SegmentsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11540,7 +11541,7 @@ export const deserializeAws_restJson1GetSegmentVersionCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11641,7 +11642,7 @@ export const deserializeAws_restJson1GetSegmentVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentsResponse = deserializeAws_restJson1SegmentsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11742,7 +11743,7 @@ export const deserializeAws_restJson1GetSmsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     SMSChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSChannelResponse = deserializeAws_restJson1SMSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11843,7 +11844,7 @@ export const deserializeAws_restJson1GetSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     SMSTemplateResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSTemplateResponse = deserializeAws_restJson1SMSTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11944,7 +11945,7 @@ export const deserializeAws_restJson1GetUserEndpointsCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointsResponse = deserializeAws_restJson1EndpointsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12045,7 +12046,7 @@ export const deserializeAws_restJson1GetVoiceChannelCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceChannelResponse = deserializeAws_restJson1VoiceChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12146,7 +12147,7 @@ export const deserializeAws_restJson1GetVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceTemplateResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceTemplateResponse = deserializeAws_restJson1VoiceTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12247,7 +12248,7 @@ export const deserializeAws_restJson1ListJourneysCommand = async (
     $metadata: deserializeMetadata(output),
     JourneysResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneysResponse = deserializeAws_restJson1JourneysResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12348,7 +12349,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     TagsModel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.TagsModel = deserializeAws_restJson1TagsModel(data, context);
   return Promise.resolve(contents);
 };
@@ -12393,7 +12394,7 @@ export const deserializeAws_restJson1ListTemplatesCommand = async (
     $metadata: deserializeMetadata(output),
     TemplatesResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.TemplatesResponse = deserializeAws_restJson1TemplatesResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12478,7 +12479,7 @@ export const deserializeAws_restJson1ListTemplateVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     TemplateVersionsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.TemplateVersionsResponse = deserializeAws_restJson1TemplateVersionsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12579,7 +12580,7 @@ export const deserializeAws_restJson1PhoneNumberValidateCommand = async (
     $metadata: deserializeMetadata(output),
     NumberValidateResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.NumberValidateResponse = deserializeAws_restJson1NumberValidateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12680,7 +12681,7 @@ export const deserializeAws_restJson1PutEventsCommand = async (
     $metadata: deserializeMetadata(output),
     EventsResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventsResponse = deserializeAws_restJson1EventsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12781,7 +12782,7 @@ export const deserializeAws_restJson1PutEventStreamCommand = async (
     $metadata: deserializeMetadata(output),
     EventStream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventStream = deserializeAws_restJson1EventStream(data, context);
   return Promise.resolve(contents);
 };
@@ -12882,7 +12883,7 @@ export const deserializeAws_restJson1RemoveAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     AttributesResource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.AttributesResource = deserializeAws_restJson1AttributesResource(data, context);
   return Promise.resolve(contents);
 };
@@ -12983,7 +12984,7 @@ export const deserializeAws_restJson1SendMessagesCommand = async (
     $metadata: deserializeMetadata(output),
     MessageResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageResponse = deserializeAws_restJson1MessageResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13084,7 +13085,7 @@ export const deserializeAws_restJson1SendUsersMessagesCommand = async (
     $metadata: deserializeMetadata(output),
     SendUsersMessageResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SendUsersMessageResponse = deserializeAws_restJson1SendUsersMessageResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13271,7 +13272,7 @@ export const deserializeAws_restJson1UpdateAdmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ADMChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ADMChannelResponse = deserializeAws_restJson1ADMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13372,7 +13373,7 @@ export const deserializeAws_restJson1UpdateApnsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSChannelResponse = deserializeAws_restJson1APNSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13473,7 +13474,7 @@ export const deserializeAws_restJson1UpdateApnsSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSSandboxChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSSandboxChannelResponse = deserializeAws_restJson1APNSSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13574,7 +13575,7 @@ export const deserializeAws_restJson1UpdateApnsVoipChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipChannelResponse = deserializeAws_restJson1APNSVoipChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13675,7 +13676,7 @@ export const deserializeAws_restJson1UpdateApnsVoipSandboxChannelCommand = async
     $metadata: deserializeMetadata(output),
     APNSVoipSandboxChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipSandboxChannelResponse = deserializeAws_restJson1APNSVoipSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13776,7 +13777,7 @@ export const deserializeAws_restJson1UpdateApplicationSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationSettingsResource: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationSettingsResource = deserializeAws_restJson1ApplicationSettingsResource(data, context);
   return Promise.resolve(contents);
 };
@@ -13877,7 +13878,7 @@ export const deserializeAws_restJson1UpdateBaiduChannelCommand = async (
     $metadata: deserializeMetadata(output),
     BaiduChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.BaiduChannelResponse = deserializeAws_restJson1BaiduChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13978,7 +13979,7 @@ export const deserializeAws_restJson1UpdateCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14079,7 +14080,7 @@ export const deserializeAws_restJson1UpdateEmailChannelCommand = async (
     $metadata: deserializeMetadata(output),
     EmailChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailChannelResponse = deserializeAws_restJson1EmailChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14180,7 +14181,7 @@ export const deserializeAws_restJson1UpdateEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14281,7 +14282,7 @@ export const deserializeAws_restJson1UpdateEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14382,7 +14383,7 @@ export const deserializeAws_restJson1UpdateEndpointsBatchCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14483,7 +14484,7 @@ export const deserializeAws_restJson1UpdateGcmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     GCMChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.GCMChannelResponse = deserializeAws_restJson1GCMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14584,7 +14585,7 @@ export const deserializeAws_restJson1UpdateJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14693,7 +14694,7 @@ export const deserializeAws_restJson1UpdateJourneyStateCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14794,7 +14795,7 @@ export const deserializeAws_restJson1UpdatePushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14895,7 +14896,7 @@ export const deserializeAws_restJson1UpdateRecommenderConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14996,7 +14997,7 @@ export const deserializeAws_restJson1UpdateSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -15097,7 +15098,7 @@ export const deserializeAws_restJson1UpdateSmsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     SMSChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSChannelResponse = deserializeAws_restJson1SMSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -15198,7 +15199,7 @@ export const deserializeAws_restJson1UpdateSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -15299,7 +15300,7 @@ export const deserializeAws_restJson1UpdateTemplateActiveVersionCommand = async 
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -15400,7 +15401,7 @@ export const deserializeAws_restJson1UpdateVoiceChannelCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceChannelResponse: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceChannelResponse = deserializeAws_restJson1VoiceChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -15501,7 +15502,7 @@ export const deserializeAws_restJson1UpdateVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-polly/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1.ts
@@ -50,6 +50,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   strictParseInt32 as __strictParseInt32,
@@ -408,7 +410,7 @@ export const deserializeAws_restJson1DescribeVoicesCommand = async (
     NextToken: undefined,
     Voices: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -475,7 +477,7 @@ export const deserializeAws_restJson1GetLexiconCommand = async (
     Lexicon: undefined,
     LexiconAttributes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Lexicon !== undefined && data.Lexicon !== null) {
     contents.Lexicon = deserializeAws_restJson1Lexicon(data.Lexicon, context);
   }
@@ -541,7 +543,7 @@ export const deserializeAws_restJson1GetSpeechSynthesisTaskCommand = async (
     $metadata: deserializeMetadata(output),
     SynthesisTask: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SynthesisTask !== undefined && data.SynthesisTask !== null) {
     contents.SynthesisTask = deserializeAws_restJson1SynthesisTask(data.SynthesisTask, context);
   }
@@ -613,7 +615,7 @@ export const deserializeAws_restJson1ListLexiconsCommand = async (
     Lexicons: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Lexicons !== undefined && data.Lexicons !== null) {
     contents.Lexicons = deserializeAws_restJson1LexiconDescriptionList(data.Lexicons, context);
   }
@@ -680,7 +682,7 @@ export const deserializeAws_restJson1ListSpeechSynthesisTasksCommand = async (
     NextToken: undefined,
     SynthesisTasks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -845,7 +847,7 @@ export const deserializeAws_restJson1StartSpeechSynthesisTaskCommand = async (
     $metadata: deserializeMetadata(output),
     SynthesisTask: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SynthesisTask !== undefined && data.SynthesisTask !== null) {
     contents.SynthesisTask = deserializeAws_restJson1SynthesisTask(data.SynthesisTask, context);
   }

--- a/clients/client-qldb/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1.ts
@@ -64,6 +64,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -765,7 +767,7 @@ export const deserializeAws_restJson1CancelJournalKinesisStreamCommand = async (
     $metadata: deserializeMetadata(output),
     StreamId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamId !== undefined && data.StreamId !== null) {
     contents.StreamId = __expectString(data.StreamId);
   }
@@ -842,7 +844,7 @@ export const deserializeAws_restJson1CreateLedgerCommand = async (
     PermissionsMode: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1014,7 +1016,7 @@ export const deserializeAws_restJson1DescribeJournalKinesisStreamCommand = async
     $metadata: deserializeMetadata(output),
     Stream: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Stream !== undefined && data.Stream !== null) {
     contents.Stream = deserializeAws_restJson1JournalKinesisStreamDescription(data.Stream, context);
   }
@@ -1085,7 +1087,7 @@ export const deserializeAws_restJson1DescribeJournalS3ExportCommand = async (
     $metadata: deserializeMetadata(output),
     ExportDescription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExportDescription !== undefined && data.ExportDescription !== null) {
     contents.ExportDescription = deserializeAws_restJson1JournalS3ExportDescription(data.ExportDescription, context);
   }
@@ -1146,7 +1148,7 @@ export const deserializeAws_restJson1DescribeLedgerCommand = async (
     PermissionsMode: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1230,7 +1232,7 @@ export const deserializeAws_restJson1ExportJournalToS3Command = async (
     $metadata: deserializeMetadata(output),
     ExportId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExportId !== undefined && data.ExportId !== null) {
     contents.ExportId = __expectString(data.ExportId);
   }
@@ -1294,7 +1296,7 @@ export const deserializeAws_restJson1GetBlockCommand = async (
     Block: undefined,
     Proof: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Block !== undefined && data.Block !== null) {
     contents.Block = deserializeAws_restJson1ValueHolder(data.Block, context);
   }
@@ -1369,7 +1371,7 @@ export const deserializeAws_restJson1GetDigestCommand = async (
     Digest: undefined,
     DigestTipAddress: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Digest !== undefined && data.Digest !== null) {
     contents.Digest = context.base64Decoder(data.Digest);
   }
@@ -1444,7 +1446,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     Proof: undefined,
     Revision: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proof !== undefined && data.Proof !== null) {
     contents.Proof = deserializeAws_restJson1ValueHolder(data.Proof, context);
   }
@@ -1519,7 +1521,7 @@ export const deserializeAws_restJson1ListJournalKinesisStreamsForLedgerCommand =
     NextToken: undefined,
     Streams: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1594,7 +1596,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsCommand = async (
     JournalS3Exports: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JournalS3Exports !== undefined && data.JournalS3Exports !== null) {
     contents.JournalS3Exports = deserializeAws_restJson1JournalS3ExportList(data.JournalS3Exports, context);
   }
@@ -1645,7 +1647,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsForLedgerCommand = asyn
     JournalS3Exports: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JournalS3Exports !== undefined && data.JournalS3Exports !== null) {
     contents.JournalS3Exports = deserializeAws_restJson1JournalS3ExportList(data.JournalS3Exports, context);
   }
@@ -1696,7 +1698,7 @@ export const deserializeAws_restJson1ListLedgersCommand = async (
     Ledgers: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Ledgers !== undefined && data.Ledgers !== null) {
     contents.Ledgers = deserializeAws_restJson1LedgerList(data.Ledgers, context);
   }
@@ -1746,7 +1748,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -1809,7 +1811,7 @@ export const deserializeAws_restJson1StreamJournalToKinesisCommand = async (
     $metadata: deserializeMetadata(output),
     StreamId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamId !== undefined && data.StreamId !== null) {
     contents.StreamId = __expectString(data.StreamId);
   }
@@ -2003,7 +2005,7 @@ export const deserializeAws_restJson1UpdateLedgerCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2086,7 +2088,7 @@ export const deserializeAws_restJson1UpdateLedgerPermissionsModeCommand = async 
     Name: undefined,
     PermissionsMode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-quicksight/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1.ts
@@ -412,6 +412,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   serializeFloat as __serializeFloat,
@@ -5642,7 +5644,7 @@ export const deserializeAws_restJson1CancelIngestionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5751,7 +5753,7 @@ export const deserializeAws_restJson1CreateAccountCustomizationCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountCustomization !== undefined && data.AccountCustomization !== null) {
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
@@ -5873,7 +5875,7 @@ export const deserializeAws_restJson1CreateAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -5993,7 +5995,7 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
     Status: undefined,
     VersionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6116,7 +6118,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6254,7 +6256,7 @@ export const deserializeAws_restJson1CreateDataSourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6380,7 +6382,7 @@ export const deserializeAws_restJson1CreateFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6510,7 +6512,7 @@ export const deserializeAws_restJson1CreateFolderMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderMember !== undefined && data.FolderMember !== null) {
     contents.FolderMember = deserializeAws_restJson1FolderMember(data.FolderMember, context);
   }
@@ -6629,7 +6631,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -6756,7 +6758,7 @@ export const deserializeAws_restJson1CreateGroupMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupMember !== undefined && data.GroupMember !== null) {
     contents.GroupMember = deserializeAws_restJson1GroupMember(data.GroupMember, context);
   }
@@ -6871,7 +6873,7 @@ export const deserializeAws_restJson1CreateIAMPolicyAssignmentCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssignmentId !== undefined && data.AssignmentId !== null) {
     contents.AssignmentId = __expectString(data.AssignmentId);
   }
@@ -6996,7 +6998,7 @@ export const deserializeAws_restJson1CreateIngestionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7117,7 +7119,7 @@ export const deserializeAws_restJson1CreateNamespaceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7267,7 +7269,7 @@ export const deserializeAws_restJson1CreateTemplateCommand = async (
     TemplateId: undefined,
     VersionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7403,7 +7405,7 @@ export const deserializeAws_restJson1CreateTemplateAliasCommand = async (
     Status: undefined,
     TemplateAlias: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7517,7 +7519,7 @@ export const deserializeAws_restJson1CreateThemeCommand = async (
     ThemeId: undefined,
     VersionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7645,7 +7647,7 @@ export const deserializeAws_restJson1CreateThemeAliasCommand = async (
     Status: undefined,
     ThemeAlias: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7763,7 +7765,7 @@ export const deserializeAws_restJson1DeleteAccountCustomizationCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7865,7 +7867,7 @@ export const deserializeAws_restJson1DeleteAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -7975,7 +7977,7 @@ export const deserializeAws_restJson1DeleteDashboardCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -8082,7 +8084,7 @@ export const deserializeAws_restJson1DeleteDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -8181,7 +8183,7 @@ export const deserializeAws_restJson1DeleteDataSourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -8280,7 +8282,7 @@ export const deserializeAws_restJson1DeleteFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -8401,7 +8403,7 @@ export const deserializeAws_restJson1DeleteFolderMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -8500,7 +8502,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -8607,7 +8609,7 @@ export const deserializeAws_restJson1DeleteGroupMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -8715,7 +8717,7 @@ export const deserializeAws_restJson1DeleteIAMPolicyAssignmentCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssignmentName !== undefined && data.AssignmentName !== null) {
     contents.AssignmentName = __expectString(data.AssignmentName);
   }
@@ -8825,7 +8827,7 @@ export const deserializeAws_restJson1DeleteNamespaceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -8934,7 +8936,7 @@ export const deserializeAws_restJson1DeleteTemplateCommand = async (
     Status: undefined,
     TemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -9050,7 +9052,7 @@ export const deserializeAws_restJson1DeleteTemplateAliasCommand = async (
     Status: undefined,
     TemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasName !== undefined && data.AliasName !== null) {
     contents.AliasName = __expectString(data.AliasName);
   }
@@ -9152,7 +9154,7 @@ export const deserializeAws_restJson1DeleteThemeCommand = async (
     Status: undefined,
     ThemeId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -9268,7 +9270,7 @@ export const deserializeAws_restJson1DeleteThemeAliasCommand = async (
     Status: undefined,
     ThemeId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasName !== undefined && data.AliasName !== null) {
     contents.AliasName = __expectString(data.AliasName);
   }
@@ -9376,7 +9378,7 @@ export const deserializeAws_restJson1DeleteUserCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -9483,7 +9485,7 @@ export const deserializeAws_restJson1DeleteUserByPrincipalIdCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -9594,7 +9596,7 @@ export const deserializeAws_restJson1DescribeAccountCustomizationCommand = async
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountCustomization !== undefined && data.AccountCustomization !== null) {
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
@@ -9706,7 +9708,7 @@ export const deserializeAws_restJson1DescribeAccountSettingsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountSettings !== undefined && data.AccountSettings !== null) {
     contents.AccountSettings = deserializeAws_restJson1AccountSettings(data.AccountSettings, context);
   }
@@ -9809,7 +9811,7 @@ export const deserializeAws_restJson1DescribeAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Analysis !== undefined && data.Analysis !== null) {
     contents.Analysis = deserializeAws_restJson1Analysis(data.Analysis, context);
   }
@@ -9914,7 +9916,7 @@ export const deserializeAws_restJson1DescribeAnalysisPermissionsCommand = async 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisArn !== undefined && data.AnalysisArn !== null) {
     contents.AnalysisArn = __expectString(data.AnalysisArn);
   }
@@ -10015,7 +10017,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Dashboard !== undefined && data.Dashboard !== null) {
     contents.Dashboard = deserializeAws_restJson1Dashboard(data.Dashboard, context);
   }
@@ -10120,7 +10122,7 @@ export const deserializeAws_restJson1DescribeDashboardPermissionsCommand = async
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
     contents.DashboardArn = __expectString(data.DashboardArn);
   }
@@ -10221,7 +10223,7 @@ export const deserializeAws_restJson1DescribeDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSet !== undefined && data.DataSet !== null) {
     contents.DataSet = deserializeAws_restJson1DataSet(data.DataSet, context);
   }
@@ -10318,7 +10320,7 @@ export const deserializeAws_restJson1DescribeDataSetPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSetArn !== undefined && data.DataSetArn !== null) {
     contents.DataSetArn = __expectString(data.DataSetArn);
   }
@@ -10419,7 +10421,7 @@ export const deserializeAws_restJson1DescribeDataSourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSource !== undefined && data.DataSource !== null) {
     contents.DataSource = deserializeAws_restJson1DataSource(data.DataSource, context);
   }
@@ -10516,7 +10518,7 @@ export const deserializeAws_restJson1DescribeDataSourcePermissionsCommand = asyn
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSourceArn !== undefined && data.DataSourceArn !== null) {
     contents.DataSourceArn = __expectString(data.DataSourceArn);
   }
@@ -10617,7 +10619,7 @@ export const deserializeAws_restJson1DescribeFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Folder !== undefined && data.Folder !== null) {
     contents.Folder = deserializeAws_restJson1Folder(data.Folder, context);
   }
@@ -10722,7 +10724,7 @@ export const deserializeAws_restJson1DescribeFolderPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -10833,7 +10835,7 @@ export const deserializeAws_restJson1DescribeFolderResolvedPermissionsCommand = 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -10942,7 +10944,7 @@ export const deserializeAws_restJson1DescribeGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -11053,7 +11055,7 @@ export const deserializeAws_restJson1DescribeIAMPolicyAssignmentCommand = async 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IAMPolicyAssignment !== undefined && data.IAMPolicyAssignment !== null) {
     contents.IAMPolicyAssignment = deserializeAws_restJson1IAMPolicyAssignment(data.IAMPolicyAssignment, context);
   }
@@ -11156,7 +11158,7 @@ export const deserializeAws_restJson1DescribeIngestionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Ingestion !== undefined && data.Ingestion !== null) {
     contents.Ingestion = deserializeAws_restJson1Ingestion(data.Ingestion, context);
   }
@@ -11259,7 +11261,7 @@ export const deserializeAws_restJson1DescribeNamespaceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Namespace !== undefined && data.Namespace !== null) {
     contents.Namespace = deserializeAws_restJson1NamespaceInfoV2(data.Namespace, context);
   }
@@ -11362,7 +11364,7 @@ export const deserializeAws_restJson1DescribeTemplateCommand = async (
     Status: undefined,
     Template: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -11481,7 +11483,7 @@ export const deserializeAws_restJson1DescribeTemplateAliasCommand = async (
     Status: undefined,
     TemplateAlias: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -11570,7 +11572,7 @@ export const deserializeAws_restJson1DescribeTemplatePermissionsCommand = async 
     TemplateArn: undefined,
     TemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -11679,7 +11681,7 @@ export const deserializeAws_restJson1DescribeThemeCommand = async (
     Status: undefined,
     Theme: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -11790,7 +11792,7 @@ export const deserializeAws_restJson1DescribeThemeAliasCommand = async (
     Status: undefined,
     ThemeAlias: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -11895,7 +11897,7 @@ export const deserializeAws_restJson1DescribeThemePermissionsCommand = async (
     ThemeArn: undefined,
     ThemeId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -12004,7 +12006,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
     Status: undefined,
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -12115,7 +12117,7 @@ export const deserializeAws_restJson1GenerateEmbedUrlForAnonymousUserCommand = a
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -12234,7 +12236,7 @@ export const deserializeAws_restJson1GenerateEmbedUrlForRegisteredUserCommand = 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -12361,7 +12363,7 @@ export const deserializeAws_restJson1GetDashboardEmbedUrlCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -12512,7 +12514,7 @@ export const deserializeAws_restJson1GetSessionEmbedUrlCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -12640,7 +12642,7 @@ export const deserializeAws_restJson1ListAnalysesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisSummaryList !== undefined && data.AnalysisSummaryList !== null) {
     contents.AnalysisSummaryList = deserializeAws_restJson1AnalysisSummaryList(data.AnalysisSummaryList, context);
   }
@@ -12731,7 +12733,7 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardSummaryList !== undefined && data.DashboardSummaryList !== null) {
     contents.DashboardSummaryList = deserializeAws_restJson1DashboardSummaryList(data.DashboardSummaryList, context);
   }
@@ -12822,7 +12824,7 @@ export const deserializeAws_restJson1ListDashboardVersionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardVersionSummaryList !== undefined && data.DashboardVersionSummaryList !== null) {
     contents.DashboardVersionSummaryList = deserializeAws_restJson1DashboardVersionSummaryList(
       data.DashboardVersionSummaryList,
@@ -12932,7 +12934,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSetSummaries !== undefined && data.DataSetSummaries !== null) {
     contents.DataSetSummaries = deserializeAws_restJson1DataSetSummaryList(data.DataSetSummaries, context);
   }
@@ -13031,7 +13033,7 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSources !== undefined && data.DataSources !== null) {
     contents.DataSources = deserializeAws_restJson1DataSourceList(data.DataSources, context);
   }
@@ -13130,7 +13132,7 @@ export const deserializeAws_restJson1ListFolderMembersCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderMemberList !== undefined && data.FolderMemberList !== null) {
     contents.FolderMemberList = deserializeAws_restJson1FolderMemberList(data.FolderMemberList, context);
   }
@@ -13245,7 +13247,7 @@ export const deserializeAws_restJson1ListFoldersCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderSummaryList !== undefined && data.FolderSummaryList !== null) {
     contents.FolderSummaryList = deserializeAws_restJson1FolderSummaryList(data.FolderSummaryList, context);
   }
@@ -13360,7 +13362,7 @@ export const deserializeAws_restJson1ListGroupMembershipsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupMemberList !== undefined && data.GroupMemberList !== null) {
     contents.GroupMemberList = deserializeAws_restJson1GroupMemberList(data.GroupMemberList, context);
   }
@@ -13483,7 +13485,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupList !== undefined && data.GroupList !== null) {
     contents.GroupList = deserializeAws_restJson1GroupList(data.GroupList, context);
   }
@@ -13606,7 +13608,7 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IAMPolicyAssignments !== undefined && data.IAMPolicyAssignments !== null) {
     contents.IAMPolicyAssignments = deserializeAws_restJson1IAMPolicyAssignmentSummaryList(
       data.IAMPolicyAssignments,
@@ -13716,7 +13718,7 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsForUserCommand = as
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActiveAssignments !== undefined && data.ActiveAssignments !== null) {
     contents.ActiveAssignments = deserializeAws_restJson1ActiveIAMPolicyAssignmentList(data.ActiveAssignments, context);
   }
@@ -13831,7 +13833,7 @@ export const deserializeAws_restJson1ListIngestionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Ingestions !== undefined && data.Ingestions !== null) {
     contents.Ingestions = deserializeAws_restJson1Ingestions(data.Ingestions, context);
   }
@@ -13946,7 +13948,7 @@ export const deserializeAws_restJson1ListNamespacesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Namespaces !== undefined && data.Namespaces !== null) {
     contents.Namespaces = deserializeAws_restJson1Namespaces(data.Namespaces, context);
   }
@@ -14068,7 +14070,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -14164,7 +14166,7 @@ export const deserializeAws_restJson1ListTemplateAliasesCommand = async (
     Status: undefined,
     TemplateAliasList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -14263,7 +14265,7 @@ export const deserializeAws_restJson1ListTemplatesCommand = async (
     Status: undefined,
     TemplateSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -14370,7 +14372,7 @@ export const deserializeAws_restJson1ListTemplateVersionsCommand = async (
     Status: undefined,
     TemplateVersionSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -14480,7 +14482,7 @@ export const deserializeAws_restJson1ListThemeAliasesCommand = async (
     Status: undefined,
     ThemeAliasList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -14595,7 +14597,7 @@ export const deserializeAws_restJson1ListThemesCommand = async (
     Status: undefined,
     ThemeSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -14710,7 +14712,7 @@ export const deserializeAws_restJson1ListThemeVersionsCommand = async (
     Status: undefined,
     ThemeVersionSummaryList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -14828,7 +14830,7 @@ export const deserializeAws_restJson1ListUserGroupsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupList !== undefined && data.GroupList !== null) {
     contents.GroupList = deserializeAws_restJson1GroupList(data.GroupList, context);
   }
@@ -14943,7 +14945,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     Status: undefined,
     UserList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -15066,7 +15068,7 @@ export const deserializeAws_restJson1RegisterUserCommand = async (
     User: undefined,
     UserInvitationUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -15197,7 +15199,7 @@ export const deserializeAws_restJson1RestoreAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -15304,7 +15306,7 @@ export const deserializeAws_restJson1SearchAnalysesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisSummaryList !== undefined && data.AnalysisSummaryList !== null) {
     contents.AnalysisSummaryList = deserializeAws_restJson1AnalysisSummaryList(data.AnalysisSummaryList, context);
   }
@@ -15411,7 +15413,7 @@ export const deserializeAws_restJson1SearchDashboardsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardSummaryList !== undefined && data.DashboardSummaryList !== null) {
     contents.DashboardSummaryList = deserializeAws_restJson1DashboardSummaryList(data.DashboardSummaryList, context);
   }
@@ -15518,7 +15520,7 @@ export const deserializeAws_restJson1SearchFoldersCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderSummaryList !== undefined && data.FolderSummaryList !== null) {
     contents.FolderSummaryList = deserializeAws_restJson1FolderSummaryList(data.FolderSummaryList, context);
   }
@@ -15631,7 +15633,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -15730,7 +15732,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -15825,7 +15827,7 @@ export const deserializeAws_restJson1UpdateAccountCustomizationCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountCustomization !== undefined && data.AccountCustomization !== null) {
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
@@ -15936,7 +15938,7 @@ export const deserializeAws_restJson1UpdateAccountSettingsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -16038,7 +16040,7 @@ export const deserializeAws_restJson1UpdateAnalysisCommand = async (
     Status: undefined,
     UpdateStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -16157,7 +16159,7 @@ export const deserializeAws_restJson1UpdateAnalysisPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisArn !== undefined && data.AnalysisArn !== null) {
     contents.AnalysisArn = __expectString(data.AnalysisArn);
   }
@@ -16269,7 +16271,7 @@ export const deserializeAws_restJson1UpdateDashboardCommand = async (
     Status: undefined,
     VersionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -16391,7 +16393,7 @@ export const deserializeAws_restJson1UpdateDashboardPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
     contents.DashboardArn = __expectString(data.DashboardArn);
   }
@@ -16501,7 +16503,7 @@ export const deserializeAws_restJson1UpdateDashboardPublishedVersionCommand = as
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
     contents.DashboardArn = __expectString(data.DashboardArn);
   }
@@ -16610,7 +16612,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -16739,7 +16741,7 @@ export const deserializeAws_restJson1UpdateDataSetPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSetArn !== undefined && data.DataSetArn !== null) {
     contents.DataSetArn = __expectString(data.DataSetArn);
   }
@@ -16847,7 +16849,7 @@ export const deserializeAws_restJson1UpdateDataSourceCommand = async (
     Status: undefined,
     UpdateStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -16957,7 +16959,7 @@ export const deserializeAws_restJson1UpdateDataSourcePermissionsCommand = async 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSourceArn !== undefined && data.DataSourceArn !== null) {
     contents.DataSourceArn = __expectString(data.DataSourceArn);
   }
@@ -17064,7 +17066,7 @@ export const deserializeAws_restJson1UpdateFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -17188,7 +17190,7 @@ export const deserializeAws_restJson1UpdateFolderPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -17305,7 +17307,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -17420,7 +17422,7 @@ export const deserializeAws_restJson1UpdateIAMPolicyAssignmentCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssignmentId !== undefined && data.AssignmentId !== null) {
     contents.AssignmentId = __expectString(data.AssignmentId);
   }
@@ -17546,7 +17548,7 @@ export const deserializeAws_restJson1UpdateTemplateCommand = async (
     TemplateId: undefined,
     VersionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -17674,7 +17676,7 @@ export const deserializeAws_restJson1UpdateTemplateAliasCommand = async (
     Status: undefined,
     TemplateAlias: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -17771,7 +17773,7 @@ export const deserializeAws_restJson1UpdateTemplatePermissionsCommand = async (
     TemplateArn: undefined,
     TemplateId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -17883,7 +17885,7 @@ export const deserializeAws_restJson1UpdateThemeCommand = async (
     ThemeId: undefined,
     VersionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -18011,7 +18013,7 @@ export const deserializeAws_restJson1UpdateThemeAliasCommand = async (
     Status: undefined,
     ThemeAlias: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -18124,7 +18126,7 @@ export const deserializeAws_restJson1UpdateThemePermissionsCommand = async (
     ThemeArn: undefined,
     ThemeId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -18233,7 +18235,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
     Status: undefined,
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }

--- a/clients/client-ram/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1.ts
@@ -106,6 +106,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -850,7 +852,7 @@ export const deserializeAws_restJson1AcceptResourceShareInvitationCommand = asyn
     clientToken: undefined,
     resourceShareInvitation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -990,7 +992,7 @@ export const deserializeAws_restJson1AssociateResourceShareCommand = async (
     clientToken: undefined,
     resourceShareAssociations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1124,7 +1126,7 @@ export const deserializeAws_restJson1AssociateResourceSharePermissionCommand = a
     clientToken: undefined,
     returnValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1231,7 +1233,7 @@ export const deserializeAws_restJson1CreateResourceShareCommand = async (
     clientToken: undefined,
     resourceShare: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1370,7 +1372,7 @@ export const deserializeAws_restJson1DeleteResourceShareCommand = async (
     clientToken: undefined,
     returnValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1493,7 +1495,7 @@ export const deserializeAws_restJson1DisassociateResourceShareCommand = async (
     clientToken: undefined,
     resourceShareAssociations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1627,7 +1629,7 @@ export const deserializeAws_restJson1DisassociateResourceSharePermissionCommand 
     clientToken: undefined,
     returnValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1741,7 +1743,7 @@ export const deserializeAws_restJson1EnableSharingWithAwsOrganizationCommand = a
     $metadata: deserializeMetadata(output),
     returnValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.returnValue !== undefined && data.returnValue !== null) {
     contents.returnValue = __expectBoolean(data.returnValue);
   }
@@ -1812,7 +1814,7 @@ export const deserializeAws_restJson1GetPermissionCommand = async (
     $metadata: deserializeMetadata(output),
     permission: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.permission !== undefined && data.permission !== null) {
     contents.permission = deserializeAws_restJson1ResourceSharePermissionDetail(data.permission, context);
   }
@@ -1908,7 +1910,7 @@ export const deserializeAws_restJson1GetResourcePoliciesCommand = async (
     nextToken: undefined,
     policies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2007,7 +2009,7 @@ export const deserializeAws_restJson1GetResourceShareAssociationsCommand = async
     nextToken: undefined,
     resourceShareAssociations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2117,7 +2119,7 @@ export const deserializeAws_restJson1GetResourceShareInvitationsCommand = async 
     nextToken: undefined,
     resourceShareInvitations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2235,7 +2237,7 @@ export const deserializeAws_restJson1GetResourceSharesCommand = async (
     nextToken: undefined,
     resourceShares: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2334,7 +2336,7 @@ export const deserializeAws_restJson1ListPendingInvitationResourcesCommand = asy
     nextToken: undefined,
     resources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2460,7 +2462,7 @@ export const deserializeAws_restJson1ListPermissionsCommand = async (
     nextToken: undefined,
     permissions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2551,7 +2553,7 @@ export const deserializeAws_restJson1ListPrincipalsCommand = async (
     nextToken: undefined,
     principals: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2650,7 +2652,7 @@ export const deserializeAws_restJson1ListResourcesCommand = async (
     nextToken: undefined,
     resources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2757,7 +2759,7 @@ export const deserializeAws_restJson1ListResourceSharePermissionsCommand = async
     nextToken: undefined,
     permissions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2864,7 +2866,7 @@ export const deserializeAws_restJson1ListResourceTypesCommand = async (
     nextToken: undefined,
     resourceTypes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2946,7 +2948,7 @@ export const deserializeAws_restJson1PromoteResourceShareCreatedFromPolicyComman
     $metadata: deserializeMetadata(output),
     returnValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.returnValue !== undefined && data.returnValue !== null) {
     contents.returnValue = __expectBoolean(data.returnValue);
   }
@@ -3058,7 +3060,7 @@ export const deserializeAws_restJson1RejectResourceShareInvitationCommand = asyn
     clientToken: undefined,
     resourceShareInvitation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -3372,7 +3374,7 @@ export const deserializeAws_restJson1UpdateResourceShareCommand = async (
     clientToken: undefined,
     resourceShare: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }

--- a/clients/client-rds-data/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1.ts
@@ -35,6 +35,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
@@ -240,7 +242,7 @@ export const deserializeAws_restJson1BatchExecuteStatementCommand = async (
     $metadata: deserializeMetadata(output),
     updateResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.updateResults !== undefined && data.updateResults !== null) {
     contents.updateResults = deserializeAws_restJson1UpdateResults(data.updateResults, context);
   }
@@ -327,7 +329,7 @@ export const deserializeAws_restJson1BeginTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     transactionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transactionId !== undefined && data.transactionId !== null) {
     contents.transactionId = __expectString(data.transactionId);
   }
@@ -414,7 +416,7 @@ export const deserializeAws_restJson1CommitTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     transactionStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transactionStatus !== undefined && data.transactionStatus !== null) {
     contents.transactionStatus = __expectString(data.transactionStatus);
   }
@@ -509,7 +511,7 @@ export const deserializeAws_restJson1ExecuteSqlCommand = async (
     $metadata: deserializeMetadata(output),
     sqlStatementResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.sqlStatementResults !== undefined && data.sqlStatementResults !== null) {
     contents.sqlStatementResults = deserializeAws_restJson1SqlStatementResults(data.sqlStatementResults, context);
   }
@@ -591,7 +593,7 @@ export const deserializeAws_restJson1ExecuteStatementCommand = async (
     numberOfRecordsUpdated: undefined,
     records: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.columnMetadata !== undefined && data.columnMetadata !== null) {
     contents.columnMetadata = deserializeAws_restJson1Metadata(data.columnMetadata, context);
   }
@@ -687,7 +689,7 @@ export const deserializeAws_restJson1RollbackTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     transactionStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transactionStatus !== undefined && data.transactionStatus !== null) {
     contents.transactionStatus = __expectString(data.transactionStatus);
   }

--- a/clients/client-resource-groups/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1.ts
@@ -46,6 +46,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -526,7 +528,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     ResourceQuery: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -622,7 +624,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -717,7 +719,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -812,7 +814,7 @@ export const deserializeAws_restJson1GetGroupConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     GroupConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupConfiguration !== undefined && data.GroupConfiguration !== null) {
     contents.GroupConfiguration = deserializeAws_restJson1GroupConfiguration(data.GroupConfiguration, context);
   }
@@ -907,7 +909,7 @@ export const deserializeAws_restJson1GetGroupQueryCommand = async (
     $metadata: deserializeMetadata(output),
     GroupQuery: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupQuery !== undefined && data.GroupQuery !== null) {
     contents.GroupQuery = deserializeAws_restJson1GroupQuery(data.GroupQuery, context);
   }
@@ -1003,7 +1005,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
     Arn: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1103,7 +1105,7 @@ export const deserializeAws_restJson1GroupResourcesCommand = async (
     Pending: undefined,
     Succeeded: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failed !== undefined && data.Failed !== null) {
     contents.Failed = deserializeAws_restJson1FailedResourceList(data.Failed, context);
   }
@@ -1207,7 +1209,7 @@ export const deserializeAws_restJson1ListGroupResourcesCommand = async (
     ResourceIdentifiers: undefined,
     Resources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1321,7 +1323,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     Groups: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupIdentifiers !== undefined && data.GroupIdentifiers !== null) {
     contents.GroupIdentifiers = deserializeAws_restJson1GroupIdentifierList(data.GroupIdentifiers, context);
   }
@@ -1507,7 +1509,7 @@ export const deserializeAws_restJson1SearchResourcesCommand = async (
     QueryErrors: undefined,
     ResourceIdentifiers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1609,7 +1611,7 @@ export const deserializeAws_restJson1TagCommand = async (
     Arn: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1709,7 +1711,7 @@ export const deserializeAws_restJson1UngroupResourcesCommand = async (
     Pending: undefined,
     Succeeded: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failed !== undefined && data.Failed !== null) {
     contents.Failed = deserializeAws_restJson1FailedResourceList(data.Failed, context);
   }
@@ -1811,7 +1813,7 @@ export const deserializeAws_restJson1UntagCommand = async (
     Arn: undefined,
     Keys: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1909,7 +1911,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -2004,7 +2006,7 @@ export const deserializeAws_restJson1UpdateGroupQueryCommand = async (
     $metadata: deserializeMetadata(output),
     GroupQuery: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupQuery !== undefined && data.GroupQuery !== null) {
     contents.GroupQuery = deserializeAws_restJson1GroupQuery(data.GroupQuery, context);
   }

--- a/clients/client-robomaker/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1.ts
@@ -235,6 +235,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
@@ -1850,7 +1852,7 @@ export const deserializeAws_restJson1BatchDeleteWorldsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedWorlds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedWorlds !== undefined && data.unprocessedWorlds !== null) {
     contents.unprocessedWorlds = deserializeAws_restJson1Arns(data.unprocessedWorlds, context);
   }
@@ -1922,7 +1924,7 @@ export const deserializeAws_restJson1BatchDescribeSimulationJobCommand = async (
     jobs: undefined,
     unprocessedJobs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1SimulationJobs(data.jobs, context);
   }
@@ -2387,7 +2389,7 @@ export const deserializeAws_restJson1CreateDeploymentJobCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2520,7 +2522,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2613,7 +2615,7 @@ export const deserializeAws_restJson1CreateRobotCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.architecture !== undefined && data.architecture !== null) {
     contents.architecture = __expectString(data.architecture);
   }
@@ -2722,7 +2724,7 @@ export const deserializeAws_restJson1CreateRobotApplicationCommand = async (
     tags: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2844,7 +2846,7 @@ export const deserializeAws_restJson1CreateRobotApplicationVersionCommand = asyn
     sources: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2958,7 +2960,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationCommand = async 
     tags: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3091,7 +3093,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationVersionCommand =
     sources: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3222,7 +3224,7 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
     tags: undefined,
     vpcConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3386,7 +3388,7 @@ export const deserializeAws_restJson1CreateWorldExportJobCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3510,7 +3512,7 @@ export const deserializeAws_restJson1CreateWorldGenerationJobCommand = async (
     worldCount: undefined,
     worldTags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3641,7 +3643,7 @@ export const deserializeAws_restJson1CreateWorldTemplateCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4092,7 +4094,7 @@ export const deserializeAws_restJson1DeregisterRobotCommand = async (
     fleet: undefined,
     robot: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fleet !== undefined && data.fleet !== null) {
     contents.fleet = __expectString(data.fleet);
   }
@@ -4183,7 +4185,7 @@ export const deserializeAws_restJson1DescribeDeploymentJobCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4302,7 +4304,7 @@ export const deserializeAws_restJson1DescribeFleetCommand = async (
     robots: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4411,7 +4413,7 @@ export const deserializeAws_restJson1DescribeRobotCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.architecture !== undefined && data.architecture !== null) {
     contents.architecture = __expectString(data.architecture);
   }
@@ -4524,7 +4526,7 @@ export const deserializeAws_restJson1DescribeRobotApplicationCommand = async (
     tags: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4633,7 +4635,7 @@ export const deserializeAws_restJson1DescribeSimulationApplicationCommand = asyn
     tags: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4762,7 +4764,7 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
     tags: undefined,
     vpcConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4915,7 +4917,7 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5024,7 +5026,7 @@ export const deserializeAws_restJson1DescribeWorldCommand = async (
     template: undefined,
     worldDescriptionBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5127,7 +5129,7 @@ export const deserializeAws_restJson1DescribeWorldExportJobCommand = async (
     tags: undefined,
     worlds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5243,7 +5245,7 @@ export const deserializeAws_restJson1DescribeWorldGenerationJobCommand = async (
     worldCount: undefined,
     worldTags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5358,7 +5360,7 @@ export const deserializeAws_restJson1DescribeWorldTemplateCommand = async (
     tags: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5455,7 +5457,7 @@ export const deserializeAws_restJson1GetWorldTemplateBodyCommand = async (
     $metadata: deserializeMetadata(output),
     templateBody: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.templateBody !== undefined && data.templateBody !== null) {
     contents.templateBody = __expectString(data.templateBody);
   }
@@ -5535,7 +5537,7 @@ export const deserializeAws_restJson1ListDeploymentJobsCommand = async (
     deploymentJobs: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deploymentJobs !== undefined && data.deploymentJobs !== null) {
     contents.deploymentJobs = deserializeAws_restJson1DeploymentJobs(data.deploymentJobs, context);
   }
@@ -5618,7 +5620,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
     fleetDetails: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fleetDetails !== undefined && data.fleetDetails !== null) {
     contents.fleetDetails = deserializeAws_restJson1Fleets(data.fleetDetails, context);
   }
@@ -5701,7 +5703,7 @@ export const deserializeAws_restJson1ListRobotApplicationsCommand = async (
     nextToken: undefined,
     robotApplicationSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5779,7 +5781,7 @@ export const deserializeAws_restJson1ListRobotsCommand = async (
     nextToken: undefined,
     robots: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5862,7 +5864,7 @@ export const deserializeAws_restJson1ListSimulationApplicationsCommand = async (
     nextToken: undefined,
     simulationApplicationSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5940,7 +5942,7 @@ export const deserializeAws_restJson1ListSimulationJobBatchesCommand = async (
     nextToken: undefined,
     simulationJobBatchSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6010,7 +6012,7 @@ export const deserializeAws_restJson1ListSimulationJobsCommand = async (
     nextToken: undefined,
     simulationJobSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6087,7 +6089,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -6167,7 +6169,7 @@ export const deserializeAws_restJson1ListWorldExportJobsCommand = async (
     nextToken: undefined,
     worldExportJobSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6245,7 +6247,7 @@ export const deserializeAws_restJson1ListWorldGenerationJobsCommand = async (
     nextToken: undefined,
     worldGenerationJobSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6323,7 +6325,7 @@ export const deserializeAws_restJson1ListWorldsCommand = async (
     nextToken: undefined,
     worldSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6398,7 +6400,7 @@ export const deserializeAws_restJson1ListWorldTemplatesCommand = async (
     nextToken: undefined,
     templateSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6473,7 +6475,7 @@ export const deserializeAws_restJson1RegisterRobotCommand = async (
     fleet: undefined,
     robot: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fleet !== undefined && data.fleet !== null) {
     contents.fleet = __expectString(data.fleet);
   }
@@ -6656,7 +6658,7 @@ export const deserializeAws_restJson1StartSimulationJobBatchCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -6780,7 +6782,7 @@ export const deserializeAws_restJson1SyncDeploymentJobCommand = async (
     fleet: undefined,
     status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -7063,7 +7065,7 @@ export const deserializeAws_restJson1UpdateRobotApplicationCommand = async (
     sources: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -7176,7 +7178,7 @@ export const deserializeAws_restJson1UpdateSimulationApplicationCommand = async 
     sources: undefined,
     version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -7293,7 +7295,7 @@ export const deserializeAws_restJson1UpdateWorldTemplateCommand = async (
     lastUpdatedAt: undefined,
     name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -299,6 +299,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
@@ -2596,7 +2598,7 @@ export const deserializeAws_restXmlActivateKeySigningKeyCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -2691,7 +2693,7 @@ export const deserializeAws_restXmlAssociateVPCWithHostedZoneCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -2802,7 +2804,7 @@ export const deserializeAws_restXmlChangeResourceRecordSetsCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -2976,7 +2978,7 @@ export const deserializeAws_restXmlCreateHealthCheckCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(data["HealthCheck"], context);
   }
@@ -3054,7 +3056,7 @@ export const deserializeAws_restXmlCreateHostedZoneCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -3187,7 +3189,7 @@ export const deserializeAws_restXmlCreateKeySigningKeyCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -3321,7 +3323,7 @@ export const deserializeAws_restXmlCreateQueryLoggingConfigCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(data["QueryLoggingConfig"], context);
   }
@@ -3420,7 +3422,7 @@ export const deserializeAws_restXmlCreateReusableDelegationSetCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(data["DelegationSet"], context);
   }
@@ -3527,7 +3529,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -3610,7 +3612,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyInstanceCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -3704,7 +3706,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyVersionCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -3792,7 +3794,7 @@ export const deserializeAws_restXmlCreateVPCAssociationAuthorizationCommand = as
     HostedZoneId: undefined,
     VPC: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = __expectString(data["HostedZoneId"]);
   }
@@ -3882,7 +3884,7 @@ export const deserializeAws_restXmlDeactivateKeySigningKeyCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4052,7 +4054,7 @@ export const deserializeAws_restXmlDeleteHostedZoneCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4139,7 +4141,7 @@ export const deserializeAws_restXmlDeleteKeySigningKeyCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4601,7 +4603,7 @@ export const deserializeAws_restXmlDisableHostedZoneDNSSECCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4712,7 +4714,7 @@ export const deserializeAws_restXmlDisassociateVPCFromHostedZoneCommand = async 
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4799,7 +4801,7 @@ export const deserializeAws_restXmlEnableHostedZoneDNSSECCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4919,7 +4921,7 @@ export const deserializeAws_restXmlGetAccountLimitCommand = async (
     Count: undefined,
     Limit: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Count"] !== undefined) {
     contents.Count = __strictParseLong(data["Count"]) as number;
   }
@@ -4977,7 +4979,7 @@ export const deserializeAws_restXmlGetChangeCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -5040,7 +5042,7 @@ export const deserializeAws_restXmlGetCheckerIpRangesCommand = async (
     $metadata: deserializeMetadata(output),
     CheckerIpRanges: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CheckerIpRanges === "") {
     contents.CheckerIpRanges = [];
   }
@@ -5094,7 +5096,7 @@ export const deserializeAws_restXmlGetDNSSECCommand = async (
     KeySigningKeys: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KeySigningKeys === "") {
     contents.KeySigningKeys = [];
   }
@@ -5174,7 +5176,7 @@ export const deserializeAws_restXmlGetGeoLocationCommand = async (
     $metadata: deserializeMetadata(output),
     GeoLocationDetails: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["GeoLocationDetails"] !== undefined) {
     contents.GeoLocationDetails = deserializeAws_restXmlGeoLocationDetails(data["GeoLocationDetails"], context);
   }
@@ -5237,7 +5239,7 @@ export const deserializeAws_restXmlGetHealthCheckCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheck: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(data["HealthCheck"], context);
   }
@@ -5308,7 +5310,7 @@ export const deserializeAws_restXmlGetHealthCheckCountCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheckCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheckCount"] !== undefined) {
     contents.HealthCheckCount = __strictParseLong(data["HealthCheckCount"]) as number;
   }
@@ -5355,7 +5357,7 @@ export const deserializeAws_restXmlGetHealthCheckLastFailureReasonCommand = asyn
     $metadata: deserializeMetadata(output),
     HealthCheckObservations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   }
@@ -5427,7 +5429,7 @@ export const deserializeAws_restXmlGetHealthCheckStatusCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheckObservations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   }
@@ -5501,7 +5503,7 @@ export const deserializeAws_restXmlGetHostedZoneCommand = async (
     HostedZone: undefined,
     VPCs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(data["DelegationSet"], context);
   }
@@ -5573,7 +5575,7 @@ export const deserializeAws_restXmlGetHostedZoneCountCommand = async (
     $metadata: deserializeMetadata(output),
     HostedZoneCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneCount"] !== undefined) {
     contents.HostedZoneCount = __strictParseLong(data["HostedZoneCount"]) as number;
   }
@@ -5629,7 +5631,7 @@ export const deserializeAws_restXmlGetHostedZoneLimitCommand = async (
     Count: undefined,
     Limit: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Count"] !== undefined) {
     contents.Count = __strictParseLong(data["Count"]) as number;
   }
@@ -5703,7 +5705,7 @@ export const deserializeAws_restXmlGetQueryLoggingConfigCommand = async (
     $metadata: deserializeMetadata(output),
     QueryLoggingConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(data["QueryLoggingConfig"], context);
   }
@@ -5766,7 +5768,7 @@ export const deserializeAws_restXmlGetReusableDelegationSetCommand = async (
     $metadata: deserializeMetadata(output),
     DelegationSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(data["DelegationSet"], context);
   }
@@ -5838,7 +5840,7 @@ export const deserializeAws_restXmlGetReusableDelegationSetLimitCommand = async 
     Count: undefined,
     Limit: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Count"] !== undefined) {
     contents.Count = __strictParseLong(data["Count"]) as number;
   }
@@ -5904,7 +5906,7 @@ export const deserializeAws_restXmlGetTrafficPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -5967,7 +5969,7 @@ export const deserializeAws_restXmlGetTrafficPolicyInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicyInstance: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -6033,7 +6035,7 @@ export const deserializeAws_restXmlGetTrafficPolicyInstanceCountCommand = async 
     $metadata: deserializeMetadata(output),
     TrafficPolicyInstanceCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstanceCount"] !== undefined) {
     contents.TrafficPolicyInstanceCount = __strictParseInt32(data["TrafficPolicyInstanceCount"]) as number;
   }
@@ -6085,7 +6087,7 @@ export const deserializeAws_restXmlListGeoLocationsCommand = async (
     NextCountryCode: undefined,
     NextSubdivisionCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GeoLocationDetailsList === "") {
     contents.GeoLocationDetailsList = [];
   }
@@ -6168,7 +6170,7 @@ export const deserializeAws_restXmlListHealthChecksCommand = async (
     MaxItems: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthChecks === "") {
     contents.HealthChecks = [];
   }
@@ -6253,7 +6255,7 @@ export const deserializeAws_restXmlListHostedZonesCommand = async (
     MaxItems: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HostedZones === "") {
     contents.HostedZones = [];
   }
@@ -6348,7 +6350,7 @@ export const deserializeAws_restXmlListHostedZonesByNameCommand = async (
     NextDNSName: undefined,
     NextHostedZoneId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DNSName"] !== undefined) {
     contents.DNSName = __expectString(data["DNSName"]);
   }
@@ -6437,7 +6439,7 @@ export const deserializeAws_restXmlListHostedZonesByVPCCommand = async (
     MaxItems: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HostedZoneSummaries === "") {
     contents.HostedZoneSummaries = [];
   }
@@ -6513,7 +6515,7 @@ export const deserializeAws_restXmlListQueryLoggingConfigsCommand = async (
     NextToken: undefined,
     QueryLoggingConfigs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -6598,7 +6600,7 @@ export const deserializeAws_restXmlListResourceRecordSetsCommand = async (
     NextRecordType: undefined,
     ResourceRecordSets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -6686,7 +6688,7 @@ export const deserializeAws_restXmlListReusableDelegationSetsCommand = async (
     MaxItems: undefined,
     NextMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DelegationSets === "") {
     contents.DelegationSets = [];
   }
@@ -6759,7 +6761,7 @@ export const deserializeAws_restXmlListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTagSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ResourceTagSet"] !== undefined) {
     contents.ResourceTagSet = deserializeAws_restXmlResourceTagSet(data["ResourceTagSet"], context);
   }
@@ -6846,7 +6848,7 @@ export const deserializeAws_restXmlListTagsForResourcesCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTagSets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceTagSets === "") {
     contents.ResourceTagSets = [];
   }
@@ -6942,7 +6944,7 @@ export const deserializeAws_restXmlListTrafficPoliciesCommand = async (
     TrafficPolicyIdMarker: undefined,
     TrafficPolicySummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -7020,7 +7022,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesCommand = async (
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneIdMarker"] !== undefined) {
     contents.HostedZoneIdMarker = __expectString(data["HostedZoneIdMarker"]);
   }
@@ -7111,7 +7113,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByHostedZoneCommand
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -7208,7 +7210,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCommand = a
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneIdMarker"] !== undefined) {
     contents.HostedZoneIdMarker = __expectString(data["HostedZoneIdMarker"]);
   }
@@ -7306,7 +7308,7 @@ export const deserializeAws_restXmlListTrafficPolicyVersionsCommand = async (
     TrafficPolicies: undefined,
     TrafficPolicyVersionMarker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -7386,7 +7388,7 @@ export const deserializeAws_restXmlListVPCAssociationAuthorizationsCommand = asy
     NextToken: undefined,
     VPCs: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = __expectString(data["HostedZoneId"]);
   }
@@ -7471,7 +7473,7 @@ export const deserializeAws_restXmlTestDNSAnswerCommand = async (
     RecordType: undefined,
     ResponseCode: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Nameserver"] !== undefined) {
     contents.Nameserver = __expectString(data["Nameserver"]);
   }
@@ -7555,7 +7557,7 @@ export const deserializeAws_restXmlUpdateHealthCheckCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheck: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(data["HealthCheck"], context);
   }
@@ -7626,7 +7628,7 @@ export const deserializeAws_restXmlUpdateHostedZoneCommentCommand = async (
     $metadata: deserializeMetadata(output),
     HostedZone: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZone"] !== undefined) {
     contents.HostedZone = deserializeAws_restXmlHostedZone(data["HostedZone"], context);
   }
@@ -7689,7 +7691,7 @@ export const deserializeAws_restXmlUpdateTrafficPolicyCommentCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -7760,7 +7762,7 @@ export const deserializeAws_restXmlUpdateTrafficPolicyInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicyInstance: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],

--- a/clients/client-route53-recovery-control-config/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-control-config/protocols/Aws_restJson1.ts
@@ -64,6 +64,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -667,7 +669,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
     $metadata: deserializeMetadata(output),
     Cluster: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Cluster !== undefined && data.Cluster !== null) {
     contents.Cluster = deserializeAws_restJson1Cluster(data.Cluster, context);
   }
@@ -770,7 +772,7 @@ export const deserializeAws_restJson1CreateControlPanelCommand = async (
     $metadata: deserializeMetadata(output),
     ControlPanel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanel !== undefined && data.ControlPanel !== null) {
     contents.ControlPanel = deserializeAws_restJson1ControlPanel(data.ControlPanel, context);
   }
@@ -873,7 +875,7 @@ export const deserializeAws_restJson1CreateRoutingControlCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingControl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingControl !== undefined && data.RoutingControl !== null) {
     contents.RoutingControl = deserializeAws_restJson1RoutingControl(data.RoutingControl, context);
   }
@@ -977,7 +979,7 @@ export const deserializeAws_restJson1CreateSafetyRuleCommand = async (
     AssertionRule: undefined,
     GatingRule: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssertionRule !== undefined && data.AssertionRule !== null) {
     contents.AssertionRule = deserializeAws_restJson1AssertionRule(data.AssertionRule, context);
   }
@@ -1383,7 +1385,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
     $metadata: deserializeMetadata(output),
     Cluster: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Cluster !== undefined && data.Cluster !== null) {
     contents.Cluster = deserializeAws_restJson1Cluster(data.Cluster, context);
   }
@@ -1478,7 +1480,7 @@ export const deserializeAws_restJson1DescribeControlPanelCommand = async (
     $metadata: deserializeMetadata(output),
     ControlPanel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanel !== undefined && data.ControlPanel !== null) {
     contents.ControlPanel = deserializeAws_restJson1ControlPanel(data.ControlPanel, context);
   }
@@ -1573,7 +1575,7 @@ export const deserializeAws_restJson1DescribeRoutingControlCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingControl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingControl !== undefined && data.RoutingControl !== null) {
     contents.RoutingControl = deserializeAws_restJson1RoutingControl(data.RoutingControl, context);
   }
@@ -1669,7 +1671,7 @@ export const deserializeAws_restJson1DescribeSafetyRuleCommand = async (
     AssertionRule: undefined,
     GatingRule: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssertionRule !== undefined && data.AssertionRule !== null) {
     contents.AssertionRule = deserializeAws_restJson1AssertionRule(data.AssertionRule, context);
   }
@@ -1736,7 +1738,7 @@ export const deserializeAws_restJson1ListAssociatedRoute53HealthChecksCommand = 
     HealthCheckIds: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckIds !== undefined && data.HealthCheckIds !== null) {
     contents.HealthCheckIds = deserializeAws_restJson1__listOf__string(data.HealthCheckIds, context);
   }
@@ -1811,7 +1813,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     Clusters: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Clusters !== undefined && data.Clusters !== null) {
     contents.Clusters = deserializeAws_restJson1__listOfCluster(data.Clusters, context);
   }
@@ -1902,7 +1904,7 @@ export const deserializeAws_restJson1ListControlPanelsCommand = async (
     ControlPanels: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanels !== undefined && data.ControlPanels !== null) {
     contents.ControlPanels = deserializeAws_restJson1__listOfControlPanel(data.ControlPanels, context);
   }
@@ -1993,7 +1995,7 @@ export const deserializeAws_restJson1ListRoutingControlsCommand = async (
     NextToken: undefined,
     RoutingControls: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2084,7 +2086,7 @@ export const deserializeAws_restJson1ListSafetyRulesCommand = async (
     NextToken: undefined,
     SafetyRules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2174,7 +2176,7 @@ export const deserializeAws_restJson1UpdateControlPanelCommand = async (
     $metadata: deserializeMetadata(output),
     ControlPanel: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanel !== undefined && data.ControlPanel !== null) {
     contents.ControlPanel = deserializeAws_restJson1ControlPanel(data.ControlPanel, context);
   }
@@ -2269,7 +2271,7 @@ export const deserializeAws_restJson1UpdateRoutingControlCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingControl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingControl !== undefined && data.RoutingControl !== null) {
     contents.RoutingControl = deserializeAws_restJson1RoutingControl(data.RoutingControl, context);
   }
@@ -2365,7 +2367,7 @@ export const deserializeAws_restJson1UpdateSafetyRuleCommand = async (
     AssertionRule: undefined,
     GatingRule: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssertionRule !== undefined && data.AssertionRule !== null) {
     contents.AssertionRule = deserializeAws_restJson1AssertionRule(data.AssertionRule, context);
   }

--- a/clients/client-route53-recovery-readiness/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/protocols/Aws_restJson1.ts
@@ -103,6 +103,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1091,7 +1093,7 @@ export const deserializeAws_restJson1CreateCellCommand = async (
     ParentReadinessScopes: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cellArn !== undefined && data.cellArn !== null) {
     contents.CellArn = __expectString(data.cellArn);
   }
@@ -1190,7 +1192,7 @@ export const deserializeAws_restJson1CreateCrossAccountAuthorizationCommand = as
     $metadata: deserializeMetadata(output),
     CrossAccountAuthorization: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.crossAccountAuthorization !== undefined && data.crossAccountAuthorization !== null) {
     contents.CrossAccountAuthorization = __expectString(data.crossAccountAuthorization);
   }
@@ -1280,7 +1282,7 @@ export const deserializeAws_restJson1CreateReadinessCheckCommand = async (
     ResourceSet: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.readinessCheckArn !== undefined && data.readinessCheckArn !== null) {
     contents.ReadinessCheckArn = __expectString(data.readinessCheckArn);
   }
@@ -1379,7 +1381,7 @@ export const deserializeAws_restJson1CreateRecoveryGroupCommand = async (
     RecoveryGroupName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOf__string(data.cells, context);
   }
@@ -1479,7 +1481,7 @@ export const deserializeAws_restJson1CreateResourceSetCommand = async (
     Resources: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceSetArn !== undefined && data.resourceSetArn !== null) {
     contents.ResourceSetArn = __expectString(data.resourceSetArn);
   }
@@ -1987,7 +1989,7 @@ export const deserializeAws_restJson1GetArchitectureRecommendationsCommand = asy
     NextToken: undefined,
     Recommendations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.lastAuditTimestamp !== undefined && data.lastAuditTimestamp !== null) {
     contents.LastAuditTimestamp = new Date(data.lastAuditTimestamp);
   }
@@ -2084,7 +2086,7 @@ export const deserializeAws_restJson1GetCellCommand = async (
     ParentReadinessScopes: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cellArn !== undefined && data.cellArn !== null) {
     contents.CellArn = __expectString(data.cellArn);
   }
@@ -2185,7 +2187,7 @@ export const deserializeAws_restJson1GetCellReadinessSummaryCommand = async (
     Readiness: undefined,
     ReadinessChecks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2281,7 +2283,7 @@ export const deserializeAws_restJson1GetReadinessCheckCommand = async (
     ResourceSet: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.readinessCheckArn !== undefined && data.readinessCheckArn !== null) {
     contents.ReadinessCheckArn = __expectString(data.readinessCheckArn);
   }
@@ -2379,7 +2381,7 @@ export const deserializeAws_restJson1GetReadinessCheckResourceStatusCommand = as
     Readiness: undefined,
     Rules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2475,7 +2477,7 @@ export const deserializeAws_restJson1GetReadinessCheckStatusCommand = async (
     Readiness: undefined,
     Resources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.messages !== undefined && data.messages !== null) {
     contents.Messages = deserializeAws_restJson1__listOfMessage(data.messages, context);
   }
@@ -2574,7 +2576,7 @@ export const deserializeAws_restJson1GetRecoveryGroupCommand = async (
     RecoveryGroupName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOf__string(data.cells, context);
   }
@@ -2672,7 +2674,7 @@ export const deserializeAws_restJson1GetRecoveryGroupReadinessSummaryCommand = a
     Readiness: undefined,
     ReadinessChecks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2769,7 +2771,7 @@ export const deserializeAws_restJson1GetResourceSetCommand = async (
     Resources: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceSetArn !== undefined && data.resourceSetArn !== null) {
     contents.ResourceSetArn = __expectString(data.resourceSetArn);
   }
@@ -2869,7 +2871,7 @@ export const deserializeAws_restJson1ListCellsCommand = async (
     Cells: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOfCellOutput(data.cells, context);
   }
@@ -2952,7 +2954,7 @@ export const deserializeAws_restJson1ListCrossAccountAuthorizationsCommand = asy
     CrossAccountAuthorizations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.crossAccountAuthorizations !== undefined && data.crossAccountAuthorizations !== null) {
     contents.CrossAccountAuthorizations = deserializeAws_restJson1__listOfCrossAccountAuthorization(
       data.crossAccountAuthorizations,
@@ -3038,7 +3040,7 @@ export const deserializeAws_restJson1ListReadinessChecksCommand = async (
     NextToken: undefined,
     ReadinessChecks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -3121,7 +3123,7 @@ export const deserializeAws_restJson1ListRecoveryGroupsCommand = async (
     NextToken: undefined,
     RecoveryGroups: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -3204,7 +3206,7 @@ export const deserializeAws_restJson1ListResourceSetsCommand = async (
     NextToken: undefined,
     ResourceSets: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -3287,7 +3289,7 @@ export const deserializeAws_restJson1ListRulesCommand = async (
     NextToken: undefined,
     Rules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -3369,7 +3371,7 @@ export const deserializeAws_restJson1ListTagsForResourcesCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -3578,7 +3580,7 @@ export const deserializeAws_restJson1UpdateCellCommand = async (
     ParentReadinessScopes: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cellArn !== undefined && data.cellArn !== null) {
     contents.CellArn = __expectString(data.cellArn);
   }
@@ -3680,7 +3682,7 @@ export const deserializeAws_restJson1UpdateReadinessCheckCommand = async (
     ResourceSet: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.readinessCheckArn !== undefined && data.readinessCheckArn !== null) {
     contents.ReadinessCheckArn = __expectString(data.readinessCheckArn);
   }
@@ -3779,7 +3781,7 @@ export const deserializeAws_restJson1UpdateRecoveryGroupCommand = async (
     RecoveryGroupName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOf__string(data.cells, context);
   }
@@ -3879,7 +3881,7 @@ export const deserializeAws_restJson1UpdateResourceSetCommand = async (
     Resources: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceSetArn !== undefined && data.resourceSetArn !== null) {
     contents.ResourceSetArn = __expectString(data.resourceSetArn);
   }

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -221,6 +221,8 @@ import {
   isValidHostname as __isValidHostname,
 } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
@@ -2486,7 +2488,7 @@ export const deserializeAws_restXmlCreateAccessPointCommand = async (
     AccessPointArn: undefined,
     Alias: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["AccessPointArn"] !== undefined) {
     contents.AccessPointArn = __expectString(data["AccessPointArn"]);
   }
@@ -2536,7 +2538,7 @@ export const deserializeAws_restXmlCreateAccessPointForObjectLambdaCommand = asy
     $metadata: deserializeMetadata(output),
     ObjectLambdaAccessPointArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ObjectLambdaAccessPointArn"] !== undefined) {
     contents.ObjectLambdaAccessPointArn = __expectString(data["ObjectLambdaAccessPointArn"]);
   }
@@ -2587,7 +2589,7 @@ export const deserializeAws_restXmlCreateBucketCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["BucketArn"] !== undefined) {
     contents.BucketArn = __expectString(data["BucketArn"]);
   }
@@ -2650,7 +2652,7 @@ export const deserializeAws_restXmlCreateJobCommand = async (
     $metadata: deserializeMetadata(output),
     JobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["JobId"] !== undefined) {
     contents.JobId = __expectString(data["JobId"]);
   }
@@ -3269,7 +3271,7 @@ export const deserializeAws_restXmlDescribeJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Job"] !== undefined) {
     contents.Job = deserializeAws_restXmlJobDescriptor(data["Job"], context);
   }
@@ -3356,7 +3358,7 @@ export const deserializeAws_restXmlGetAccessPointCommand = async (
     PublicAccessBlockConfiguration: undefined,
     VpcConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["AccessPointArn"] !== undefined) {
     contents.AccessPointArn = __expectString(data["AccessPointArn"]);
   }
@@ -3433,7 +3435,7 @@ export const deserializeAws_restXmlGetAccessPointConfigurationForObjectLambdaCom
     $metadata: deserializeMetadata(output),
     Configuration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Configuration"] !== undefined) {
     contents.Configuration = deserializeAws_restXmlObjectLambdaConfiguration(data["Configuration"], context);
   }
@@ -3482,7 +3484,7 @@ export const deserializeAws_restXmlGetAccessPointForObjectLambdaCommand = async 
     Name: undefined,
     PublicAccessBlockConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["CreationDate"] !== undefined) {
     contents.CreationDate = new Date(data["CreationDate"]);
   }
@@ -3538,7 +3540,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Policy"] !== undefined) {
     contents.Policy = __expectString(data["Policy"]);
   }
@@ -3585,7 +3587,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyForObjectLambdaCommand = 
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Policy"] !== undefined) {
     contents.Policy = __expectString(data["Policy"]);
   }
@@ -3632,7 +3634,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyStatusCommand = async (
     $metadata: deserializeMetadata(output),
     PolicyStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["PolicyStatus"] !== undefined) {
     contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(data["PolicyStatus"], context);
   }
@@ -3679,7 +3681,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyStatusForObjectLambdaComm
     $metadata: deserializeMetadata(output),
     PolicyStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["PolicyStatus"] !== undefined) {
     contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(data["PolicyStatus"], context);
   }
@@ -3728,7 +3730,7 @@ export const deserializeAws_restXmlGetBucketCommand = async (
     CreationDate: undefined,
     PublicAccessBlockEnabled: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -3781,7 +3783,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     Rules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Rules === "") {
     contents.Rules = [];
   }
@@ -3831,7 +3833,7 @@ export const deserializeAws_restXmlGetBucketPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Policy"] !== undefined) {
     contents.Policy = __expectString(data["Policy"]);
   }
@@ -3878,7 +3880,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
     $metadata: deserializeMetadata(output),
     TagSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
   }
@@ -3928,7 +3930,7 @@ export const deserializeAws_restXmlGetJobTaggingCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags === "") {
     contents.Tags = [];
   }
@@ -4002,7 +4004,7 @@ export const deserializeAws_restXmlGetPublicAccessBlockCommand = async (
     $metadata: deserializeMetadata(output),
     PublicAccessBlockConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicAccessBlockConfiguration = deserializeAws_restXmlPublicAccessBlockConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -4055,7 +4057,7 @@ export const deserializeAws_restXmlGetStorageLensConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     StorageLensConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.StorageLensConfiguration = deserializeAws_restXmlStorageLensConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -4100,7 +4102,7 @@ export const deserializeAws_restXmlGetStorageLensConfigurationTaggingCommand = a
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags === "") {
     contents.Tags = [];
   }
@@ -4151,7 +4153,7 @@ export const deserializeAws_restXmlListAccessPointsCommand = async (
     AccessPointList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPointList === "") {
     contents.AccessPointList = [];
   }
@@ -4208,7 +4210,7 @@ export const deserializeAws_restXmlListAccessPointsForObjectLambdaCommand = asyn
     NextToken: undefined,
     ObjectLambdaAccessPointList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -4268,7 +4270,7 @@ export const deserializeAws_restXmlListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs === "") {
     contents.Jobs = [];
   }
@@ -4349,7 +4351,7 @@ export const deserializeAws_restXmlListRegionalBucketsCommand = async (
     NextToken: undefined,
     RegionalBucketList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -4406,7 +4408,7 @@ export const deserializeAws_restXmlListStorageLensConfigurationsCommand = async 
     NextToken: undefined,
     StorageLensConfigurationList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -4925,7 +4927,7 @@ export const deserializeAws_restXmlUpdateJobPriorityCommand = async (
     JobId: undefined,
     Priority: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["JobId"] !== undefined) {
     contents.JobId = __expectString(data["JobId"]);
   }
@@ -5009,7 +5011,7 @@ export const deserializeAws_restXmlUpdateJobStatusCommand = async (
     Status: undefined,
     StatusUpdateReason: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["JobId"] !== undefined) {
     contents.JobId = __expectString(data["JobId"]);
   }

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -392,6 +392,8 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   dateToUtcString as __dateToUtcString,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
@@ -5017,7 +5019,7 @@ export const deserializeAws_restXmlCompleteMultipartUploadCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -5113,7 +5115,7 @@ export const deserializeAws_restXmlCopyObjectCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CopyObjectResult = deserializeAws_restXmlCopyObjectResult(data, context);
   return Promise.resolve(contents);
 };
@@ -5267,7 +5269,7 @@ export const deserializeAws_restXmlCreateMultipartUploadCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -5939,7 +5941,7 @@ export const deserializeAws_restXmlDeleteObjectsCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Deleted === "") {
     contents.Deleted = [];
   }
@@ -6085,7 +6087,7 @@ export const deserializeAws_restXmlGetBucketAccelerateConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Status"] !== undefined) {
     contents.Status = __expectString(data["Status"]);
   }
@@ -6133,7 +6135,7 @@ export const deserializeAws_restXmlGetBucketAclCommand = async (
     Grants: undefined,
     Owner: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessControlList === "") {
     contents.Grants = [];
   }
@@ -6186,7 +6188,7 @@ export const deserializeAws_restXmlGetBucketAnalyticsConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     AnalyticsConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.AnalyticsConfiguration = deserializeAws_restXmlAnalyticsConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6231,7 +6233,7 @@ export const deserializeAws_restXmlGetBucketCorsCommand = async (
     $metadata: deserializeMetadata(output),
     CORSRules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CORSRule === "") {
     contents.CORSRules = [];
   }
@@ -6281,7 +6283,7 @@ export const deserializeAws_restXmlGetBucketEncryptionCommand = async (
     $metadata: deserializeMetadata(output),
     ServerSideEncryptionConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ServerSideEncryptionConfiguration = deserializeAws_restXmlServerSideEncryptionConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6326,7 +6328,7 @@ export const deserializeAws_restXmlGetBucketIntelligentTieringConfigurationComma
     $metadata: deserializeMetadata(output),
     IntelligentTieringConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.IntelligentTieringConfiguration = deserializeAws_restXmlIntelligentTieringConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6371,7 +6373,7 @@ export const deserializeAws_restXmlGetBucketInventoryConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     InventoryConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.InventoryConfiguration = deserializeAws_restXmlInventoryConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6416,7 +6418,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     Rules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Rule === "") {
     contents.Rules = [];
   }
@@ -6466,7 +6468,7 @@ export const deserializeAws_restXmlGetBucketLocationCommand = async (
     $metadata: deserializeMetadata(output),
     LocationConstraint: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["LocationConstraint"] !== undefined) {
     contents.LocationConstraint = __expectString(data["LocationConstraint"]);
   }
@@ -6513,7 +6515,7 @@ export const deserializeAws_restXmlGetBucketLoggingCommand = async (
     $metadata: deserializeMetadata(output),
     LoggingEnabled: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["LoggingEnabled"] !== undefined) {
     contents.LoggingEnabled = deserializeAws_restXmlLoggingEnabled(data["LoggingEnabled"], context);
   }
@@ -6560,7 +6562,7 @@ export const deserializeAws_restXmlGetBucketMetricsConfigurationCommand = async 
     $metadata: deserializeMetadata(output),
     MetricsConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.MetricsConfiguration = deserializeAws_restXmlMetricsConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6607,7 +6609,7 @@ export const deserializeAws_restXmlGetBucketNotificationConfigurationCommand = a
     QueueConfigurations: undefined,
     TopicConfigurations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CloudFunctionConfiguration === "") {
     contents.LambdaFunctionConfigurations = [];
   }
@@ -6678,7 +6680,7 @@ export const deserializeAws_restXmlGetBucketOwnershipControlsCommand = async (
     $metadata: deserializeMetadata(output),
     OwnershipControls: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.OwnershipControls = deserializeAws_restXmlOwnershipControls(data, context);
   return Promise.resolve(contents);
 };
@@ -6768,7 +6770,7 @@ export const deserializeAws_restXmlGetBucketPolicyStatusCommand = async (
     $metadata: deserializeMetadata(output),
     PolicyStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(data, context);
   return Promise.resolve(contents);
 };
@@ -6813,7 +6815,7 @@ export const deserializeAws_restXmlGetBucketReplicationCommand = async (
     $metadata: deserializeMetadata(output),
     ReplicationConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ReplicationConfiguration = deserializeAws_restXmlReplicationConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6858,7 +6860,7 @@ export const deserializeAws_restXmlGetBucketRequestPaymentCommand = async (
     $metadata: deserializeMetadata(output),
     Payer: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Payer"] !== undefined) {
     contents.Payer = __expectString(data["Payer"]);
   }
@@ -6905,7 +6907,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
     $metadata: deserializeMetadata(output),
     TagSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
   }
@@ -6956,7 +6958,7 @@ export const deserializeAws_restXmlGetBucketVersioningCommand = async (
     MFADelete: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["MfaDelete"] !== undefined) {
     contents.MFADelete = __expectString(data["MfaDelete"]);
   }
@@ -7009,7 +7011,7 @@ export const deserializeAws_restXmlGetBucketWebsiteCommand = async (
     RedirectAllRequestsTo: undefined,
     RoutingRules: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ErrorDocument"] !== undefined) {
     contents.ErrorDocument = deserializeAws_restXmlErrorDocument(data["ErrorDocument"], context);
   }
@@ -7269,7 +7271,7 @@ export const deserializeAws_restXmlGetObjectAclCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessControlList === "") {
     contents.Grants = [];
   }
@@ -7330,7 +7332,7 @@ export const deserializeAws_restXmlGetObjectLegalHoldCommand = async (
     $metadata: deserializeMetadata(output),
     LegalHold: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.LegalHold = deserializeAws_restXmlObjectLockLegalHold(data, context);
   return Promise.resolve(contents);
 };
@@ -7375,7 +7377,7 @@ export const deserializeAws_restXmlGetObjectLockConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectLockConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.ObjectLockConfiguration = deserializeAws_restXmlObjectLockConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -7420,7 +7422,7 @@ export const deserializeAws_restXmlGetObjectRetentionCommand = async (
     $metadata: deserializeMetadata(output),
     Retention: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.Retention = deserializeAws_restXmlObjectLockRetention(data, context);
   return Promise.resolve(contents);
 };
@@ -7469,7 +7471,7 @@ export const deserializeAws_restXmlGetObjectTaggingCommand = async (
   if (output.headers["x-amz-version-id"] !== undefined) {
     contents.VersionId = output.headers["x-amz-version-id"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
   }
@@ -7568,7 +7570,7 @@ export const deserializeAws_restXmlGetPublicAccessBlockCommand = async (
     $metadata: deserializeMetadata(output),
     PublicAccessBlockConfiguration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicAccessBlockConfiguration = deserializeAws_restXmlPublicAccessBlockConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -7843,7 +7845,7 @@ export const deserializeAws_restXmlListBucketAnalyticsConfigurationsCommand = as
     IsTruncated: undefined,
     NextContinuationToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalyticsConfiguration === "") {
     contents.AnalyticsConfigurationList = [];
   }
@@ -7908,7 +7910,7 @@ export const deserializeAws_restXmlListBucketIntelligentTieringConfigurationsCom
     IsTruncated: undefined,
     NextContinuationToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ContinuationToken"] !== undefined) {
     contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
@@ -7973,7 +7975,7 @@ export const deserializeAws_restXmlListBucketInventoryConfigurationsCommand = as
     IsTruncated: undefined,
     NextContinuationToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ContinuationToken"] !== undefined) {
     contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
@@ -8038,7 +8040,7 @@ export const deserializeAws_restXmlListBucketMetricsConfigurationsCommand = asyn
     MetricsConfigurationList: undefined,
     NextContinuationToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ContinuationToken"] !== undefined) {
     contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
@@ -8101,7 +8103,7 @@ export const deserializeAws_restXmlListBucketsCommand = async (
     Buckets: undefined,
     Owner: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Buckets === "") {
     contents.Buckets = [];
   }
@@ -8165,7 +8167,7 @@ export const deserializeAws_restXmlListMultipartUploadsCommand = async (
     UploadIdMarker: undefined,
     Uploads: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -8263,7 +8265,7 @@ export const deserializeAws_restXmlListObjectsCommand = async (
     NextMarker: undefined,
     Prefix: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
   }
@@ -8365,7 +8367,7 @@ export const deserializeAws_restXmlListObjectsV2Command = async (
     Prefix: undefined,
     StartAfter: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
   }
@@ -8474,7 +8476,7 @@ export const deserializeAws_restXmlListObjectVersionsCommand = async (
     VersionIdMarker: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
   }
@@ -8591,7 +8593,7 @@ export const deserializeAws_restXmlListPartsCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -10031,7 +10033,7 @@ export const deserializeAws_restXmlUploadPartCopyCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.CopyPartResult = deserializeAws_restXmlCopyPartResult(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-s3outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-s3outposts/protocols/Aws_restJson1.ts
@@ -12,6 +12,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -115,7 +117,7 @@ export const deserializeAws_restJson1CreateEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EndpointArn !== undefined && data.EndpointArn !== null) {
     contents.EndpointArn = __expectString(data.EndpointArn);
   }
@@ -278,7 +280,7 @@ export const deserializeAws_restJson1ListEndpointsCommand = async (
     Endpoints: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Endpoints !== undefined && data.Endpoints !== null) {
     contents.Endpoints = deserializeAws_restJson1Endpoints(data.Endpoints, context);
   }

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
@@ -18,6 +18,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -270,7 +272,7 @@ export const deserializeAws_restJson1DescribeHumanLoopCommand = async (
     HumanLoopOutput: undefined,
     HumanLoopStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
   }
@@ -371,7 +373,7 @@ export const deserializeAws_restJson1ListHumanLoopsCommand = async (
     HumanLoopSummaries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HumanLoopSummaries !== undefined && data.HumanLoopSummaries !== null) {
     contents.HumanLoopSummaries = deserializeAws_restJson1HumanLoopSummaries(data.HumanLoopSummaries, context);
   }
@@ -453,7 +455,7 @@ export const deserializeAws_restJson1StartHumanLoopCommand = async (
     $metadata: deserializeMetadata(output),
     HumanLoopArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HumanLoopArn !== undefined && data.HumanLoopArn !== null) {
     contents.HumanLoopArn = __expectString(data.HumanLoopArn);
   }

--- a/clients/client-sagemaker-edge/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-edge/protocols/Aws_restJson1.ts
@@ -5,7 +5,12 @@ import {
 import { SendHeartbeatCommandInput, SendHeartbeatCommandOutput } from "../commands/SendHeartbeatCommand";
 import { EdgeMetric, InternalServiceException, Model } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString, serializeFloat as __serializeFloat } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+  serializeFloat as __serializeFloat,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -83,7 +88,7 @@ export const deserializeAws_restJson1GetDeviceRegistrationCommand = async (
     CacheTTL: undefined,
     DeviceRegistration: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CacheTTL !== undefined && data.CacheTTL !== null) {
     contents.CacheTTL = __expectString(data.CacheTTL);
   }

--- a/clients/client-sagemaker-featurestore-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-featurestore-runtime/protocols/Aws_restJson1.ts
@@ -15,6 +15,8 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -173,7 +175,7 @@ export const deserializeAws_restJson1BatchGetRecordCommand = async (
     Records: undefined,
     UnprocessedIdentifiers: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchGetRecordErrors(data.Errors, context);
   }
@@ -336,7 +338,7 @@ export const deserializeAws_restJson1GetRecordCommand = async (
     $metadata: deserializeMetadata(output),
     Record: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Record !== undefined && data.Record !== null) {
     contents.Record = deserializeAws_restJson1Record(data.Record, context);
   }

--- a/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
@@ -7,6 +7,8 @@ import { InternalFailure, ModelError, ServiceUnavailable, ValidationError } from
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -208,7 +210,7 @@ export const deserializeAws_restJson1InvokeEndpointAsyncCommand = async (
   if (output.headers["x-amzn-sagemaker-outputlocation"] !== undefined) {
     contents.OutputLocation = output.headers["x-amzn-sagemaker-outputlocation"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InferenceId !== undefined && data.InferenceId !== null) {
     contents.InferenceId = __expectString(data.InferenceId);
   }

--- a/clients/client-savingsplans/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1.ts
@@ -50,7 +50,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectLong as __expectLong, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   MetadataBearer as __MetadataBearer,
@@ -388,7 +393,7 @@ export const deserializeAws_restJson1CreateSavingsPlanCommand = async (
     $metadata: deserializeMetadata(output),
     savingsPlanId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.savingsPlanId !== undefined && data.savingsPlanId !== null) {
     contents.savingsPlanId = __expectString(data.savingsPlanId);
   }
@@ -544,7 +549,7 @@ export const deserializeAws_restJson1DescribeSavingsPlanRatesCommand = async (
     savingsPlanId: undefined,
     searchResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -614,7 +619,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansCommand = async (
     nextToken: undefined,
     savingsPlans: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -681,7 +686,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingRatesCommand = 
     nextToken: undefined,
     searchResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -748,7 +753,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingsCommand = asyn
     nextToken: undefined,
     searchResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -814,7 +819,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-schemas/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1.ts
@@ -69,6 +69,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   LazyJsonString as __LazyJsonString,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1188,7 +1190,7 @@ export const deserializeAws_restJson1CreateDiscovererCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1301,7 +1303,7 @@ export const deserializeAws_restJson1CreateRegistryCommand = async (
     RegistryName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1412,7 +1414,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     Type: undefined,
     VersionCreatedDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1970,7 +1972,7 @@ export const deserializeAws_restJson1DescribeCodeBindingCommand = async (
     SchemaVersion: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(data.CreationDate);
   }
@@ -2079,7 +2081,7 @@ export const deserializeAws_restJson1DescribeDiscovererCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -2192,7 +2194,7 @@ export const deserializeAws_restJson1DescribeRegistryCommand = async (
     RegistryName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -2304,7 +2306,7 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
     Type: undefined,
     VersionCreatedDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Content !== undefined && data.Content !== null) {
     contents.Content = __expectString(data.Content);
   }
@@ -2427,7 +2429,7 @@ export const deserializeAws_restJson1ExportSchemaCommand = async (
     SchemaVersion: undefined,
     Type: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Content !== undefined && data.Content !== null) {
     contents.Content = __expectString(data.Content);
   }
@@ -2635,7 +2637,7 @@ export const deserializeAws_restJson1GetDiscoveredSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     Content: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Content !== undefined && data.Content !== null) {
     contents.Content = __expectString(data.Content);
   }
@@ -2723,7 +2725,7 @@ export const deserializeAws_restJson1GetResourcePolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = new __LazyJsonString(data.Policy);
   }
@@ -2822,7 +2824,7 @@ export const deserializeAws_restJson1ListDiscoverersCommand = async (
     Discoverers: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Discoverers !== undefined && data.Discoverers !== null) {
     contents.Discoverers = deserializeAws_restJson1__listOfDiscovererSummary(data.Discoverers, context);
   }
@@ -2913,7 +2915,7 @@ export const deserializeAws_restJson1ListRegistriesCommand = async (
     NextToken: undefined,
     Registries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3004,7 +3006,7 @@ export const deserializeAws_restJson1ListSchemasCommand = async (
     NextToken: undefined,
     Schemas: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3095,7 +3097,7 @@ export const deserializeAws_restJson1ListSchemaVersionsCommand = async (
     NextToken: undefined,
     SchemaVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3193,7 +3195,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -3275,7 +3277,7 @@ export const deserializeAws_restJson1PutCodeBindingCommand = async (
     SchemaVersion: undefined,
     Status: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = new Date(data.CreationDate);
   }
@@ -3388,7 +3390,7 @@ export const deserializeAws_restJson1PutResourcePolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = new __LazyJsonString(data.Policy);
   }
@@ -3495,7 +3497,7 @@ export const deserializeAws_restJson1SearchSchemasCommand = async (
     NextToken: undefined,
     Schemas: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3586,7 +3588,7 @@ export const deserializeAws_restJson1StartDiscovererCommand = async (
     DiscovererId: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
     contents.DiscovererId = __expectString(data.DiscovererId);
   }
@@ -3685,7 +3687,7 @@ export const deserializeAws_restJson1StopDiscovererCommand = async (
     DiscovererId: undefined,
     State: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
     contents.DiscovererId = __expectString(data.DiscovererId);
   }
@@ -3938,7 +3940,7 @@ export const deserializeAws_restJson1UpdateDiscovererCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -4051,7 +4053,7 @@ export const deserializeAws_restJson1UpdateRegistryCommand = async (
     RegistryName: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -4162,7 +4164,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     Type: undefined,
     VersionCreatedDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }

--- a/clients/client-securityhub/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1.ts
@@ -467,6 +467,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -2095,7 +2097,7 @@ export const deserializeAws_restJson1BatchDisableStandardsCommand = async (
     $metadata: deserializeMetadata(output),
     StandardsSubscriptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StandardsSubscriptions !== undefined && data.StandardsSubscriptions !== null) {
     contents.StandardsSubscriptions = deserializeAws_restJson1StandardsSubscriptions(
       data.StandardsSubscriptions,
@@ -2177,7 +2179,7 @@ export const deserializeAws_restJson1BatchEnableStandardsCommand = async (
     $metadata: deserializeMetadata(output),
     StandardsSubscriptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StandardsSubscriptions !== undefined && data.StandardsSubscriptions !== null) {
     contents.StandardsSubscriptions = deserializeAws_restJson1StandardsSubscriptions(
       data.StandardsSubscriptions,
@@ -2261,7 +2263,7 @@ export const deserializeAws_restJson1BatchImportFindingsCommand = async (
     FailedFindings: undefined,
     SuccessCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FailedCount !== undefined && data.FailedCount !== null) {
     contents.FailedCount = __expectInt32(data.FailedCount);
   }
@@ -2347,7 +2349,7 @@ export const deserializeAws_restJson1BatchUpdateFindingsCommand = async (
     ProcessedFindings: undefined,
     UnprocessedFindings: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProcessedFindings !== undefined && data.ProcessedFindings !== null) {
     contents.ProcessedFindings = deserializeAws_restJson1AwsSecurityFindingIdentifierList(
       data.ProcessedFindings,
@@ -2435,7 +2437,7 @@ export const deserializeAws_restJson1CreateActionTargetCommand = async (
     $metadata: deserializeMetadata(output),
     ActionTargetArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionTargetArn !== undefined && data.ActionTargetArn !== null) {
     contents.ActionTargetArn = __expectString(data.ActionTargetArn);
   }
@@ -2522,7 +2524,7 @@ export const deserializeAws_restJson1CreateInsightCommand = async (
     $metadata: deserializeMetadata(output),
     InsightArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightArn !== undefined && data.InsightArn !== null) {
     contents.InsightArn = __expectString(data.InsightArn);
   }
@@ -2609,7 +2611,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -2696,7 +2698,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -2775,7 +2777,7 @@ export const deserializeAws_restJson1DeleteActionTargetCommand = async (
     $metadata: deserializeMetadata(output),
     ActionTargetArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionTargetArn !== undefined && data.ActionTargetArn !== null) {
     contents.ActionTargetArn = __expectString(data.ActionTargetArn);
   }
@@ -2854,7 +2856,7 @@ export const deserializeAws_restJson1DeleteInsightCommand = async (
     $metadata: deserializeMetadata(output),
     InsightArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightArn !== undefined && data.InsightArn !== null) {
     contents.InsightArn = __expectString(data.InsightArn);
   }
@@ -2941,7 +2943,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -3028,7 +3030,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -3116,7 +3118,7 @@ export const deserializeAws_restJson1DescribeActionTargetsCommand = async (
     ActionTargets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionTargets !== undefined && data.ActionTargets !== null) {
     contents.ActionTargets = deserializeAws_restJson1ActionTargetList(data.ActionTargets, context);
   }
@@ -3200,7 +3202,7 @@ export const deserializeAws_restJson1DescribeHubCommand = async (
     HubArn: undefined,
     SubscribedAt: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoEnableControls !== undefined && data.AutoEnableControls !== null) {
     contents.AutoEnableControls = __expectBoolean(data.AutoEnableControls);
   }
@@ -3294,7 +3296,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     AutoEnable: undefined,
     MemberAccountLimitReached: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoEnable !== undefined && data.AutoEnable !== null) {
     contents.AutoEnable = __expectBoolean(data.AutoEnable);
   }
@@ -3377,7 +3379,7 @@ export const deserializeAws_restJson1DescribeProductsCommand = async (
     NextToken: undefined,
     Products: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3460,7 +3462,7 @@ export const deserializeAws_restJson1DescribeStandardsCommand = async (
     NextToken: undefined,
     Standards: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3535,7 +3537,7 @@ export const deserializeAws_restJson1DescribeStandardsControlsCommand = async (
     Controls: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Controls !== undefined && data.Controls !== null) {
     contents.Controls = deserializeAws_restJson1StandardsControls(data.Controls, context);
   }
@@ -4099,7 +4101,7 @@ export const deserializeAws_restJson1EnableImportFindingsForProductCommand = asy
     $metadata: deserializeMetadata(output),
     ProductSubscriptionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProductSubscriptionArn !== undefined && data.ProductSubscriptionArn !== null) {
     contents.ProductSubscriptionArn = __expectString(data.ProductSubscriptionArn);
   }
@@ -4344,7 +4346,7 @@ export const deserializeAws_restJson1GetAdministratorAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Administrator: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Administrator !== undefined && data.Administrator !== null) {
     contents.Administrator = deserializeAws_restJson1Invitation(data.Administrator, context);
   }
@@ -4432,7 +4434,7 @@ export const deserializeAws_restJson1GetEnabledStandardsCommand = async (
     NextToken: undefined,
     StandardsSubscriptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -4518,7 +4520,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
     Findings: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Findings !== undefined && data.Findings !== null) {
     contents.Findings = deserializeAws_restJson1AwsSecurityFindingList(data.Findings, context);
   }
@@ -4600,7 +4602,7 @@ export const deserializeAws_restJson1GetInsightResultsCommand = async (
     $metadata: deserializeMetadata(output),
     InsightResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightResults !== undefined && data.InsightResults !== null) {
     contents.InsightResults = deserializeAws_restJson1InsightResults(data.InsightResults, context);
   }
@@ -4688,7 +4690,7 @@ export const deserializeAws_restJson1GetInsightsCommand = async (
     Insights: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Insights !== undefined && data.Insights !== null) {
     contents.Insights = deserializeAws_restJson1InsightList(data.Insights, context);
   }
@@ -4778,7 +4780,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
     $metadata: deserializeMetadata(output),
     InvitationsCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InvitationsCount !== undefined && data.InvitationsCount !== null) {
     contents.InvitationsCount = __expectInt32(data.InvitationsCount);
   }
@@ -4857,7 +4859,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Master: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Master !== undefined && data.Master !== null) {
     contents.Master = deserializeAws_restJson1Invitation(data.Master, context);
   }
@@ -4945,7 +4947,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
     Members: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberList(data.Members, context);
   }
@@ -5035,7 +5037,7 @@ export const deserializeAws_restJson1InviteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -5123,7 +5125,7 @@ export const deserializeAws_restJson1ListEnabledProductsForImportCommand = async
     NextToken: undefined,
     ProductSubscriptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5201,7 +5203,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invitations !== undefined && data.Invitations !== null) {
     contents.Invitations = deserializeAws_restJson1InvitationList(data.Invitations, context);
   }
@@ -5284,7 +5286,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     Members: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberList(data.Members, context);
   }
@@ -5367,7 +5369,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     AdminAccounts: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdminAccounts !== undefined && data.AdminAccounts !== null) {
     contents.AdminAccounts = deserializeAws_restJson1AdminAccounts(data.AdminAccounts, context);
   }
@@ -5449,7 +5451,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
@@ -59,6 +59,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -615,7 +617,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     VerifiedAuthorUrl: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -746,7 +748,7 @@ export const deserializeAws_restJson1CreateApplicationVersionCommand = async (
     SourceCodeUrl: undefined,
     TemplateUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -863,7 +865,7 @@ export const deserializeAws_restJson1CreateCloudFormationChangeSetCommand = asyn
     SemanticVersion: undefined,
     StackId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -957,7 +959,7 @@ export const deserializeAws_restJson1CreateCloudFormationTemplateCommand = async
     TemplateId: undefined,
     TemplateUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -1165,7 +1167,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     VerifiedAuthorUrl: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -1288,7 +1290,7 @@ export const deserializeAws_restJson1GetApplicationPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Statements: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.statements !== undefined && data.statements !== null) {
     contents.Statements = deserializeAws_restJson1__listOfApplicationPolicyStatement(data.statements, context);
   }
@@ -1381,7 +1383,7 @@ export const deserializeAws_restJson1GetCloudFormationTemplateCommand = async (
     TemplateId: undefined,
     TemplateUrl: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -1487,7 +1489,7 @@ export const deserializeAws_restJson1ListApplicationDependenciesCommand = async 
     Dependencies: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dependencies !== undefined && data.dependencies !== null) {
     contents.Dependencies = deserializeAws_restJson1__listOfApplicationDependencySummary(data.dependencies, context);
   }
@@ -1578,7 +1580,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     Applications: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applications !== undefined && data.applications !== null) {
     contents.Applications = deserializeAws_restJson1__listOfApplicationSummary(data.applications, context);
   }
@@ -1661,7 +1663,7 @@ export const deserializeAws_restJson1ListApplicationVersionsCommand = async (
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -1751,7 +1753,7 @@ export const deserializeAws_restJson1PutApplicationPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Statements: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.statements !== undefined && data.statements !== null) {
     contents.Statements = deserializeAws_restJson1__listOfApplicationPolicyStatement(data.statements, context);
   }
@@ -1933,7 +1935,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     VerifiedAuthorUrl: undefined,
     Version: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }

--- a/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
@@ -63,6 +63,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -751,7 +753,7 @@ export const deserializeAws_restJson1AssociateAttributeGroupCommand = async (
     applicationArn: undefined,
     attributeGroupArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -834,7 +836,7 @@ export const deserializeAws_restJson1AssociateResourceCommand = async (
     applicationArn: undefined,
     resourceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -916,7 +918,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1Application(data.application, context);
   }
@@ -987,7 +989,7 @@ export const deserializeAws_restJson1CreateAttributeGroupCommand = async (
     $metadata: deserializeMetadata(output),
     attributeGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroup !== undefined && data.attributeGroup !== null) {
     contents.attributeGroup = deserializeAws_restJson1AttributeGroup(data.attributeGroup, context);
   }
@@ -1066,7 +1068,7 @@ export const deserializeAws_restJson1DeleteApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1ApplicationSummary(data.application, context);
   }
@@ -1137,7 +1139,7 @@ export const deserializeAws_restJson1DeleteAttributeGroupCommand = async (
     $metadata: deserializeMetadata(output),
     attributeGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroup !== undefined && data.attributeGroup !== null) {
     contents.attributeGroup = deserializeAws_restJson1AttributeGroupSummary(data.attributeGroup, context);
   }
@@ -1209,7 +1211,7 @@ export const deserializeAws_restJson1DisassociateAttributeGroupCommand = async (
     applicationArn: undefined,
     attributeGroupArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -1284,7 +1286,7 @@ export const deserializeAws_restJson1DisassociateResourceCommand = async (
     applicationArn: undefined,
     resourceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -1357,7 +1359,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1456,7 +1458,7 @@ export const deserializeAws_restJson1GetAttributeGroupCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1549,7 +1551,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     applications: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applications !== undefined && data.applications !== null) {
     contents.applications = deserializeAws_restJson1ApplicationSummaries(data.applications, context);
   }
@@ -1616,7 +1618,7 @@ export const deserializeAws_restJson1ListAssociatedAttributeGroupsCommand = asyn
     attributeGroups: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroups !== undefined && data.attributeGroups !== null) {
     contents.attributeGroups = deserializeAws_restJson1AttributeGroupIds(data.attributeGroups, context);
   }
@@ -1691,7 +1693,7 @@ export const deserializeAws_restJson1ListAssociatedResourcesCommand = async (
     nextToken: undefined,
     resources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1766,7 +1768,7 @@ export const deserializeAws_restJson1ListAttributeGroupsCommand = async (
     attributeGroups: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroups !== undefined && data.attributeGroups !== null) {
     contents.attributeGroups = deserializeAws_restJson1AttributeGroupSummaries(data.attributeGroups, context);
   }
@@ -1832,7 +1834,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -1905,7 +1907,7 @@ export const deserializeAws_restJson1SyncResourceCommand = async (
     applicationArn: undefined,
     resourceArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionTaken !== undefined && data.actionTaken !== null) {
     contents.actionTaken = __expectString(data.actionTaken);
   }
@@ -2116,7 +2118,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1Application(data.application, context);
   }
@@ -2187,7 +2189,7 @@ export const deserializeAws_restJson1UpdateAttributeGroupCommand = async (
     $metadata: deserializeMetadata(output),
     attributeGroup: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroup !== undefined && data.attributeGroup !== null) {
     contents.attributeGroup = deserializeAws_restJson1AttributeGroup(data.attributeGroup, context);
   }

--- a/clients/client-sesv2/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1.ts
@@ -336,6 +336,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
@@ -3513,7 +3515,7 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
     DeliverabilityTestStatus: undefined,
     ReportId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestStatus !== undefined && data.DeliverabilityTestStatus !== null) {
     contents.DeliverabilityTestStatus = __expectString(data.DeliverabilityTestStatus);
   }
@@ -3637,7 +3639,7 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
     IdentityType: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimAttributes !== undefined && data.DkimAttributes !== null) {
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
@@ -3896,7 +3898,7 @@ export const deserializeAws_restJson1CreateImportJobCommand = async (
     $metadata: deserializeMetadata(output),
     JobId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobId !== undefined && data.JobId !== null) {
     contents.JobId = __expectString(data.JobId);
   }
@@ -4675,7 +4677,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     SendingEnabled: undefined,
     SuppressionAttributes: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpAutoWarmupEnabled !== undefined && data.DedicatedIpAutoWarmupEnabled !== null) {
     contents.DedicatedIpAutoWarmupEnabled = __expectBoolean(data.DedicatedIpAutoWarmupEnabled);
   }
@@ -4756,7 +4758,7 @@ export const deserializeAws_restJson1GetBlacklistReportsCommand = async (
     $metadata: deserializeMetadata(output),
     BlacklistReport: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlacklistReport !== undefined && data.BlacklistReport !== null) {
     contents.BlacklistReport = deserializeAws_restJson1BlacklistReport(data.BlacklistReport, context);
   }
@@ -4833,7 +4835,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
     Tags: undefined,
     TrackingOptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
     contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
@@ -4922,7 +4924,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
     $metadata: deserializeMetadata(output),
     EventDestinations: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventDestinations !== undefined && data.EventDestinations !== null) {
     contents.EventDestinations = deserializeAws_restJson1EventDestinations(data.EventDestinations, context);
   }
@@ -5000,7 +5002,7 @@ export const deserializeAws_restJson1GetContactCommand = async (
     TopicPreferences: undefined,
     UnsubscribeAll: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttributesData !== undefined && data.AttributesData !== null) {
     contents.AttributesData = __expectString(data.AttributesData);
   }
@@ -5100,7 +5102,7 @@ export const deserializeAws_restJson1GetContactListCommand = async (
     Tags: undefined,
     Topics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactListName !== undefined && data.ContactListName !== null) {
     contents.ContactListName = __expectString(data.ContactListName);
   }
@@ -5191,7 +5193,7 @@ export const deserializeAws_restJson1GetCustomVerificationEmailTemplateCommand =
     TemplateName: undefined,
     TemplateSubject: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FailureRedirectionURL !== undefined && data.FailureRedirectionURL !== null) {
     contents.FailureRedirectionURL = __expectString(data.FailureRedirectionURL);
   }
@@ -5277,7 +5279,7 @@ export const deserializeAws_restJson1GetDedicatedIpCommand = async (
     $metadata: deserializeMetadata(output),
     DedicatedIp: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIp !== undefined && data.DedicatedIp !== null) {
     contents.DedicatedIp = deserializeAws_restJson1DedicatedIp(data.DedicatedIp, context);
   }
@@ -5349,7 +5351,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
     DedicatedIps: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIps !== undefined && data.DedicatedIps !== null) {
     contents.DedicatedIps = deserializeAws_restJson1DedicatedIpList(data.DedicatedIps, context);
   }
@@ -5427,7 +5429,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     PendingExpirationSubscribedDomains: undefined,
     SubscriptionExpiryDate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountStatus !== undefined && data.AccountStatus !== null) {
     contents.AccountStatus = __expectString(data.AccountStatus);
   }
@@ -5520,7 +5522,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
     OverallPlacement: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReport !== undefined && data.DeliverabilityTestReport !== null) {
     contents.DeliverabilityTestReport = deserializeAws_restJson1DeliverabilityTestReport(
       data.DeliverabilityTestReport,
@@ -5606,7 +5608,7 @@ export const deserializeAws_restJson1GetDomainDeliverabilityCampaignCommand = as
     $metadata: deserializeMetadata(output),
     DomainDeliverabilityCampaign: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaign !== undefined && data.DomainDeliverabilityCampaign !== null) {
     contents.DomainDeliverabilityCampaign = deserializeAws_restJson1DomainDeliverabilityCampaign(
       data.DomainDeliverabilityCampaign,
@@ -5681,7 +5683,7 @@ export const deserializeAws_restJson1GetDomainStatisticsReportCommand = async (
     DailyVolumes: undefined,
     OverallVolume: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DailyVolumes !== undefined && data.DailyVolumes !== null) {
     contents.DailyVolumes = deserializeAws_restJson1DailyVolumes(data.DailyVolumes, context);
   }
@@ -5762,7 +5764,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
     Tags: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
     contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
@@ -5854,7 +5856,7 @@ export const deserializeAws_restJson1GetEmailIdentityPoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     Policies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policies !== undefined && data.Policies !== null) {
     contents.Policies = deserializeAws_restJson1PolicyMap(data.Policies, context);
   }
@@ -5926,7 +5928,7 @@ export const deserializeAws_restJson1GetEmailTemplateCommand = async (
     TemplateContent: undefined,
     TemplateName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TemplateContent !== undefined && data.TemplateContent !== null) {
     contents.TemplateContent = deserializeAws_restJson1EmailTemplateContent(data.TemplateContent, context);
   }
@@ -6008,7 +6010,7 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
     JobStatus: undefined,
     ProcessedRecordsCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompletedTimestamp !== undefined && data.CompletedTimestamp !== null) {
     contents.CompletedTimestamp = new Date(Math.round(data.CompletedTimestamp * 1000));
   }
@@ -6103,7 +6105,7 @@ export const deserializeAws_restJson1GetSuppressedDestinationCommand = async (
     $metadata: deserializeMetadata(output),
     SuppressedDestination: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SuppressedDestination !== undefined && data.SuppressedDestination !== null) {
     contents.SuppressedDestination = deserializeAws_restJson1SuppressedDestination(data.SuppressedDestination, context);
   }
@@ -6175,7 +6177,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     ConfigurationSets: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSets !== undefined && data.ConfigurationSets !== null) {
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSetNameList(data.ConfigurationSets, context);
   }
@@ -6242,7 +6244,7 @@ export const deserializeAws_restJson1ListContactListsCommand = async (
     ContactLists: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactLists !== undefined && data.ContactLists !== null) {
     contents.ContactLists = deserializeAws_restJson1ListOfContactLists(data.ContactLists, context);
   }
@@ -6309,7 +6311,7 @@ export const deserializeAws_restJson1ListContactsCommand = async (
     Contacts: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Contacts !== undefined && data.Contacts !== null) {
     contents.Contacts = deserializeAws_restJson1ListOfContacts(data.Contacts, context);
   }
@@ -6384,7 +6386,7 @@ export const deserializeAws_restJson1ListCustomVerificationEmailTemplatesCommand
     CustomVerificationEmailTemplates: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomVerificationEmailTemplates !== undefined && data.CustomVerificationEmailTemplates !== null) {
     contents.CustomVerificationEmailTemplates = deserializeAws_restJson1CustomVerificationEmailTemplatesList(
       data.CustomVerificationEmailTemplates,
@@ -6454,7 +6456,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
     DedicatedIpPools: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpPools !== undefined && data.DedicatedIpPools !== null) {
     contents.DedicatedIpPools = deserializeAws_restJson1ListOfDedicatedIpPools(data.DedicatedIpPools, context);
   }
@@ -6521,7 +6523,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
     DeliverabilityTestReports: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReports !== undefined && data.DeliverabilityTestReports !== null) {
     contents.DeliverabilityTestReports = deserializeAws_restJson1DeliverabilityTestReports(
       data.DeliverabilityTestReports,
@@ -6599,7 +6601,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
     DomainDeliverabilityCampaigns: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaigns !== undefined && data.DomainDeliverabilityCampaigns !== null) {
     contents.DomainDeliverabilityCampaigns = deserializeAws_restJson1DomainDeliverabilityCampaignList(
       data.DomainDeliverabilityCampaigns,
@@ -6677,7 +6679,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
     EmailIdentities: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmailIdentities !== undefined && data.EmailIdentities !== null) {
     contents.EmailIdentities = deserializeAws_restJson1IdentityInfoList(data.EmailIdentities, context);
   }
@@ -6744,7 +6746,7 @@ export const deserializeAws_restJson1ListEmailTemplatesCommand = async (
     NextToken: undefined,
     TemplatesMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6811,7 +6813,7 @@ export const deserializeAws_restJson1ListImportJobsCommand = async (
     ImportJobs: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ImportJobs !== undefined && data.ImportJobs !== null) {
     contents.ImportJobs = deserializeAws_restJson1ImportJobSummaryList(data.ImportJobs, context);
   }
@@ -6878,7 +6880,7 @@ export const deserializeAws_restJson1ListSuppressedDestinationsCommand = async (
     NextToken: undefined,
     SuppressedDestinationSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6955,7 +6957,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -7957,7 +7959,7 @@ export const deserializeAws_restJson1PutEmailIdentityDkimSigningAttributesComman
     DkimStatus: undefined,
     DkimTokens: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimStatus !== undefined && data.DkimStatus !== null) {
     contents.DkimStatus = __expectString(data.DkimStatus);
   }
@@ -8224,7 +8226,7 @@ export const deserializeAws_restJson1SendBulkEmailCommand = async (
     $metadata: deserializeMetadata(output),
     BulkEmailEntryResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkEmailEntryResults !== undefined && data.BulkEmailEntryResults !== null) {
     contents.BulkEmailEntryResults = deserializeAws_restJson1BulkEmailEntryResultList(
       data.BulkEmailEntryResults,
@@ -8338,7 +8340,7 @@ export const deserializeAws_restJson1SendCustomVerificationEmailCommand = async 
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }
@@ -8441,7 +8443,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }
@@ -8627,7 +8629,7 @@ export const deserializeAws_restJson1TestRenderEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     RenderedTemplate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RenderedTemplate !== undefined && data.RenderedTemplate !== null) {
     contents.RenderedTemplate = __expectString(data.RenderedTemplate);
   }

--- a/clients/client-signer/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1.ts
@@ -78,6 +78,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -673,7 +675,7 @@ export const deserializeAws_restJson1AddProfilePermissionCommand = async (
     $metadata: deserializeMetadata(output),
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.revisionId !== undefined && data.revisionId !== null) {
     contents.revisionId = __expectString(data.revisionId);
   }
@@ -869,7 +871,7 @@ export const deserializeAws_restJson1DescribeSigningJobCommand = async (
     status: undefined,
     statusReason: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completedAt !== undefined && data.completedAt !== null) {
     contents.completedAt = new Date(Math.round(data.completedAt * 1000));
   }
@@ -1010,7 +1012,7 @@ export const deserializeAws_restJson1GetSigningPlatformCommand = async (
     signingImageFormat: undefined,
     target: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.category !== undefined && data.category !== null) {
     contents.category = __expectString(data.category);
   }
@@ -1126,7 +1128,7 @@ export const deserializeAws_restJson1GetSigningProfileCommand = async (
     statusReason: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1250,7 +1252,7 @@ export const deserializeAws_restJson1ListProfilePermissionsCommand = async (
     policySizeBytes: undefined,
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1347,7 +1349,7 @@ export const deserializeAws_restJson1ListSigningJobsCommand = async (
     jobs: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1SigningJobs(data.jobs, context);
   }
@@ -1430,7 +1432,7 @@ export const deserializeAws_restJson1ListSigningPlatformsCommand = async (
     nextToken: undefined,
     platforms: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1513,7 +1515,7 @@ export const deserializeAws_restJson1ListSigningProfilesCommand = async (
     nextToken: undefined,
     profiles: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1587,7 +1589,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1668,7 +1670,7 @@ export const deserializeAws_restJson1PutSigningProfileCommand = async (
     profileVersion: undefined,
     profileVersionArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1761,7 +1763,7 @@ export const deserializeAws_restJson1RemoveProfilePermissionCommand = async (
     $metadata: deserializeMetadata(output),
     revisionId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.revisionId !== undefined && data.revisionId !== null) {
     contents.revisionId = __expectString(data.revisionId);
   }
@@ -2023,7 +2025,7 @@ export const deserializeAws_restJson1StartSigningJobCommand = async (
     jobId: undefined,
     jobOwner: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobId !== undefined && data.jobId !== null) {
     contents.jobId = __expectString(data.jobId);
   }

--- a/clients/client-snow-device-management/protocols/Aws_restJson1.ts
+++ b/clients/client-snow-device-management/protocols/Aws_restJson1.ts
@@ -50,6 +50,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -469,7 +471,7 @@ export const deserializeAws_restJson1CancelTaskCommand = async (
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -557,7 +559,7 @@ export const deserializeAws_restJson1CreateTaskCommand = async (
     taskArn: undefined,
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskArn !== undefined && data.taskArn !== null) {
     contents.taskArn = __expectString(data.taskArn);
   }
@@ -665,7 +667,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     software: undefined,
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associatedWithJob !== undefined && data.associatedWithJob !== null) {
     contents.associatedWithJob = __expectString(data.associatedWithJob);
   }
@@ -785,7 +787,7 @@ export const deserializeAws_restJson1DescribeDeviceEc2InstancesCommand = async (
     $metadata: deserializeMetadata(output),
     instances: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.instances !== undefined && data.instances !== null) {
     contents.instances = deserializeAws_restJson1InstanceSummaryList(data.instances, context);
   }
@@ -877,7 +879,7 @@ export const deserializeAws_restJson1DescribeExecutionCommand = async (
     state: undefined,
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionId !== undefined && data.executionId !== null) {
     contents.executionId = __expectString(data.executionId);
   }
@@ -987,7 +989,7 @@ export const deserializeAws_restJson1DescribeTaskCommand = async (
     taskArn: undefined,
     taskId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completedAt !== undefined && data.completedAt !== null) {
     contents.completedAt = new Date(Math.round(data.completedAt * 1000));
   }
@@ -1099,7 +1101,7 @@ export const deserializeAws_restJson1ListDeviceResourcesCommand = async (
     nextToken: undefined,
     resources: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1190,7 +1192,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     devices: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.devices = deserializeAws_restJson1DeviceSummaryList(data.devices, context);
   }
@@ -1273,7 +1275,7 @@ export const deserializeAws_restJson1ListExecutionsCommand = async (
     executions: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executions !== undefined && data.executions !== null) {
     contents.executions = deserializeAws_restJson1ExecutionSummaryList(data.executions, context);
   }
@@ -1363,7 +1365,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1435,7 +1437,7 @@ export const deserializeAws_restJson1ListTasksCommand = async (
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
@@ -110,6 +110,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -959,7 +961,7 @@ export const deserializeAws_restJson1CreateReplicationSetCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1054,7 +1056,7 @@ export const deserializeAws_restJson1CreateResponsePlanCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1150,7 +1152,7 @@ export const deserializeAws_restJson1CreateTimelineEventCommand = async (
     eventId: undefined,
     incidentRecordArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eventId !== undefined && data.eventId !== null) {
     contents.eventId = __expectString(data.eventId);
   }
@@ -1639,7 +1641,7 @@ export const deserializeAws_restJson1GetIncidentRecordCommand = async (
     $metadata: deserializeMetadata(output),
     incidentRecord: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.incidentRecord !== undefined && data.incidentRecord !== null) {
     contents.incidentRecord = deserializeAws_restJson1IncidentRecord(data.incidentRecord, context);
   }
@@ -1726,7 +1728,7 @@ export const deserializeAws_restJson1GetReplicationSetCommand = async (
     $metadata: deserializeMetadata(output),
     replicationSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.replicationSet !== undefined && data.replicationSet !== null) {
     contents.replicationSet = deserializeAws_restJson1ReplicationSet(data.replicationSet, context);
   }
@@ -1814,7 +1816,7 @@ export const deserializeAws_restJson1GetResourcePoliciesCommand = async (
     nextToken: undefined,
     resourcePolicies: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1910,7 +1912,7 @@ export const deserializeAws_restJson1GetResponsePlanCommand = async (
     incidentTemplate: undefined,
     name: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actions !== undefined && data.actions !== null) {
     contents.actions = deserializeAws_restJson1ActionsList(data.actions, context);
   }
@@ -2015,7 +2017,7 @@ export const deserializeAws_restJson1GetTimelineEventCommand = async (
     $metadata: deserializeMetadata(output),
     event: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.event !== undefined && data.event !== null) {
     contents.event = deserializeAws_restJson1TimelineEvent(data.event, context);
   }
@@ -2103,7 +2105,7 @@ export const deserializeAws_restJson1ListIncidentRecordsCommand = async (
     incidentRecordSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.incidentRecordSummaries !== undefined && data.incidentRecordSummaries !== null) {
     contents.incidentRecordSummaries = deserializeAws_restJson1IncidentRecordSummaryList(
       data.incidentRecordSummaries,
@@ -2189,7 +2191,7 @@ export const deserializeAws_restJson1ListRelatedItemsCommand = async (
     nextToken: undefined,
     relatedItems: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2272,7 +2274,7 @@ export const deserializeAws_restJson1ListReplicationSetsCommand = async (
     nextToken: undefined,
     replicationSetArns: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2355,7 +2357,7 @@ export const deserializeAws_restJson1ListResponsePlansCommand = async (
     nextToken: undefined,
     responsePlanSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2440,7 +2442,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -2528,7 +2530,7 @@ export const deserializeAws_restJson1ListTimelineEventsCommand = async (
     eventSummaries: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eventSummaries !== undefined && data.eventSummaries !== null) {
     contents.eventSummaries = deserializeAws_restJson1EventSummaryList(data.eventSummaries, context);
   }
@@ -2610,7 +2612,7 @@ export const deserializeAws_restJson1PutResourcePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policyId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policyId !== undefined && data.policyId !== null) {
     contents.policyId = __expectString(data.policyId);
   }
@@ -2697,7 +2699,7 @@ export const deserializeAws_restJson1StartIncidentCommand = async (
     $metadata: deserializeMetadata(output),
     incidentRecordArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.incidentRecordArn !== undefined && data.incidentRecordArn !== null) {
     contents.incidentRecordArn = __expectString(data.incidentRecordArn);
   }

--- a/clients/client-sso-oidc/protocols/Aws_restJson1.ts
+++ b/clients/client-sso-oidc/protocols/Aws_restJson1.ts
@@ -22,6 +22,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
 } from "@aws-sdk/smithy-client";
 import {
@@ -132,7 +134,7 @@ export const deserializeAws_restJson1CreateTokenCommand = async (
     refreshToken: undefined,
     tokenType: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessToken !== undefined && data.accessToken !== null) {
     contents.accessToken = __expectString(data.accessToken);
   }
@@ -284,7 +286,7 @@ export const deserializeAws_restJson1RegisterClientCommand = async (
     clientSecretExpiresAt: undefined,
     tokenEndpoint: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizationEndpoint !== undefined && data.authorizationEndpoint !== null) {
     contents.authorizationEndpoint = __expectString(data.authorizationEndpoint);
   }
@@ -383,7 +385,7 @@ export const deserializeAws_restJson1StartDeviceAuthorizationCommand = async (
     verificationUri: undefined,
     verificationUriComplete: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceCode !== undefined && data.deviceCode !== null) {
     contents.deviceCode = __expectString(data.deviceCode);
   }

--- a/clients/client-sso/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1.ts
@@ -14,6 +14,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -136,7 +138,7 @@ export const deserializeAws_restJson1GetRoleCredentialsCommand = async (
     $metadata: deserializeMetadata(output),
     roleCredentials: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleCredentials !== undefined && data.roleCredentials !== null) {
     contents.roleCredentials = deserializeAws_restJson1RoleCredentials(data.roleCredentials, context);
   }
@@ -216,7 +218,7 @@ export const deserializeAws_restJson1ListAccountRolesCommand = async (
     nextToken: undefined,
     roleList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -299,7 +301,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
     accountList: undefined,
     nextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accountList !== undefined && data.accountList !== null) {
     contents.accountList = deserializeAws_restJson1AccountListType(data.accountList, context);
   }

--- a/clients/client-synthetics/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/protocols/Aws_restJson1.ts
@@ -50,6 +50,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -489,7 +491,7 @@ export const deserializeAws_restJson1CreateCanaryCommand = async (
     $metadata: deserializeMetadata(output),
     Canary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Canary !== undefined && data.Canary !== null) {
     contents.Canary = deserializeAws_restJson1Canary(data.Canary, context);
   }
@@ -628,7 +630,7 @@ export const deserializeAws_restJson1DescribeCanariesCommand = async (
     Canaries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Canaries !== undefined && data.Canaries !== null) {
     contents.Canaries = deserializeAws_restJson1Canaries(data.Canaries, context);
   }
@@ -695,7 +697,7 @@ export const deserializeAws_restJson1DescribeCanariesLastRunCommand = async (
     CanariesLastRun: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CanariesLastRun !== undefined && data.CanariesLastRun !== null) {
     contents.CanariesLastRun = deserializeAws_restJson1CanariesLastRun(data.CanariesLastRun, context);
   }
@@ -762,7 +764,7 @@ export const deserializeAws_restJson1DescribeRuntimeVersionsCommand = async (
     NextToken: undefined,
     RuntimeVersions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -828,7 +830,7 @@ export const deserializeAws_restJson1GetCanaryCommand = async (
     $metadata: deserializeMetadata(output),
     Canary: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Canary !== undefined && data.Canary !== null) {
     contents.Canary = deserializeAws_restJson1Canary(data.Canary, context);
   }
@@ -892,7 +894,7 @@ export const deserializeAws_restJson1GetCanaryRunsCommand = async (
     CanaryRuns: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CanaryRuns !== undefined && data.CanaryRuns !== null) {
     contents.CanaryRuns = deserializeAws_restJson1CanaryRuns(data.CanaryRuns, context);
   }
@@ -966,7 +968,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-wellarchitected/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/protocols/Aws_restJson1.ts
@@ -96,6 +96,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1400,7 +1402,7 @@ export const deserializeAws_restJson1CreateMilestoneCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
     contents.MilestoneNumber = __expectInt32(data.MilestoneNumber);
   }
@@ -1507,7 +1509,7 @@ export const deserializeAws_restJson1CreateWorkloadCommand = async (
     WorkloadArn: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WorkloadArn !== undefined && data.WorkloadArn !== null) {
     contents.WorkloadArn = __expectString(data.WorkloadArn);
   }
@@ -1606,7 +1608,7 @@ export const deserializeAws_restJson1CreateWorkloadShareCommand = async (
     ShareId: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ShareId !== undefined && data.ShareId !== null) {
     contents.ShareId = __expectString(data.ShareId);
   }
@@ -1988,7 +1990,7 @@ export const deserializeAws_restJson1GetAnswerCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Answer !== undefined && data.Answer !== null) {
     contents.Answer = deserializeAws_restJson1Answer(data.Answer, context);
   }
@@ -2086,7 +2088,7 @@ export const deserializeAws_restJson1GetLensReviewCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReview !== undefined && data.LensReview !== null) {
     contents.LensReview = deserializeAws_restJson1LensReview(data.LensReview, context);
   }
@@ -2181,7 +2183,7 @@ export const deserializeAws_restJson1GetLensReviewReportCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReviewReport !== undefined && data.LensReviewReport !== null) {
     contents.LensReviewReport = deserializeAws_restJson1LensReviewReport(data.LensReviewReport, context);
   }
@@ -2277,7 +2279,7 @@ export const deserializeAws_restJson1GetLensVersionDifferenceCommand = async (
     LensAlias: undefined,
     VersionDifferences: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BaseLensVersion !== undefined && data.BaseLensVersion !== null) {
     contents.BaseLensVersion = __expectString(data.BaseLensVersion);
   }
@@ -2374,7 +2376,7 @@ export const deserializeAws_restJson1GetMilestoneCommand = async (
     Milestone: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Milestone !== undefined && data.Milestone !== null) {
     contents.Milestone = deserializeAws_restJson1Milestone(data.Milestone, context);
   }
@@ -2464,7 +2466,7 @@ export const deserializeAws_restJson1GetWorkloadCommand = async (
     $metadata: deserializeMetadata(output),
     Workload: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Workload !== undefined && data.Workload !== null) {
     contents.Workload = deserializeAws_restJson1Workload(data.Workload, context);
   }
@@ -2555,7 +2557,7 @@ export const deserializeAws_restJson1ListAnswersCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnswerSummaries !== undefined && data.AnswerSummaries !== null) {
     contents.AnswerSummaries = deserializeAws_restJson1AnswerSummaries(data.AnswerSummaries, context);
   }
@@ -2655,7 +2657,7 @@ export const deserializeAws_restJson1ListLensesCommand = async (
     LensSummaries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensSummaries !== undefined && data.LensSummaries !== null) {
     contents.LensSummaries = deserializeAws_restJson1LensSummaries(data.LensSummaries, context);
   }
@@ -2741,7 +2743,7 @@ export const deserializeAws_restJson1ListLensReviewImprovementsCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ImprovementSummaries !== undefined && data.ImprovementSummaries !== null) {
     contents.ImprovementSummaries = deserializeAws_restJson1ImprovementSummaries(data.ImprovementSummaries, context);
   }
@@ -2843,7 +2845,7 @@ export const deserializeAws_restJson1ListLensReviewsCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReviewSummaries !== undefined && data.LensReviewSummaries !== null) {
     contents.LensReviewSummaries = deserializeAws_restJson1LensReviewSummaries(data.LensReviewSummaries, context);
   }
@@ -2941,7 +2943,7 @@ export const deserializeAws_restJson1ListMilestonesCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MilestoneSummaries !== undefined && data.MilestoneSummaries !== null) {
     contents.MilestoneSummaries = deserializeAws_restJson1MilestoneSummaries(data.MilestoneSummaries, context);
   }
@@ -3035,7 +3037,7 @@ export const deserializeAws_restJson1ListNotificationsCommand = async (
     NextToken: undefined,
     NotificationSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3118,7 +3120,7 @@ export const deserializeAws_restJson1ListShareInvitationsCommand = async (
     NextToken: undefined,
     ShareInvitationSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3203,7 +3205,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3267,7 +3269,7 @@ export const deserializeAws_restJson1ListWorkloadsCommand = async (
     NextToken: undefined,
     WorkloadSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3351,7 +3353,7 @@ export const deserializeAws_restJson1ListWorkloadSharesCommand = async (
     WorkloadId: undefined,
     WorkloadShareSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3567,7 +3569,7 @@ export const deserializeAws_restJson1UpdateAnswerCommand = async (
     LensAlias: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Answer !== undefined && data.Answer !== null) {
     contents.Answer = deserializeAws_restJson1Answer(data.Answer, context);
   }
@@ -3669,7 +3671,7 @@ export const deserializeAws_restJson1UpdateLensReviewCommand = async (
     LensReview: undefined,
     WorkloadId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReview !== undefined && data.LensReview !== null) {
     contents.LensReview = deserializeAws_restJson1LensReview(data.LensReview, context);
   }
@@ -3767,7 +3769,7 @@ export const deserializeAws_restJson1UpdateShareInvitationCommand = async (
     $metadata: deserializeMetadata(output),
     ShareInvitation: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ShareInvitation !== undefined && data.ShareInvitation !== null) {
     contents.ShareInvitation = deserializeAws_restJson1ShareInvitation(data.ShareInvitation, context);
   }
@@ -3862,7 +3864,7 @@ export const deserializeAws_restJson1UpdateWorkloadCommand = async (
     $metadata: deserializeMetadata(output),
     Workload: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Workload !== undefined && data.Workload !== null) {
     contents.Workload = deserializeAws_restJson1Workload(data.Workload, context);
   }
@@ -3958,7 +3960,7 @@ export const deserializeAws_restJson1UpdateWorkloadShareCommand = async (
     WorkloadId: undefined,
     WorkloadShare: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
     contents.WorkloadId = __expectString(data.WorkloadId);
   }

--- a/clients/client-workdocs/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1.ts
@@ -142,6 +142,8 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1750,7 +1752,7 @@ export const deserializeAws_restJson1ActivateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -1837,7 +1839,7 @@ export const deserializeAws_restJson1AddResourcePermissionsCommand = async (
     $metadata: deserializeMetadata(output),
     ShareResults: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ShareResults !== undefined && data.ShareResults !== null) {
     contents.ShareResults = deserializeAws_restJson1ShareResultsList(data.ShareResults, context);
   }
@@ -1916,7 +1918,7 @@ export const deserializeAws_restJson1CreateCommentCommand = async (
     $metadata: deserializeMetadata(output),
     Comment: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Comment !== undefined && data.Comment !== null) {
     contents.Comment = deserializeAws_restJson1Comment(data.Comment, context);
   }
@@ -2126,7 +2128,7 @@ export const deserializeAws_restJson1CreateFolderCommand = async (
     $metadata: deserializeMetadata(output),
     Metadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Metadata !== undefined && data.Metadata !== null) {
     contents.Metadata = deserializeAws_restJson1FolderMetadata(data.Metadata, context);
   }
@@ -2336,7 +2338,7 @@ export const deserializeAws_restJson1CreateNotificationSubscriptionCommand = asy
     $metadata: deserializeMetadata(output),
     Subscription: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Subscription !== undefined && data.Subscription !== null) {
     contents.Subscription = deserializeAws_restJson1Subscription(data.Subscription, context);
   }
@@ -2407,7 +2409,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -3322,7 +3324,7 @@ export const deserializeAws_restJson1DescribeActivitiesCommand = async (
     Marker: undefined,
     UserActivities: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -3413,7 +3415,7 @@ export const deserializeAws_restJson1DescribeCommentsCommand = async (
     Comments: undefined,
     Marker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Comments !== undefined && data.Comments !== null) {
     contents.Comments = deserializeAws_restJson1CommentList(data.Comments, context);
   }
@@ -3512,7 +3514,7 @@ export const deserializeAws_restJson1DescribeDocumentVersionsCommand = async (
     DocumentVersions: undefined,
     Marker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DocumentVersions !== undefined && data.DocumentVersions !== null) {
     contents.DocumentVersions = deserializeAws_restJson1DocumentVersionMetadataList(data.DocumentVersions, context);
   }
@@ -3620,7 +3622,7 @@ export const deserializeAws_restJson1DescribeFolderContentsCommand = async (
     Folders: undefined,
     Marker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Documents !== undefined && data.Documents !== null) {
     contents.Documents = deserializeAws_restJson1DocumentMetadataList(data.Documents, context);
   }
@@ -3722,7 +3724,7 @@ export const deserializeAws_restJson1DescribeGroupsCommand = async (
     Groups: undefined,
     Marker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Groups !== undefined && data.Groups !== null) {
     contents.Groups = deserializeAws_restJson1GroupMetadataList(data.Groups, context);
   }
@@ -3805,7 +3807,7 @@ export const deserializeAws_restJson1DescribeNotificationSubscriptionsCommand = 
     Marker: undefined,
     Subscriptions: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -3880,7 +3882,7 @@ export const deserializeAws_restJson1DescribeResourcePermissionsCommand = async 
     Marker: undefined,
     Principals: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -3963,7 +3965,7 @@ export const deserializeAws_restJson1DescribeRootFoldersCommand = async (
     Folders: undefined,
     Marker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Folders !== undefined && data.Folders !== null) {
     contents.Folders = deserializeAws_restJson1FolderMetadataList(data.Folders, context);
   }
@@ -4055,7 +4057,7 @@ export const deserializeAws_restJson1DescribeUsersCommand = async (
     TotalNumberOfUsers: undefined,
     Users: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -4164,7 +4166,7 @@ export const deserializeAws_restJson1GetCurrentUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -4252,7 +4254,7 @@ export const deserializeAws_restJson1GetDocumentCommand = async (
     CustomMetadata: undefined,
     Metadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomMetadata !== undefined && data.CustomMetadata !== null) {
     contents.CustomMetadata = deserializeAws_restJson1CustomMetadataMap(data.CustomMetadata, context);
   }
@@ -4358,7 +4360,7 @@ export const deserializeAws_restJson1GetDocumentPathCommand = async (
     $metadata: deserializeMetadata(output),
     Path: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Path !== undefined && data.Path !== null) {
     contents.Path = deserializeAws_restJson1ResourcePath(data.Path, context);
   }
@@ -4446,7 +4448,7 @@ export const deserializeAws_restJson1GetDocumentVersionCommand = async (
     CustomMetadata: undefined,
     Metadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomMetadata !== undefined && data.CustomMetadata !== null) {
     contents.CustomMetadata = deserializeAws_restJson1CustomMetadataMap(data.CustomMetadata, context);
   }
@@ -4553,7 +4555,7 @@ export const deserializeAws_restJson1GetFolderCommand = async (
     CustomMetadata: undefined,
     Metadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomMetadata !== undefined && data.CustomMetadata !== null) {
     contents.CustomMetadata = deserializeAws_restJson1CustomMetadataMap(data.CustomMetadata, context);
   }
@@ -4659,7 +4661,7 @@ export const deserializeAws_restJson1GetFolderPathCommand = async (
     $metadata: deserializeMetadata(output),
     Path: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Path !== undefined && data.Path !== null) {
     contents.Path = deserializeAws_restJson1ResourcePath(data.Path, context);
   }
@@ -4748,7 +4750,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
     Folders: undefined,
     Marker: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Documents !== undefined && data.Documents !== null) {
     contents.Documents = deserializeAws_restJson1DocumentMetadataList(data.Documents, context);
   }
@@ -4842,7 +4844,7 @@ export const deserializeAws_restJson1InitiateDocumentVersionUploadCommand = asyn
     Metadata: undefined,
     UploadMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Metadata !== undefined && data.Metadata !== null) {
     contents.Metadata = deserializeAws_restJson1DocumentMetadata(data.Metadata, context);
   }
@@ -5483,7 +5485,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }

--- a/clients/client-worklink/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1.ts
@@ -107,6 +107,8 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
 } from "@aws-sdk/smithy-client";
@@ -1102,7 +1104,7 @@ export const deserializeAws_restJson1AssociateWebsiteAuthorizationProviderComman
     $metadata: deserializeMetadata(output),
     AuthorizationProviderId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AuthorizationProviderId !== undefined && data.AuthorizationProviderId !== null) {
     contents.AuthorizationProviderId = __expectString(data.AuthorizationProviderId);
   }
@@ -1197,7 +1199,7 @@ export const deserializeAws_restJson1AssociateWebsiteCertificateAuthorityCommand
     $metadata: deserializeMetadata(output),
     WebsiteCaId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WebsiteCaId !== undefined && data.WebsiteCaId !== null) {
     contents.WebsiteCaId = __expectString(data.WebsiteCaId);
   }
@@ -1292,7 +1294,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
     $metadata: deserializeMetadata(output),
     FleetArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FleetArn !== undefined && data.FleetArn !== null) {
     contents.FleetArn = __expectString(data.FleetArn);
   }
@@ -1470,7 +1472,7 @@ export const deserializeAws_restJson1DescribeAuditStreamConfigurationCommand = a
     $metadata: deserializeMetadata(output),
     AuditStreamArn: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AuditStreamArn !== undefined && data.AuditStreamArn !== null) {
     contents.AuditStreamArn = __expectString(data.AuditStreamArn);
   }
@@ -1559,7 +1561,7 @@ export const deserializeAws_restJson1DescribeCompanyNetworkConfigurationCommand 
     SubnetIds: undefined,
     VpcId: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SecurityGroupIds !== undefined && data.SecurityGroupIds !== null) {
     contents.SecurityGroupIds = deserializeAws_restJson1SecurityGroupIds(data.SecurityGroupIds, context);
   }
@@ -1660,7 +1662,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     Status: undefined,
     Username: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FirstAccessedTime !== undefined && data.FirstAccessedTime !== null) {
     contents.FirstAccessedTime = new Date(Math.round(data.FirstAccessedTime * 1000));
   }
@@ -1771,7 +1773,7 @@ export const deserializeAws_restJson1DescribeDevicePolicyConfigurationCommand = 
     $metadata: deserializeMetadata(output),
     DeviceCaCertificate: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceCaCertificate !== undefined && data.DeviceCaCertificate !== null) {
     contents.DeviceCaCertificate = __expectString(data.DeviceCaCertificate);
   }
@@ -1862,7 +1864,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
     DomainName: undefined,
     DomainStatus: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AcmCertificateArn !== undefined && data.AcmCertificateArn !== null) {
     contents.AcmCertificateArn = __expectString(data.AcmCertificateArn);
   }
@@ -1968,7 +1970,7 @@ export const deserializeAws_restJson1DescribeFleetMetadataCommand = async (
     OptimizeForEndUserLocation: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompanyCode !== undefined && data.CompanyCode !== null) {
     contents.CompanyCode = __expectString(data.CompanyCode);
   }
@@ -2078,7 +2080,7 @@ export const deserializeAws_restJson1DescribeIdentityProviderConfigurationComman
     IdentityProviderType: undefined,
     ServiceProviderSamlMetadata: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityProviderSamlMetadata !== undefined && data.IdentityProviderSamlMetadata !== null) {
     contents.IdentityProviderSamlMetadata = __expectString(data.IdentityProviderSamlMetadata);
   }
@@ -2173,7 +2175,7 @@ export const deserializeAws_restJson1DescribeWebsiteCertificateAuthorityCommand 
     CreatedTime: undefined,
     DisplayName: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Certificate !== undefined && data.Certificate !== null) {
     contents.Certificate = __expectString(data.Certificate);
   }
@@ -2524,7 +2526,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     Devices: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Devices !== undefined && data.Devices !== null) {
     contents.Devices = deserializeAws_restJson1DeviceSummaryList(data.Devices, context);
   }
@@ -2615,7 +2617,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     Domains: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Domains !== undefined && data.Domains !== null) {
     contents.Domains = deserializeAws_restJson1DomainSummaryList(data.Domains, context);
   }
@@ -2706,7 +2708,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
     FleetSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FleetSummaryList !== undefined && data.FleetSummaryList !== null) {
     contents.FleetSummaryList = deserializeAws_restJson1FleetSummaryList(data.FleetSummaryList, context);
   }
@@ -2788,7 +2790,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -2844,7 +2846,7 @@ export const deserializeAws_restJson1ListWebsiteAuthorizationProvidersCommand = 
     NextToken: undefined,
     WebsiteAuthorizationProviders: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2938,7 +2940,7 @@ export const deserializeAws_restJson1ListWebsiteCertificateAuthoritiesCommand = 
     NextToken: undefined,
     WebsiteCertificateAuthorities: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-xray/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1.ts
@@ -117,6 +117,8 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   serializeFloat as __serializeFloat,
@@ -884,7 +886,7 @@ export const deserializeAws_restJson1BatchGetTracesCommand = async (
     Traces: undefined,
     UnprocessedTraceIds: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -953,7 +955,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -1016,7 +1018,7 @@ export const deserializeAws_restJson1CreateSamplingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SamplingRuleRecord: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SamplingRuleRecord !== undefined && data.SamplingRuleRecord !== null) {
     contents.SamplingRuleRecord = deserializeAws_restJson1SamplingRuleRecord(data.SamplingRuleRecord, context);
   }
@@ -1146,7 +1148,7 @@ export const deserializeAws_restJson1DeleteSamplingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SamplingRuleRecord: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SamplingRuleRecord !== undefined && data.SamplingRuleRecord !== null) {
     contents.SamplingRuleRecord = deserializeAws_restJson1SamplingRuleRecord(data.SamplingRuleRecord, context);
   }
@@ -1209,7 +1211,7 @@ export const deserializeAws_restJson1GetEncryptionConfigCommand = async (
     $metadata: deserializeMetadata(output),
     EncryptionConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EncryptionConfig !== undefined && data.EncryptionConfig !== null) {
     contents.EncryptionConfig = deserializeAws_restJson1EncryptionConfig(data.EncryptionConfig, context);
   }
@@ -1272,7 +1274,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -1336,7 +1338,7 @@ export const deserializeAws_restJson1GetGroupsCommand = async (
     Groups: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Groups !== undefined && data.Groups !== null) {
     contents.Groups = deserializeAws_restJson1GroupSummaryList(data.Groups, context);
   }
@@ -1402,7 +1404,7 @@ export const deserializeAws_restJson1GetInsightCommand = async (
     $metadata: deserializeMetadata(output),
     Insight: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Insight !== undefined && data.Insight !== null) {
     contents.Insight = deserializeAws_restJson1Insight(data.Insight, context);
   }
@@ -1466,7 +1468,7 @@ export const deserializeAws_restJson1GetInsightEventsCommand = async (
     InsightEvents: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightEvents !== undefined && data.InsightEvents !== null) {
     contents.InsightEvents = deserializeAws_restJson1InsightEventList(data.InsightEvents, context);
   }
@@ -1538,7 +1540,7 @@ export const deserializeAws_restJson1GetInsightImpactGraphCommand = async (
     Services: undefined,
     StartTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EndTime !== undefined && data.EndTime !== null) {
     contents.EndTime = new Date(Math.round(data.EndTime * 1000));
   }
@@ -1620,7 +1622,7 @@ export const deserializeAws_restJson1GetInsightSummariesCommand = async (
     InsightSummaries: undefined,
     NextToken: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightSummaries !== undefined && data.InsightSummaries !== null) {
     contents.InsightSummaries = deserializeAws_restJson1InsightSummaryList(data.InsightSummaries, context);
   }
@@ -1687,7 +1689,7 @@ export const deserializeAws_restJson1GetSamplingRulesCommand = async (
     NextToken: undefined,
     SamplingRuleRecords: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1754,7 +1756,7 @@ export const deserializeAws_restJson1GetSamplingStatisticSummariesCommand = asyn
     NextToken: undefined,
     SamplingStatisticSummaries: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1825,7 +1827,7 @@ export const deserializeAws_restJson1GetSamplingTargetsCommand = async (
     SamplingTargetDocuments: undefined,
     UnprocessedStatistics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastRuleModification !== undefined && data.LastRuleModification !== null) {
     contents.LastRuleModification = new Date(Math.round(data.LastRuleModification * 1000));
   }
@@ -1904,7 +1906,7 @@ export const deserializeAws_restJson1GetServiceGraphCommand = async (
     Services: undefined,
     StartTime: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContainsOldGroupVersions !== undefined && data.ContainsOldGroupVersions !== null) {
     contents.ContainsOldGroupVersions = __expectBoolean(data.ContainsOldGroupVersions);
   }
@@ -1981,7 +1983,7 @@ export const deserializeAws_restJson1GetTimeSeriesServiceStatisticsCommand = asy
     NextToken: undefined,
     TimeSeriesServiceStatistics: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContainsOldGroupVersions !== undefined && data.ContainsOldGroupVersions !== null) {
     contents.ContainsOldGroupVersions = __expectBoolean(data.ContainsOldGroupVersions);
   }
@@ -2054,7 +2056,7 @@ export const deserializeAws_restJson1GetTraceGraphCommand = async (
     NextToken: undefined,
     Services: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2123,7 +2125,7 @@ export const deserializeAws_restJson1GetTraceSummariesCommand = async (
     TraceSummaries: undefined,
     TracesProcessedCount: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApproximateTime !== undefined && data.ApproximateTime !== null) {
     contents.ApproximateTime = new Date(Math.round(data.ApproximateTime * 1000));
   }
@@ -2196,7 +2198,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2270,7 +2272,7 @@ export const deserializeAws_restJson1PutEncryptionConfigCommand = async (
     $metadata: deserializeMetadata(output),
     EncryptionConfig: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EncryptionConfig !== undefined && data.EncryptionConfig !== null) {
     contents.EncryptionConfig = deserializeAws_restJson1EncryptionConfig(data.EncryptionConfig, context);
   }
@@ -2392,7 +2394,7 @@ export const deserializeAws_restJson1PutTraceSegmentsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedTraceSegments: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedTraceSegments !== undefined && data.UnprocessedTraceSegments !== null) {
     contents.UnprocessedTraceSegments = deserializeAws_restJson1UnprocessedTraceSegmentList(
       data.UnprocessedTraceSegments,
@@ -2600,7 +2602,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -2663,7 +2665,7 @@ export const deserializeAws_restJson1UpdateSamplingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SamplingRuleRecord: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SamplingRuleRecord !== undefined && data.SamplingRuleRecord !== null) {
     contents.SamplingRuleRecord = deserializeAws_restJson1SamplingRuleRecord(data.SamplingRuleRecord, context);
   }

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -148,6 +148,8 @@ import {
   expectByte as __expectByte,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectShort as __expectShort,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
@@ -1803,7 +1805,7 @@ export const deserializeAws_restJson1DocumentTypeCommand = async (
     documentValue: undefined,
     stringValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.documentValue !== undefined && data.documentValue !== null) {
     contents.documentValue = deserializeAws_restJson1Document(data.documentValue, context);
   }
@@ -2142,7 +2144,7 @@ export const deserializeAws_restJson1HttpChecksumRequiredCommand = async (
     $metadata: deserializeMetadata(output),
     foo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.foo !== undefined && data.foo !== null) {
     contents.foo = __expectString(data.foo);
   }
@@ -2332,7 +2334,7 @@ export const deserializeAws_restJson1HttpPayloadWithStructureCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restJson1NestedPayload(data, context);
   return Promise.resolve(contents);
 };
@@ -2749,7 +2751,7 @@ export const deserializeAws_restJson1IgnoreQueryParamsInResponseCommand = async 
     $metadata: deserializeMetadata(output),
     baz: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.baz !== undefined && data.baz !== null) {
     contents.baz = __expectString(data.baz);
   }
@@ -2909,7 +2911,7 @@ export const deserializeAws_restJson1JsonBlobsCommand = async (
     $metadata: deserializeMetadata(output),
     data: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.data !== undefined && data.data !== null) {
     contents.data = context.base64Decoder(data.data);
   }
@@ -2961,7 +2963,7 @@ export const deserializeAws_restJson1JsonEnumsCommand = async (
     fooEnumMap: undefined,
     fooEnumSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fooEnum1 !== undefined && data.fooEnum1 !== null) {
     contents.fooEnum1 = __expectString(data.fooEnum1);
   }
@@ -3031,7 +3033,7 @@ export const deserializeAws_restJson1JsonListsCommand = async (
     structureList: undefined,
     timestampList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList !== undefined && data.booleanList !== null) {
     contents.booleanList = deserializeAws_restJson1BooleanList(data.booleanList, context);
   }
@@ -3111,7 +3113,7 @@ export const deserializeAws_restJson1JsonMapsCommand = async (
     sparseStringMap: undefined,
     sparseStructMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.denseBooleanMap !== undefined && data.denseBooleanMap !== null) {
     contents.denseBooleanMap = deserializeAws_restJson1DenseBooleanMap(data.denseBooleanMap, context);
   }
@@ -3188,7 +3190,7 @@ export const deserializeAws_restJson1JsonTimestampsCommand = async (
     httpDate: undefined,
     normal: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dateTime !== undefined && data.dateTime !== null) {
     contents.dateTime = new Date(Math.round(data.dateTime * 1000));
   }
@@ -3244,7 +3246,7 @@ export const deserializeAws_restJson1JsonUnionsCommand = async (
     $metadata: deserializeMetadata(output),
     contents: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contents !== undefined && data.contents !== null) {
     contents.contents = deserializeAws_restJson1MyUnion(data.contents, context);
   }
@@ -3706,7 +3708,7 @@ export const deserializeAws_restJson1RecursiveShapesCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nested !== undefined && data.nested !== null) {
     contents.nested = deserializeAws_restJson1RecursiveShapesInputOutputNested1(data.nested, context);
   }
@@ -3765,7 +3767,7 @@ export const deserializeAws_restJson1SimpleScalarPropertiesCommand = async (
   if (output.headers["x-foo"] !== undefined) {
     contents.foo = output.headers["x-foo"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.byteValue !== undefined && data.byteValue !== null) {
     contents.byteValue = __expectByte(data.byteValue);
   }

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -160,6 +160,8 @@ import {
 } from "@aws-sdk/protocol-http";
 import {
   dateToUtcString as __dateToUtcString,
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
@@ -2266,7 +2268,7 @@ export const deserializeAws_restXmlBodyWithXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["nested"] !== undefined) {
     contents.nested = deserializeAws_restXmlPayloadWithXmlName(data["nested"], context);
   }
@@ -2571,7 +2573,7 @@ export const deserializeAws_restXmlFlattenedXmlMapCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   }
@@ -2621,7 +2623,7 @@ export const deserializeAws_restXmlFlattenedXmlMapWithXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KVP === "") {
     contents.myMap = {};
   }
@@ -2674,7 +2676,7 @@ export const deserializeAws_restXmlFlattenedXmlMapWithXmlNamespaceCommand = asyn
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KVP === "") {
     contents.myMap = {};
   }
@@ -2888,7 +2890,7 @@ export const deserializeAws_restXmlHttpPayloadWithMemberXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlName(data, context);
   return Promise.resolve(contents);
 };
@@ -2933,7 +2935,7 @@ export const deserializeAws_restXmlHttpPayloadWithStructureCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlNestedPayload(data, context);
   return Promise.resolve(contents);
 };
@@ -2978,7 +2980,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlName(data, context);
   return Promise.resolve(contents);
 };
@@ -3023,7 +3025,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNamespaceCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlNamespace(data, context);
   return Promise.resolve(contents);
 };
@@ -3068,7 +3070,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNamespaceAndPrefixCommand =
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlNamespaceAndPrefix(data, context);
   return Promise.resolve(contents);
 };
@@ -3388,7 +3390,7 @@ export const deserializeAws_restXmlIgnoreQueryParamsInResponseCommand = async (
     $metadata: deserializeMetadata(output),
     baz: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["baz"] !== undefined) {
     contents.baz = __expectString(data["baz"]);
   }
@@ -3549,7 +3551,7 @@ export const deserializeAws_restXmlNestedXmlMapsCommand = async (
     flatNestedMap: undefined,
     nestedMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flatNestedMap === "") {
     contents.flatNestedMap = {};
   }
@@ -3973,7 +3975,7 @@ export const deserializeAws_restXmlRecursiveShapesCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["nested"] !== undefined) {
     contents.nested = deserializeAws_restXmlRecursiveShapesInputOutputNested1(data["nested"], context);
   }
@@ -4032,7 +4034,7 @@ export const deserializeAws_restXmlSimpleScalarPropertiesCommand = async (
   if (output.headers["x-foo"] !== undefined) {
     contents.foo = output.headers["x-foo"];
   }
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["byteValue"] !== undefined) {
     contents.byteValue = __strictParseByte(data["byteValue"]) as number;
   }
@@ -4175,7 +4177,7 @@ export const deserializeAws_restXmlXmlAttributesCommand = async (
     attr: undefined,
     foo: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["test"] !== undefined) {
     contents.attr = __expectString(data["test"]);
   }
@@ -4225,7 +4227,7 @@ export const deserializeAws_restXmlXmlAttributesOnPayloadCommand = async (
     $metadata: deserializeMetadata(output),
     payload: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: object | undefined = __expectObject(await parseBody(output.body, context));
   contents.payload = deserializeAws_restXmlXmlAttributesInputOutput(data, context);
   return Promise.resolve(contents);
 };
@@ -4270,7 +4272,7 @@ export const deserializeAws_restXmlXmlBlobsCommand = async (
     $metadata: deserializeMetadata(output),
     data: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["data"] !== undefined) {
     contents.data = context.base64Decoder(data["data"]);
   }
@@ -4317,7 +4319,7 @@ export const deserializeAws_restXmlXmlEmptyBlobsCommand = async (
     $metadata: deserializeMetadata(output),
     data: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["data"] !== undefined) {
     contents.data = context.base64Decoder(data["data"]);
   }
@@ -4377,7 +4379,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
     structureList: undefined,
     timestampList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList === "") {
     contents.booleanList = [];
   }
@@ -4541,7 +4543,7 @@ export const deserializeAws_restXmlXmlEmptyMapsCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   }
@@ -4594,7 +4596,7 @@ export const deserializeAws_restXmlXmlEmptyStringsCommand = async (
     $metadata: deserializeMetadata(output),
     emptyString: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["emptyString"] !== undefined) {
     contents.emptyString = __expectString(data["emptyString"]);
   }
@@ -4646,7 +4648,7 @@ export const deserializeAws_restXmlXmlEnumsCommand = async (
     fooEnumMap: undefined,
     fooEnumSet: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["fooEnum1"] !== undefined) {
     contents.fooEnum1 = __expectString(data["fooEnum1"]);
   }
@@ -4739,7 +4741,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
     structureList: undefined,
     timestampList: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList === "") {
     contents.booleanList = [];
   }
@@ -4903,7 +4905,7 @@ export const deserializeAws_restXmlXmlMapsCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   }
@@ -4956,7 +4958,7 @@ export const deserializeAws_restXmlXmlMapsXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   }
@@ -5009,7 +5011,7 @@ export const deserializeAws_restXmlXmlNamespacesCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["nested"] !== undefined) {
     contents.nested = deserializeAws_restXmlXmlNamespaceNested(data["nested"], context);
   }
@@ -5059,7 +5061,7 @@ export const deserializeAws_restXmlXmlTimestampsCommand = async (
     httpDate: undefined,
     normal: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["dateTime"] !== undefined) {
     contents.dateTime = new Date(data["dateTime"]);
   }
@@ -5115,7 +5117,7 @@ export const deserializeAws_restXmlXmlUnionsCommand = async (
     $metadata: deserializeMetadata(output),
     unionValue: undefined,
   };
-  const data: any = await parseBody(output.body, context);
+  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["unionValue"] !== undefined) {
     contents.unionValue = deserializeAws_restXmlXmlUnionShape(data["unionValue"], context);
   }


### PR DESCRIPTION
### Description
Regeneration of clients for https://github.com/awslabs/smithy-typescript/pull/405

### Testing
Ran protocol tests locally

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
