### PR TITLE
chore(signature-v3-crt): add downlevel script

### DIFF
--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -9,7 +9,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
-    "prepublishOnly": "yarn build",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },
   "author": {


### PR DESCRIPTION
### Issue
ref: JS-2789

### Description
new crt package misses the downlevel-dts script, introduced in #2537.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
