### PR TITLE
chore: enable excess character tests

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -327,13 +327,6 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        if (!testCase.getId().matches("^RestJsonBody\\w+MalformedValueRejected.*")) {
-            //TODO: trailing characters in untyped contexts not rejected yet
-            if (testCase.hasTag("trailing_chars") || testCase.hasTag("hex")) {
-                return true;
-            }
-        }
-
         //TODO: request serialization does not verify that the request is an object
         if (testCase.hasTag("technically_valid_json_body")) {
             return true;


### PR DESCRIPTION
### Issue

n/a

### Description

This enables the ssdk protocol tests that ensure that hex numbers (`0xFF` for example) and strings with non-number characters (e.g. `123ABC`). They pass as of https://github.com/aws/aws-sdk-js-v3/pull/2729

### Testing

Built the `main` branch of Smithy, which has the relevant tests, and ran them to ensure they pass.

### Additional context

n/a

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
