### PR TITLE
feat(smithy-client): support strict union parsing

### DIFF
--- a/packages/smithy-client/src/parse-utils.spec.ts
+++ b/packages/smithy-client/src/parse-utils.spec.ts
@@ -6,6 +6,7 @@ import {
   expectNonNull,
   expectObject,
   expectShort,
+  expectUnion,
   limitedParseDouble,
   limitedParseFloat32,
   parseBoolean,
@@ -309,6 +310,27 @@ describe("expectString", () => {
   describe("rejects non-strings", () => {
     it.each([1, NaN, Infinity, -Infinity, true, false, [], {}])("rejects %s", (value) => {
       expect(() => expectString(value)).toThrowError();
+    });
+  });
+});
+
+describe("expectUnion", () => {
+  it.each([null, undefined])("accepts %s", (value) => {
+    expect(expectUnion(value)).toEqual(undefined);
+  });
+  describe("rejects non-objects", () => {
+    it.each([1, NaN, Infinity, -Infinity, true, false, [], "abc"])("%s", (value) => {
+      expect(() => expectUnion(value)).toThrowError();
+    });
+  });
+  describe("rejects malformed unions", () => {
+    it.each([{}, { a: null }, { a: undefined }, { a: 1, b: 2 }])("%s", (value) => {
+      expect(() => expectUnion(value)).toThrowError();
+    });
+  });
+  describe("accepts unions", () => {
+    it.each([{ a: 1 }, { a: 1, b: null }])("%s", (value) => {
+      expect(expectUnion(value)).toEqual(value);
     });
   });
 });

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -223,6 +223,36 @@ export const expectString = (value: any): string | undefined => {
 };
 
 /**
+ * Asserts a value is a JSON-like object with only one non-null/non-undefined key and
+ * returns it.
+ *
+ * @param value A value that is expected to be an object with exactly one non-null,
+ *              non-undefined key.
+ * @return the value if it's a union, undefined if it's null/undefined, otherwise
+ *  an error is thrown.
+ */
+export const expectUnion = (value: unknown): { [key: string]: any } | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const asObject = expectObject(value)!;
+
+  const setKeys = Object.entries(asObject)
+    .filter(([_, v]) => v !== null && v !== undefined)
+    .map(([k, _]) => k);
+
+  if (setKeys.length === 0) {
+    throw new TypeError(`Unions must have exactly one non-null member`);
+  }
+
+  if (setKeys.length > 1) {
+    throw new TypeError(`Unions must have exactly one non-null member. Keys ${setKeys} were not null.`);
+  }
+
+  return asObject;
+};
+
+/**
  * Parses a value into a double. If the value is null or undefined, undefined
  * will be returned. If the value is a string, it will be parsed by the standard
  * parseFloat with one exception: NaN may only be explicitly set as the string


### PR DESCRIPTION
### Description
Unions must be JSON objects that only have one key set.

### Testing
Unit tests, and protocol tests against regenerated clients.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
