### PR TITLE
chore(codegen): bump code generators to 0.6.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.6.0 (2021-09-02)
+
+### Features
+
+* Added support for malformed request tests. ([#2695](https://github.com/aws/aws-sdk-js-v3/pull/2695))
+* Made endpoints resolution modular. ([#2704](https://github.com/aws/aws-sdk-js-v3/pull/2704))
+* Updated number parsing to be stricter. ([#2662](https://github.com/aws/aws-sdk-js-v3/pull/2662), [#2719](https://github.com/aws/aws-sdk-js-v3/pull/2719))
+* Reintroduced CORS retry headers for supported services. ([#2658](https://github.com/aws/aws-sdk-js-v3/pull/2658))
+
+### Bug Fixes
+
+* Fixed double encoding of presigned url. ([#2711](https://github.com/aws/aws-sdk-js-v3/pull/2711))
+* Only trim xml tag values which contain newline. ([#2653](https://github.com/aws/aws-sdk-js-v3/pull/2653)) 
+
+### Other
+
+* Updated `smithy-typescript-codegen` dependency to `0.6.0`.
+* Updated `smithy` dependencies to `1.11.x`.
+
 ## 0.5.0 (2021-07-23)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.5.0"
+    version = "0.6.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("software.amazon.smithy:smithy-waiters:[1.11.0, 1.12.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.11.0, 1.12.0[")
     api("software.amazon.smithy:smithy-protocol-test-traits:[1.11.0, 1.12.0[")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.5.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.6.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
### Issue
n/a

### Description
bumps the code generator version to 0.6.0 and picks up the 0.6.0 update of smithy-typescript-codegen: https://github.com/awslabs/smithy-typescript/pull/410

### Testing
```
cd codegen
gradle build publishToMavenLocal
cd ../
yarn generate-clients
```

### Additional context
The java ci will fail until https://github.com/awslabs/smithy-typescript/pull/410 is merged.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
