### PR TITLE
chore(deps-dev): bump typescript to ~4.4.2

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-accessanalyzer/tsconfig.json
+++ b/clients/client-accessanalyzer/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-acm-pca/tsconfig.json
+++ b/clients/client-acm-pca/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-acm/tsconfig.json
+++ b/clients/client-acm/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-alexa-for-business/tsconfig.json
+++ b/clients/client-alexa-for-business/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-amp/tsconfig.json
+++ b/clients/client-amp/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-amplify/tsconfig.json
+++ b/clients/client-amplify/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-amplifybackend/tsconfig.json
+++ b/clients/client-amplifybackend/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-api-gateway/tsconfig.json
+++ b/clients/client-api-gateway/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-apigatewaymanagementapi/tsconfig.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-apigatewayv2/tsconfig.json
+++ b/clients/client-apigatewayv2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-app-mesh/tsconfig.json
+++ b/clients/client-app-mesh/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appconfig/tsconfig.json
+++ b/clients/client-appconfig/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appflow/tsconfig.json
+++ b/clients/client-appflow/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appintegrations/tsconfig.json
+++ b/clients/client-appintegrations/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-application-auto-scaling/tsconfig.json
+++ b/clients/client-application-auto-scaling/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-application-discovery-service/tsconfig.json
+++ b/clients/client-application-discovery-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-application-insights/tsconfig.json
+++ b/clients/client-application-insights/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-applicationcostprofiler/tsconfig.json
+++ b/clients/client-applicationcostprofiler/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-apprunner/tsconfig.json
+++ b/clients/client-apprunner/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appstream/tsconfig.json
+++ b/clients/client-appstream/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-appsync/tsconfig.json
+++ b/clients/client-appsync/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-athena/tsconfig.json
+++ b/clients/client-athena/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-auditmanager/tsconfig.json
+++ b/clients/client-auditmanager/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-auto-scaling-plans/tsconfig.json
+++ b/clients/client-auto-scaling-plans/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-auto-scaling/tsconfig.json
+++ b/clients/client-auto-scaling/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-backup/tsconfig.json
+++ b/clients/client-backup/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-batch/tsconfig.json
+++ b/clients/client-batch/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-braket/tsconfig.json
+++ b/clients/client-braket/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-budgets/tsconfig.json
+++ b/clients/client-budgets/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-chime-sdk-identity/tsconfig.json
+++ b/clients/client-chime-sdk-identity/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-chime-sdk-messaging/tsconfig.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-chime/tsconfig.json
+++ b/clients/client-chime/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloud9/tsconfig.json
+++ b/clients/client-cloud9/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-clouddirectory/tsconfig.json
+++ b/clients/client-clouddirectory/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudformation/tsconfig.json
+++ b/clients/client-cloudformation/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudfront/tsconfig.json
+++ b/clients/client-cloudfront/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudhsm-v2/tsconfig.json
+++ b/clients/client-cloudhsm-v2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudhsm/tsconfig.json
+++ b/clients/client-cloudhsm/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudsearch-domain/tsconfig.json
+++ b/clients/client-cloudsearch-domain/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudsearch/tsconfig.json
+++ b/clients/client-cloudsearch/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudtrail/tsconfig.json
+++ b/clients/client-cloudtrail/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudwatch-events/tsconfig.json
+++ b/clients/client-cloudwatch-events/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudwatch-logs/tsconfig.json
+++ b/clients/client-cloudwatch-logs/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cloudwatch/tsconfig.json
+++ b/clients/client-cloudwatch/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codeartifact/tsconfig.json
+++ b/clients/client-codeartifact/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codebuild/tsconfig.json
+++ b/clients/client-codebuild/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codecommit/tsconfig.json
+++ b/clients/client-codecommit/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codedeploy/tsconfig.json
+++ b/clients/client-codedeploy/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codeguru-reviewer/tsconfig.json
+++ b/clients/client-codeguru-reviewer/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codeguruprofiler/tsconfig.json
+++ b/clients/client-codeguruprofiler/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codepipeline/tsconfig.json
+++ b/clients/client-codepipeline/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codestar-connections/tsconfig.json
+++ b/clients/client-codestar-connections/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codestar-notifications/tsconfig.json
+++ b/clients/client-codestar-notifications/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-codestar/tsconfig.json
+++ b/clients/client-codestar/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cognito-identity-provider/tsconfig.json
+++ b/clients/client-cognito-identity-provider/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -14,6 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cognito-sync/tsconfig.json
+++ b/clients/client-cognito-sync/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-comprehend/tsconfig.json
+++ b/clients/client-comprehend/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-comprehendmedical/tsconfig.json
+++ b/clients/client-comprehendmedical/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-compute-optimizer/tsconfig.json
+++ b/clients/client-compute-optimizer/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-config-service/tsconfig.json
+++ b/clients/client-config-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-connect-contact-lens/tsconfig.json
+++ b/clients/client-connect-contact-lens/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-connect/tsconfig.json
+++ b/clients/client-connect/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-connectparticipant/tsconfig.json
+++ b/clients/client-connectparticipant/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cost-and-usage-report-service/tsconfig.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-cost-explorer/tsconfig.json
+++ b/clients/client-cost-explorer/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-customer-profiles/tsconfig.json
+++ b/clients/client-customer-profiles/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-data-pipeline/tsconfig.json
+++ b/clients/client-data-pipeline/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-database-migration-service/tsconfig.json
+++ b/clients/client-database-migration-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-databrew/tsconfig.json
+++ b/clients/client-databrew/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dataexchange/tsconfig.json
+++ b/clients/client-dataexchange/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-datasync/tsconfig.json
+++ b/clients/client-datasync/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dax/tsconfig.json
+++ b/clients/client-dax/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-detective/tsconfig.json
+++ b/clients/client-detective/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-device-farm/tsconfig.json
+++ b/clients/client-device-farm/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-devops-guru/tsconfig.json
+++ b/clients/client-devops-guru/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-direct-connect/tsconfig.json
+++ b/clients/client-direct-connect/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-directory-service/tsconfig.json
+++ b/clients/client-directory-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dlm/tsconfig.json
+++ b/clients/client-dlm/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-docdb/tsconfig.json
+++ b/clients/client-docdb/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dynamodb-streams/tsconfig.json
+++ b/clients/client-dynamodb-streams/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-dynamodb/tsconfig.json
+++ b/clients/client-dynamodb/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ebs/tsconfig.json
+++ b/clients/client-ebs/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ec2-instance-connect/tsconfig.json
+++ b/clients/client-ec2-instance-connect/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ec2/tsconfig.json
+++ b/clients/client-ec2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ecr-public/tsconfig.json
+++ b/clients/client-ecr-public/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ecr/tsconfig.json
+++ b/clients/client-ecr/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ecs/tsconfig.json
+++ b/clients/client-ecs/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-efs/tsconfig.json
+++ b/clients/client-efs/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-eks/tsconfig.json
+++ b/clients/client-eks/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-beanstalk/tsconfig.json
+++ b/clients/client-elastic-beanstalk/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-inference/tsconfig.json
+++ b/clients/client-elastic-inference/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-load-balancing-v2/tsconfig.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-load-balancing/tsconfig.json
+++ b/clients/client-elastic-load-balancing/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elastic-transcoder/tsconfig.json
+++ b/clients/client-elastic-transcoder/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elasticache/tsconfig.json
+++ b/clients/client-elasticache/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-elasticsearch-service/tsconfig.json
+++ b/clients/client-elasticsearch-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-emr-containers/tsconfig.json
+++ b/clients/client-emr-containers/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-emr/tsconfig.json
+++ b/clients/client-emr/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-eventbridge/tsconfig.json
+++ b/clients/client-eventbridge/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-finspace-data/tsconfig.json
+++ b/clients/client-finspace-data/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-finspace/tsconfig.json
+++ b/clients/client-finspace/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-firehose/tsconfig.json
+++ b/clients/client-firehose/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-fis/tsconfig.json
+++ b/clients/client-fis/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-fms/tsconfig.json
+++ b/clients/client-fms/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-forecast/tsconfig.json
+++ b/clients/client-forecast/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-forecastquery/tsconfig.json
+++ b/clients/client-forecastquery/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-frauddetector/tsconfig.json
+++ b/clients/client-frauddetector/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-fsx/tsconfig.json
+++ b/clients/client-fsx/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-gamelift/tsconfig.json
+++ b/clients/client-gamelift/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-glacier/tsconfig.json
+++ b/clients/client-glacier/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-global-accelerator/tsconfig.json
+++ b/clients/client-global-accelerator/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-glue/tsconfig.json
+++ b/clients/client-glue/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-greengrass/tsconfig.json
+++ b/clients/client-greengrass/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-greengrassv2/tsconfig.json
+++ b/clients/client-greengrassv2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-groundstation/tsconfig.json
+++ b/clients/client-groundstation/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-guardduty/tsconfig.json
+++ b/clients/client-guardduty/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-health/tsconfig.json
+++ b/clients/client-health/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-healthlake/tsconfig.json
+++ b/clients/client-healthlake/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-honeycode/tsconfig.json
+++ b/clients/client-honeycode/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iam/tsconfig.json
+++ b/clients/client-iam/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-identitystore/tsconfig.json
+++ b/clients/client-identitystore/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-imagebuilder/tsconfig.json
+++ b/clients/client-imagebuilder/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-inspector/tsconfig.json
+++ b/clients/client-inspector/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-1click-devices-service/tsconfig.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-1click-projects/tsconfig.json
+++ b/clients/client-iot-1click-projects/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-data-plane/tsconfig.json
+++ b/clients/client-iot-data-plane/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-events-data/tsconfig.json
+++ b/clients/client-iot-events-data/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-events/tsconfig.json
+++ b/clients/client-iot-events/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-jobs-data-plane/tsconfig.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot-wireless/tsconfig.json
+++ b/clients/client-iot-wireless/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iot/tsconfig.json
+++ b/clients/client-iot/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotanalytics/tsconfig.json
+++ b/clients/client-iotanalytics/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotdeviceadvisor/tsconfig.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotfleethub/tsconfig.json
+++ b/clients/client-iotfleethub/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotsecuretunneling/tsconfig.json
+++ b/clients/client-iotsecuretunneling/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotsitewise/tsconfig.json
+++ b/clients/client-iotsitewise/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-iotthingsgraph/tsconfig.json
+++ b/clients/client-iotthingsgraph/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ivs/tsconfig.json
+++ b/clients/client-ivs/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kafka/tsconfig.json
+++ b/clients/client-kafka/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kendra/tsconfig.json
+++ b/clients/client-kendra/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-analytics-v2/tsconfig.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-analytics/tsconfig.json
+++ b/clients/client-kinesis-analytics/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video-archived-media/tsconfig.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video-media/tsconfig.json
+++ b/clients/client-kinesis-video-media/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video-signaling/tsconfig.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis-video/tsconfig.json
+++ b/clients/client-kinesis-video/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kinesis/tsconfig.json
+++ b/clients/client-kinesis/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-kms/tsconfig.json
+++ b/clients/client-kms/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lakeformation/tsconfig.json
+++ b/clients/client-lakeformation/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lambda/tsconfig.json
+++ b/clients/client-lambda/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-model-building-service/tsconfig.json
+++ b/clients/client-lex-model-building-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-models-v2/tsconfig.json
+++ b/clients/client-lex-models-v2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-runtime-service/tsconfig.json
+++ b/clients/client-lex-runtime-service/tsconfig.json
@@ -14,6 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lex-runtime-v2/tsconfig.json
+++ b/clients/client-lex-runtime-v2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-license-manager/tsconfig.json
+++ b/clients/client-license-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lightsail/tsconfig.json
+++ b/clients/client-lightsail/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-location/tsconfig.json
+++ b/clients/client-location/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lookoutequipment/tsconfig.json
+++ b/clients/client-lookoutequipment/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lookoutmetrics/tsconfig.json
+++ b/clients/client-lookoutmetrics/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-lookoutvision/tsconfig.json
+++ b/clients/client-lookoutvision/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-machine-learning/tsconfig.json
+++ b/clients/client-machine-learning/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-macie/tsconfig.json
+++ b/clients/client-macie/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-macie2/tsconfig.json
+++ b/clients/client-macie2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-managedblockchain/tsconfig.json
+++ b/clients/client-managedblockchain/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-catalog/tsconfig.json
+++ b/clients/client-marketplace-catalog/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-commerce-analytics/tsconfig.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-entitlement-service/tsconfig.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-marketplace-metering/tsconfig.json
+++ b/clients/client-marketplace-metering/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediaconnect/tsconfig.json
+++ b/clients/client-mediaconnect/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediaconvert/tsconfig.json
+++ b/clients/client-mediaconvert/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-medialive/tsconfig.json
+++ b/clients/client-medialive/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediapackage-vod/tsconfig.json
+++ b/clients/client-mediapackage-vod/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediapackage/tsconfig.json
+++ b/clients/client-mediapackage/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediastore-data/tsconfig.json
+++ b/clients/client-mediastore-data/tsconfig.json
@@ -14,6 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false,
     "types": ["mocha"]
   },
   "typedocOptions": {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediastore/tsconfig.json
+++ b/clients/client-mediastore/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mediatailor/tsconfig.json
+++ b/clients/client-mediatailor/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-memorydb/tsconfig.json
+++ b/clients/client-memorydb/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mgn/tsconfig.json
+++ b/clients/client-mgn/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-migration-hub/tsconfig.json
+++ b/clients/client-migration-hub/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-migrationhub-config/tsconfig.json
+++ b/clients/client-migrationhub-config/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mobile/tsconfig.json
+++ b/clients/client-mobile/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mq/tsconfig.json
+++ b/clients/client-mq/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mturk/tsconfig.json
+++ b/clients/client-mturk/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-mwaa/tsconfig.json
+++ b/clients/client-mwaa/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-neptune/tsconfig.json
+++ b/clients/client-neptune/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-network-firewall/tsconfig.json
+++ b/clients/client-network-firewall/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-networkmanager/tsconfig.json
+++ b/clients/client-networkmanager/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-nimble/tsconfig.json
+++ b/clients/client-nimble/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-opsworks/tsconfig.json
+++ b/clients/client-opsworks/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-opsworkscm/tsconfig.json
+++ b/clients/client-opsworkscm/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-organizations/tsconfig.json
+++ b/clients/client-organizations/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-outposts/tsconfig.json
+++ b/clients/client-outposts/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-personalize-events/tsconfig.json
+++ b/clients/client-personalize-events/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-personalize-runtime/tsconfig.json
+++ b/clients/client-personalize-runtime/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-personalize/tsconfig.json
+++ b/clients/client-personalize/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pi/tsconfig.json
+++ b/clients/client-pi/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pinpoint-email/tsconfig.json
+++ b/clients/client-pinpoint-email/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pinpoint-sms-voice/tsconfig.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pinpoint/tsconfig.json
+++ b/clients/client-pinpoint/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-polly/tsconfig.json
+++ b/clients/client-polly/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-pricing/tsconfig.json
+++ b/clients/client-pricing/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-proton/tsconfig.json
+++ b/clients/client-proton/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-qldb-session/tsconfig.json
+++ b/clients/client-qldb-session/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-qldb/tsconfig.json
+++ b/clients/client-qldb/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-quicksight/tsconfig.json
+++ b/clients/client-quicksight/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ram/tsconfig.json
+++ b/clients/client-ram/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-rds-data/tsconfig.json
+++ b/clients/client-rds-data/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-rds/tsconfig.json
+++ b/clients/client-rds/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-redshift-data/tsconfig.json
+++ b/clients/client-redshift-data/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-redshift/tsconfig.json
+++ b/clients/client-redshift/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-rekognition/tsconfig.json
+++ b/clients/client-rekognition/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-resource-groups-tagging-api/tsconfig.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-resource-groups/tsconfig.json
+++ b/clients/client-resource-groups/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-robomaker/tsconfig.json
+++ b/clients/client-robomaker/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route-53-domains/tsconfig.json
+++ b/clients/client-route-53-domains/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route-53/tsconfig.json
+++ b/clients/client-route-53/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route53-recovery-cluster/tsconfig.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route53-recovery-control-config/tsconfig.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route53-recovery-readiness/tsconfig.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-route53resolver/tsconfig.json
+++ b/clients/client-route53resolver/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -77,7 +77,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-s3-control/tsconfig.json
+++ b/clients/client-s3-control/tsconfig.json
@@ -14,6 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -85,7 +85,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -14,6 +14,7 @@
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-s3outposts/tsconfig.json
+++ b/clients/client-s3outposts/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-edge/tsconfig.json
+++ b/clients/client-sagemaker-edge/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker-runtime/tsconfig.json
+++ b/clients/client-sagemaker-runtime/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sagemaker/tsconfig.json
+++ b/clients/client-sagemaker/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-savingsplans/tsconfig.json
+++ b/clients/client-savingsplans/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-schemas/tsconfig.json
+++ b/clients/client-schemas/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-secrets-manager/tsconfig.json
+++ b/clients/client-secrets-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-securityhub/tsconfig.json
+++ b/clients/client-securityhub/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-serverlessapplicationrepository/tsconfig.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-service-catalog-appregistry/tsconfig.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-service-catalog/tsconfig.json
+++ b/clients/client-service-catalog/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-service-quotas/tsconfig.json
+++ b/clients/client-service-quotas/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-servicediscovery/tsconfig.json
+++ b/clients/client-servicediscovery/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ses/tsconfig.json
+++ b/clients/client-ses/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sesv2/tsconfig.json
+++ b/clients/client-sesv2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sfn/tsconfig.json
+++ b/clients/client-sfn/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-shield/tsconfig.json
+++ b/clients/client-shield/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-signer/tsconfig.json
+++ b/clients/client-signer/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sms/tsconfig.json
+++ b/clients/client-sms/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-snow-device-management/tsconfig.json
+++ b/clients/client-snow-device-management/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-snowball/tsconfig.json
+++ b/clients/client-snowball/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sns/tsconfig.json
+++ b/clients/client-sns/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sqs/tsconfig.json
+++ b/clients/client-sqs/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ssm-contacts/tsconfig.json
+++ b/clients/client-ssm-contacts/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ssm-incidents/tsconfig.json
+++ b/clients/client-ssm-incidents/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-ssm/tsconfig.json
+++ b/clients/client-ssm/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sso-admin/tsconfig.json
+++ b/clients/client-sso-admin/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sso-oidc/tsconfig.json
+++ b/clients/client-sso-oidc/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sso/tsconfig.json
+++ b/clients/client-sso/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-storage-gateway/tsconfig.json
+++ b/clients/client-storage-gateway/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-sts/tsconfig.json
+++ b/clients/client-sts/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-support/tsconfig.json
+++ b/clients/client-support/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-swf/tsconfig.json
+++ b/clients/client-swf/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-synthetics/tsconfig.json
+++ b/clients/client-synthetics/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-textract/tsconfig.json
+++ b/clients/client-textract/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-timestream-query/tsconfig.json
+++ b/clients/client-timestream-query/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-timestream-write/tsconfig.json
+++ b/clients/client-timestream-write/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -74,7 +74,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-transcribe-streaming/tsconfig.json
+++ b/clients/client-transcribe-streaming/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-transcribe/tsconfig.json
+++ b/clients/client-transcribe/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-transfer/tsconfig.json
+++ b/clients/client-transfer/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-translate/tsconfig.json
+++ b/clients/client-translate/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-waf-regional/tsconfig.json
+++ b/clients/client-waf-regional/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-waf/tsconfig.json
+++ b/clients/client-waf/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-wafv2/tsconfig.json
+++ b/clients/client-wafv2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-wellarchitected/tsconfig.json
+++ b/clients/client-wellarchitected/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workdocs/tsconfig.json
+++ b/clients/client-workdocs/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-worklink/tsconfig.json
+++ b/clients/client-worklink/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workmail/tsconfig.json
+++ b/clients/client-workmail/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workmailmessageflow/tsconfig.json
+++ b/clients/client-workmailmessageflow/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-workspaces/tsconfig.json
+++ b/clients/client-workspaces/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/clients/client-xray/tsconfig.json
+++ b/clients/client-xray/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^14.11.2",
     "jest": "^26.4.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -42,7 +42,7 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-typescript": "^5.2.0",
     "ts-jest": "^26.4.1",
-    "typescript": "~4.3.2",
+    "typescript": "~4.4.2",
     "web-streams-polyfill": "^3.0.0"
   },
   "typesVersions": {

--- a/lib/lib-storage/src/chunks/getDataReadableStream.spec.ts
+++ b/lib/lib-storage/src/chunks/getDataReadableStream.spec.ts
@@ -2,9 +2,9 @@
 import { ReadableStream } from "web-streams-polyfill";
 
 import { byteLength } from "../bytelength";
+import { RawDataPart as DataPart } from "../Upload";
 import { getChunkStream as chunkFromReadable } from "./getChunkStream";
 import { getDataReadableStream } from "./getDataReadableStream";
-import { RawDataPart as DataPart } from "../Upload";
 
 describe("chunkFromReadable.name", () => {
   // larger than the 5mb min chunk size
@@ -27,7 +27,7 @@ describe("chunkFromReadable.name", () => {
   ): Promise<DataPart[]> => {
     const stream = getStreamOfUnknownlength(streamYieldSize, streamYieldCount);
     const chunks: DataPart[] = [];
-    const chunker = chunkFromReadable<ReadableStream>(stream, partsize, getDataReadableStream);
+    const chunker = chunkFromReadable<ReadableStream>(stream, partsize, getDataReadableStream as any);
 
     for await (const chunk of chunker) {
       chunks.push(chunk);
@@ -36,7 +36,7 @@ describe("chunkFromReadable.name", () => {
   };
 
   it("should a single chunk if the stream is smaller than partsize", async (done) => {
-    let chunks = await getChunks(34, 2, 100);
+    const chunks = await getChunks(34, 2, 100);
 
     expect(chunks.length).toBe(1);
     expect(byteLength(chunks[0].data)).toEqual(68);
@@ -47,7 +47,7 @@ describe("chunkFromReadable.name", () => {
   });
 
   it("should return chunks of a specific size", async (done) => {
-    let chunks = await getChunks(58, 1, 20);
+    const chunks = await getChunks(58, 1, 20);
 
     expect(chunks.length).toBe(3);
     expect(byteLength(chunks[0].data)).toEqual(20);
@@ -65,7 +65,7 @@ describe("chunkFromReadable.name", () => {
   });
 
   it("should properly chunk a large stream of unknown size", async (done) => {
-    let chunks = await getChunks(_6MB / 2, 21, _6MB);
+    const chunks = await getChunks(_6MB / 2, 21, _6MB);
 
     expect(chunks.length).toEqual(11);
     for (let index = 0; index < 10; index++) {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "ts-jest": "^26.4.1",
     "ts-loader": "^7.0.5",
     "typedoc-plugin-lerna-packages": "^0.3.1",
-    "typescript": "~4.3.2",
+    "typescript": "~4.4.2",
     "verdaccio": "^4.7.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/util-utf8-browser": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/util-utf8-node": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/node-config-provider": "3.28.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@aws-sdk/signature-v4": "3.25.0",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "private": true,
   "typesVersions": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "nock": "^13.0.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "typesVersions": {

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -56,7 +56,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/util-utf8-node": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "browser": {
     "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-utf8-node": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/util-utf8-node": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@aws-sdk/abort-controller": "3.25.0",
     "@types/jest": "^26.0.4",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-hex-encoding": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "react-native": {
     "@aws-sdk/chunked-blob-reader": "@aws-sdk/chunked-blob-reader-native"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@aws-sdk/types": "3.25.0",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/hash-stream-node/src/hash-calculator.ts
+++ b/packages/hash-stream-node/src/hash-calculator.ts
@@ -10,7 +10,7 @@ export class HashCalculator extends Writable {
     try {
       this.hash.update(chunk);
     } catch (err) {
-      return callback(err as Error);
+      return callback(err);
     }
     callback();
   }

--- a/packages/hash-stream-node/src/hash-calculator.ts
+++ b/packages/hash-stream-node/src/hash-calculator.ts
@@ -10,7 +10,7 @@ export class HashCalculator extends Writable {
     try {
       this.hash.update(chunk);
     } catch (err) {
-      return callback(err);
+      return callback(err as Error);
     }
     callback();
   }

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@aws-sdk/types": "3.25.0",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/node-config-provider": "3.28.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/node-config-provider": "3.28.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@aws-sdk/config-resolver": "3.28.0",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/node-config-provider": "3.28.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/middleware-stack": "3.25.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@aws-sdk/middleware-signing": "3.28.0",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -32,7 +32,7 @@
     "jest": "^26.1.0",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.0.3",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "dependencies": {
     "@aws-sdk/property-provider": "3.28.0",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/types": "3.25.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/middleware-stack": "3.25.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "jest": {
     "coveragePathIgnorePatterns": [

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -30,7 +30,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -30,7 +30,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/types": "3.25.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-utf8-node": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/util-buffer-from": "3.23.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/types/index.d.ts",
   "description": "Types for the AWS SDK",
   "devDependencies": {
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "typesVersions": {

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -13,7 +13,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.3",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-dynamodb": "3.28.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -20,7 +20,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/protocol-http": "3.25.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "types": "./dist/types/index.d.ts",
   "typesVersions": {

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-ec2/tsconfig.json
+++ b/protocol_tests/aws-ec2/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -64,7 +64,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-json-10/tsconfig.json
+++ b/protocol_tests/aws-json-10/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-json/tsconfig.json
+++ b/protocol_tests/aws-json/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-query/tsconfig.json
+++ b/protocol_tests/aws-query/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-restjson/tsconfig.json
+++ b/protocol_tests/aws-restjson/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/protocol_tests/aws-restxml/tsconfig.json
+++ b/protocol_tests/aws-restxml/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "@aws-sdk/client-*": ["clients/client-*/"],
       "@aws-sdk/aws-*": ["protocol_tests/aws-*/"],
       "@aws-sdk/lib-*": ["lib/*"]
-    }
+    },
+    "useUnknownInCatchVariables": false
   },
   "include": ["packages/", "lib/"],
   "exclude": ["node_modules/", "**/*.spec.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11542,10 +11542,10 @@ typescript@^4.1.0-dev.20201026:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
-typescript@~4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@~4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 ua-parser-js@0.7.22:
   version "0.7.22"


### PR DESCRIPTION
### Issue
TypeScript 4.4 [is stable](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/).

### Description
Bumps typescript to ~4.4.2

### Testing
Integration tests are successful
```console
$ yarn test:integration-legacy
yarn run v1.22.11
$ cucumber-js --fail-fast
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

150 scenarios (150 passed)
523 steps (523 passed)
1m40.949s
Done in 104.81s.

$ yarn test:integration
yarn run v1.22.11
$ jest --config jest.config.integ.js --passWithNoTests
 PASS  clients/client-transcribe-streaming/test/index.integ.spec.ts (31.559 s)
  TranscribeStream client
    ✓ should stream the transcript (28716 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        32.034 s
Ran all test suites.
Done in 32.70s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
